### PR TITLE
Fix Paths & Talents accordion contrast colors

### DIFF
--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -6871,6 +6871,73 @@ select[name="system.aura.color"] option[value="white"] {
     background: var(--bg-surface-alt);
 }
 
+/* ----- Paths / Talents / Traits / Precepts accordion contrast fixes ----- */
+.thefade .paths-section .paths-list,
+.thefade .paths-section .talents-list,
+.thefade .paths-section .traits-list,
+.thefade .paths-section .precepts-list {
+    border-color: var(--border-faint);
+    background: var(--bg-surface);
+}
+
+.thefade .paths-section .path-item,
+.thefade .paths-section .talent-item,
+.thefade .paths-section .trait-item,
+.thefade .paths-section .precept-item {
+    border-color: var(--border-faint);
+    background: var(--bg-surface);
+}
+
+.thefade .paths-section .path-header,
+.thefade .paths-section .talent-header,
+.thefade .paths-section .trait-header,
+.thefade .paths-section .precept-header {
+    background: var(--bg-surface-alt);
+    border-bottom: 1px solid var(--border-faint);
+    color: var(--text-primary);
+}
+
+.thefade .paths-section .path-name,
+.thefade .paths-section .talent-name,
+.thefade .paths-section .trait-name,
+.thefade .paths-section .precept-name {
+    color: var(--text-primary);
+}
+
+.thefade .paths-section .path-tier {
+    color: var(--text-muted);
+}
+
+.thefade .paths-section .path-controls a,
+.thefade .paths-section .talent-controls a,
+.thefade .paths-section .trait-controls a,
+.thefade .paths-section .precept-controls a {
+    color: var(--text-muted);
+}
+
+.thefade .paths-section .path-controls a:hover,
+.thefade .paths-section .talent-controls a:hover,
+.thefade .paths-section .trait-controls a:hover,
+.thefade .paths-section .precept-controls a:hover {
+    color: var(--accent-hot);
+}
+
+.thefade .paths-section .path-description,
+.thefade .paths-section .talent-description,
+.thefade .paths-section .trait-description,
+.thefade .paths-section .precept-description {
+    background: var(--bg-surface-alt);
+    color: var(--text-primary);
+    border-top: 1px solid var(--border-faint);
+}
+
+.thefade .paths-section .path-description strong,
+.thefade .paths-section .talent-description strong,
+.thefade .paths-section .trait-description strong,
+.thefade .paths-section .precept-description strong {
+    color: var(--accent-gold);
+}
+
 /* ----- Buttons across the sheet — calmer ----- */
 .thefade button:not(.initiative-roll):not(.vital-pill button) {
     background: var(--bg-surface);


### PR DESCRIPTION
### Motivation

- The Paths & Talents accordion (and matching Traits/Precepts lists) used light/default backgrounds and borders that produced low contrast on the dark sheet theme, making names, controls, and expanded descriptions hard to read.

### Description

- Added a focused CSS block in `styles/thefade.css` to theme the `paths`, `talents`, `traits`, and `precepts` lists and rows using dark-theme tokens like `--bg-surface`, `--bg-surface-alt`, and `--border-faint`.
- Updated header, name, tier, and control colors to use `--text-primary`, `--text-muted`, and `--accent-hot` for hover states so labels and action icons are legible.
- Restyled expanded description panels to use `--bg-surface-alt` and `--text-primary`, and set emphasized text to `--accent-gold` for clearer emphasis.
- Changes are localized to the accordion styling and do not alter markup or JS behavior.

### Testing

- Ran `git diff --check` to validate there are no whitespace/CSS diff issues and it completed successfully.
- Visual validation was the intended check (CSS-only change); no automated visual tests were available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e573f672688320a4701cf7fdd578d3)