### PR TITLE
Conditions engine + defensive stances automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.vs
+/.pdf-extract

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,0 +1,97 @@
+# The Fade (Abyss) — Foundry System Gap Analysis
+
+Source: `The Fade - Abyss.pdf` (554 pages) vs. current worktree code (~8,700 LOC).
+Four focus areas audited: Combat, Magic, Skills & Rolls, Character Creation & Progression.
+
+---
+
+## P0 — Critical (breaks or hollows out core gameplay)
+
+| # | Gap | Area | Evidence |
+|---|-----|------|----------|
+| 1 | **Conditions are inert** — 12 conditions with severity tiers stored as data only. Pain's -6 Avoid, Stunned's action loss, Bleed's per-round damage, Fear's flee, Confusion's self-attacks — none applied. | Combat | [actor.js:170-186](src/actor.js:170) stores `{active, intensity}`; no roll/turn pipeline reads them |
+| 2 | **Stances completely missing** — Dodge Stance, Parrying Stance, Brace, Tough it Out, Resolute Will (each costs both Minor Actions, modifies defenses/damage/saves until next turn). Not implemented. | Combat | No `activeStance` field referenced in roll handlers; no UI toggle |
+| 3 | **Dark Magic / Sin auto-enforcement missing** — Casting a dark spell does not auto-increment Sin by the spell's DT. No daily reset. No auto-trigger of the Sin-over-Threshold attack vs Grit. Addiction stages never auto-advance; their penalties (-1/-2 Grit, Meltdowns, Sanity Breaks, Terminal Soul-halving) not applied. | Magic | Threshold calc at [actor.js:306-332](src/actor.js:306) is passive; [character-sheet.js:2503-2560](src/character-sheet.js:2503) addiction roll exists but no auto-hook |
+
+## P1 — High (frequent mechanics missing automation)
+
+| # | Gap | Area | Evidence |
+|---|-----|------|----------|
+| 4 | **Passive Dodge / Parry not integrated into attack resolution** — Calculated and displayed, but attack rolls compare only vs raw DT. | Combat | [actor.js:444-482](src/actor.js:444) computes them; [character-sheet.js:2237-2410](src/character-sheet.js:2237) attack handler ignores them |
+| 5 | **Critical hits detected but do nothing** — `criticalThreshold` parsed, `canCritical` set, but `criticalHits/criticalDamage` stubbed to 0; no bonus damage. | Combat | [character-sheet.js:2364-2389](src/character-sheet.js:2364) |
+| 6 | **Damage-type effects unimplemented** — Fire/Cold/Acid/etc. listed in the rules as spendable bonus effects. No code spends successes to trigger them. B/S/P are data fields only. | Combat | No switch on `weapon.damageType` in attack flow |
+| 7 | **Damage not auto-applied to AP/HP** — AP reduction is fully manual UI. Natural Deflection tracked per body part but user must click to subtract. | Combat | [character-sheet.js:1034-1228](src/character-sheet.js:1034) |
+| 8 | **HP state thresholds not automated** — At 0 HP, Unconscious not auto-applied. Dying at negative HP not tracked. Bleed not auto-applied on damage. | Combat | [actor.js:289-299](src/actor.js:289) computes label only |
+| 9 | **Mishap tables not rolled** — Severity calculated and displayed as text ("Roll on the Severe Mishap table!"), but the 2d12 tables (Minor/Moderate/Severe/Critical, 24 entries each) are not in code. Dark-magic "one step worse" and Critical→instant-death not applied. | Magic | [character-sheet.js:2685-2703](src/character-sheet.js:2685) |
+| 10 | **Bonus successes unspent** — Spells allow extra successes → more damage / longer duration / bonus effects. Calculated at [character-sheet.js:2676](src/character-sheet.js:2676) but never consumed into output. | Magic | Same file |
+| 11 | **Opposed rolls unsupported** — Hide vs Sight, Deception vs Insight, Trickery vs Grit, etc. GM must manually roll both sides. High-frequency mechanic. | Skills | No code for two-actor roll workflow |
+| 12 | **Point-buy & random attribute generation missing** — No 20-point validator, no max-10 cap, no 1d6×5 exploding roll button. Attributes are free-form inputs. | Creation | [templates/actor/parts/attributes.html:7-82](templates/actor/parts/attributes.html:7) |
+| 13 | **Species bonuses not auto-applied** — Selecting a species item does not push `abilityBonuses` into `attributes.X.speciesBonus`. Manual entry required. | Creation | `speciesBonus` field exists ([actor.js:50-72](src/actor.js:50)) but no writer code |
+| 14 | **Path abilities & granted skills not applied** — Adding a path does not grant its listed abilities or skill ranks to the character. | Creation | `applyPathSkillModifications` in [helpers.js:414-498](src/helpers.js:414) handles *some* skill grants, but abilities object ([template.json:246](template.json:246)) is inert |
+| 15 | **Talent prerequisites never validated** — `prerequisites` is a free-text string. No eligibility dialog or enforcement at level-up. | Creation | [template.json:264](template.json:264) |
+| 16 | **Universal Abilities not modeled** — PDF pages 40-50 (~30 abilities: Regeneration, Incorporeal, Darkvision, Flight, Hivemind, etc.). No ability system exists. | Creation | No schema, no data |
+| 17 | **Sanity mechanics inert** — Max computed (10 + Mind); no Meltdown at half, no Sanity Break at 0, no disorder tracking, no auto-recovery. Dangerous-encounter triggers don't deal Sanity damage. | Creation/Combat | [actor.js:276-281](src/actor.js:276) |
+
+## P2 — Medium (polish + less-frequent mechanics)
+
+| # | Gap | Area |
+|---|-----|------|
+| 18 | Weapon qualities beyond Brutish/Agile — Puncture, Deadly, Disarm, Parrying, Pounding, Pushing, Trip, Breach, Balanced, Sunder are display-only. | Combat |
+| 19 | Gang-up penalty + "shift-provokes-AOO" not implemented. | Combat |
+| 20 | School → Path access restrictions not enforced; any character can cast any spell. | Magic |
+| 21 | Staff/wand charges not decremented on use; no daily reset for staves; no +1D bonus when using a known spell through a staff/wand; no wand-strength cap enforcement. | Magic |
+| 22 | Ritual casting mechanics (components, extended time) not implemented. | Magic |
+| 23 | Dark-school name counterparts (paired name per school) not enumerated. | Magic |
+| 24 | DT input dialog lacks difficulty labels (Trivial/Easy/Moderate/Challenging/Hard/Very Hard/Extreme/Legendary). | Skills |
+| 25 | Condition → automatic bonus/penalty dice not wired. Users manually edit `miscBonus`. | Skills |
+| 26 | Aid Another (+1D from successful helper at Learned+) unsupported. | Skills |
+| 27 | Category-wide skill bonuses (e.g. "+1D to all Knowledge") can't be applied — structure ready, no application. | Skills |
+| 28 | Tier prerequisites for paths not enforced — player can attach a Tier 3 path at level 1. | Creation |
+| 29 | Trait creation-limit (2 at creation) not enforced; no selection UI; no compendium in packs. | Creation |
+| 30 | Starting wealth (Level³ × 200 Serpents) not auto-set on creation. | Creation |
+| 31 | Species abilities stored as metadata but never apply effects (Darkvision, resistances, natural weapons). | Creation |
+
+## P3 — Low (nice to have)
+
+| # | Gap | Area |
+|---|-----|------|
+| 32 | Initiative integration with Combat Tracker: verified correct; no known issue. | Combat |
+| 33 | Natural Deflection auto-recovery after 8hr rest. | Combat |
+| 34 | Acrobatics rank modifier to Passive Dodge not automatically read from skill rank. | Skills |
+| 35 | Attribute rolls have no optional DT dialog (intentional?). | Skills |
+| 36 | Aging penalties + Infirm (attribute at 0) not modeled. | Creation |
+| 37 | Counter-spell / Dispel / Concentration not modeled (Sorcerer Path ability). | Magic |
+| 38 | Catalyst consumption for magic-item creation not enforced. | Magic |
+| 39 | HP UI breakdown (Species + Path + Physique = Max) not visible. | Creation |
+| 40 | Facing shift-provokes-AOO automation. | Combat |
+
+---
+
+## What's already solid (don't touch)
+
+- Core d12 dice pool, rank→bonus dice, untrained halving, success counting (8–11 = 1, 12 = 2): matches rules exactly.
+- Skill roll handler incl. DT comparison and chat card: complete.
+- Initiative formula (1d12 + avg(Fin, Mind)): correct.
+- Defenses base formulas (Resilience/Avoid/Grit = attr/2, min 1): correct.
+- Facing penalty math on Avoid: correct; only thing missing is the AOO hook.
+- HP & Sanity max calculations: correct per rules.
+- Carrying capacity: correct per rules.
+- Path skill grant on path-add (via `applyPathSkillModifications`): works for specific/custom/category entries.
+- Lore/Perform/Craft custom sub-skill creation: complete.
+- Overland movement (movement × 6): correct.
+
+---
+
+## Suggested sequencing
+
+1. **Conditions engine** (P0 #1) — one central "apply effects" pipeline that all rolls pass through. Unblocks #4, #25, #40 and most condition-carrying talents.
+2. **Stances** (P0 #2) — smaller, self-contained; follows the conditions engine naturally.
+3. **Attack resolution overhaul** (P1 #4, #5, #7, #8) — bundle passive defenses, crit damage, auto-damage-apply, HP-state automation into one coherent attack→damage→condition flow.
+4. **Sin / Dark Magic enforcement** (P0 #3) — hook into existing cast handler.
+5. **Mishap tables** (P1 #9) — data work, low risk.
+6. **Character creation wizard** (P1 #12, #13, #14, #15) — point-buy, species/path auto-apply, talent eligibility. One connected feature.
+7. **Universal Abilities + Species Abilities** (P1 #16, #31) — needs a new ability data model; do after conditions engine so they can share effect primitives.
+8. **Opposed rolls + Aid Another** (P1 #11, P2 #26) — shared dialog pattern.
+9. Remaining P2/P3 polish.
+
+Pick any item above and I'll implement it.

--- a/src/actor.js
+++ b/src/actor.js
@@ -1,5 +1,7 @@
 // TheFadeActor document class (extracted from thefade.js).
 import { BODY_PARTS, FALLBACK_ACTOR_DATA } from './constants.js';
+import { aggregateConditionState, computeRollModifiers, summarizeConditionState } from './conditions.js';
+import { applyBaseDefenseStances, applyPassiveStances, summarizeStance, getDamageMitigation } from './stances.js';
 
 /**
 * Base Actor class for The Fade system
@@ -221,6 +223,9 @@ export class TheFadeActor extends Actor {
             // Apply facing modifiers
             this._applyFacingModifiers(data);
 
+            // Apply active-condition modifiers (defenses, speed, action economy)
+            this._applyConditionState(data);
+
             // Calculate carrying capacity
             this._calculateCarryingCapacity(data);
 
@@ -441,6 +446,10 @@ export class TheFadeActor extends Actor {
         data.totalAvoid = Math.max(1, data.defenses.avoid + Number(data.defenses.avoidBonus || 0));
         data.totalGrit = Math.max(1, data.defenses.grit + Number(data.defenses.gritBonus || 0));
 
+        // Stance-level defense overrides (Tough it Out / Resolute Will replace
+        // the half-attribute formula with full-attribute for Resilience/Grit).
+        applyBaseDefenseStances(data);
+
         // Calculate Passive Dodge based on Acrobatics skill and Finesse
         let acrobonaticsDodge = 0;
         let finesseDodge = Math.floor(data.attributes.finesse.value / 4);
@@ -459,6 +468,8 @@ export class TheFadeActor extends Actor {
 
         data.defenses.basePassiveDodge = Math.max(acrobonaticsDodge, finesseDodge);
         data.defenses.passiveDodge = data.defenses.basePassiveDodge;
+        // Stash Acrobatics rank dice so stance code can add them to Avoid in Dodge Stance.
+        data.defenses.acrobaticsDodgeDice = acrobonaticsDodge;
 
         // Calculate Passive Parry based on highest weapon skill
         let highestParry = 0;
@@ -536,6 +547,61 @@ export class TheFadeActor extends Actor {
 
         // Ensure total avoid doesn't go below 0
         data.totalAvoid = Math.max(0, data.totalAvoid);
+
+        // Apply stance effects that depend on facing-corrected passive values
+        // (Dodge Stance bonus to Avoid; Parrying Stance restores Parry on Back Flank).
+        applyPassiveStances(data, data.defenses.acrobaticsDodgeDice || 0);
+
+        // Re-clamp in case a stance pushed totalAvoid back up from 0.
+        data.totalAvoid = Math.max(0, data.totalAvoid);
+
+        // Stance summary string for the sheet.
+        data.stanceSummary = summarizeStance(data);
+
+        // Expose damage-mitigation flags for attack resolution (Brace for Impact).
+        data.damageMitigation = getDamageMitigation(data.activeStance);
+    }
+
+    /**
+     * Apply passive state deltas from active conditions: defenses, speed,
+     * action economy flags, and prone/helpless/immobile states. Must run
+     * after facing so the facing avoid penalty is already baked in.
+     */
+    _applyConditionState(data) {
+        const state = aggregateConditionState(data.conditions);
+        data.conditionState = state;
+        data.conditionSummary = summarizeConditionState(state);
+
+        if (state.avoidDelta) {
+            data.totalAvoid = Math.max(0, (data.totalAvoid || 0) + state.avoidDelta);
+        }
+        if (state.gritDelta) {
+            data.totalGrit = Math.max(0, (data.totalGrit || 0) + state.gritDelta);
+        }
+        if (state.resilienceDelta) {
+            data.totalResilience = Math.max(0, (data.totalResilience || 0) + state.resilienceDelta);
+        }
+
+        // Compute effective movement from the base movement values, leaving
+        // data.movement as the canonical un-penalized source of truth.
+        const mult = state.immobile ? 0 : state.speedMultiplier;
+        data.effectiveMovement = {
+            land: Math.floor((data.movement?.land || 0) * mult),
+            fly: Math.floor((data.movement?.fly || 0) * mult),
+            swim: Math.floor((data.movement?.swim || 0) * mult),
+            climb: Math.floor((data.movement?.climb || 0) * mult),
+            burrow: Math.floor((data.movement?.burrow || 0) * mult)
+        };
+    }
+
+    /**
+     * Compute per-roll dice modifiers from the actor's active conditions.
+     * Roll handlers call this after assembling the base pool and before
+     * constructing the Roll formula. Returns { bonusDice, penaltyDice,
+     * notes[], autoFail }.
+     */
+    getConditionRollModifiers(context) {
+        return computeRollModifiers(this.system?.conditions, context || { kind: "generic" });
     }
 
     /**

--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -7,6 +7,7 @@ import {
     openCompendiumBrowser, initializeDefaultSkills,
     createCustomSkill, showCustomSkillDialog
 } from './helpers.js';
+import { renderModifierHtml } from './conditions.js';
 
 /**
 * Character Sheet class for The Fade system
@@ -1999,6 +2000,26 @@ export class TheFadeCharacterSheet extends ActorSheet {
         // Add misc bonus dice
         dicePool += (skillData.miscBonus || 0);
 
+        // Apply active-condition modifiers before min-1 clamp
+        const condMods = this.actor.getConditionRollModifiers({
+            kind: "skill",
+            skillName: skill.name,
+            skillCategory: skillData.category,
+            attributeName: attributeName
+        });
+
+        if (condMods.autoFail) {
+            ChatMessage.create({
+                speaker: ChatMessage.getSpeaker({ actor: this.actor }),
+                flavor: `${skill.name} Check (${skillData.rank})`,
+                content: renderModifierHtml(condMods) +
+                    `<p><strong>${this.actor.name}</strong> cannot attempt this check due to an active condition.</p>`
+            });
+            return;
+        }
+
+        dicePool += condMods.bonusDice - condMods.penaltyDice;
+
         // Ensure minimum of 1 die
         dicePool = Math.max(1, dicePool);
 
@@ -2041,8 +2062,9 @@ export class TheFadeCharacterSheet extends ActorSheet {
             rank: skillData.rank
         };
 
-        // Render the template
-        const content = await renderTemplate("systems/thefade/templates/chat/skill-roll.html", templateData);
+        // Render the template, prepend condition modifier banner if any
+        const content = renderModifierHtml(condMods) +
+            await renderTemplate("systems/thefade/templates/chat/skill-roll.html", templateData);
 
         // Send to chat
         roll.toMessage({
@@ -2208,6 +2230,25 @@ export class TheFadeCharacterSheet extends ActorSheet {
             // Add weapon's misc bonus
             dicePool += (weaponData.miscBonus || 0);
 
+            // Apply active-condition modifiers
+            const condModsUntrained = this.actor.getConditionRollModifiers({
+                kind: "attack",
+                skillName: skillName,
+                attributeName: attributeName,
+                isRanged: isRanged,
+                weaponSkill: skillName
+            });
+            if (condModsUntrained.autoFail) {
+                ChatMessage.create({
+                    speaker: ChatMessage.getSpeaker({ actor: this.actor }),
+                    flavor: `Attack with ${weapon.name} (Untrained) vs ${targetName}`,
+                    content: renderModifierHtml(condModsUntrained) +
+                        `<p><strong>${this.actor.name}</strong> cannot attack due to an active condition.</p>`
+                });
+                return;
+            }
+            dicePool += condModsUntrained.bonusDice - condModsUntrained.penaltyDice;
+
             // Ensure minimum of 1 die
             dicePool = Math.max(1, dicePool);
 
@@ -2255,7 +2296,8 @@ export class TheFadeCharacterSheet extends ActorSheet {
                 bonusDice: weaponData.miscBonus ? `Includes +${weaponData.miscBonus} bonus dice` : null
             };
 
-            const content = await renderTemplate("systems/thefade/templates/chat/attack-roll.html", templateData);
+            const content = renderModifierHtml(condModsUntrained) +
+                await renderTemplate("systems/thefade/templates/chat/attack-roll.html", templateData);
 
             // Display the result
             roll.toMessage({
@@ -2312,6 +2354,26 @@ export class TheFadeCharacterSheet extends ActorSheet {
 
         // Add weapon misc bonus
         dicePool += (weaponData.miscBonus || 0);
+
+        // Apply active-condition modifiers
+        const condMods = this.actor.getConditionRollModifiers({
+            kind: "attack",
+            skillName: skill.name,
+            skillCategory: skillData.category,
+            attributeName: attributeName,
+            isRanged: isRanged,
+            weaponSkill: skill.name
+        });
+        if (condMods.autoFail) {
+            ChatMessage.create({
+                speaker: ChatMessage.getSpeaker({ actor: this.actor }),
+                flavor: `Attack with ${weapon.name} (${skillData.rank}) vs ${targetName}`,
+                content: renderModifierHtml(condMods) +
+                    `<p><strong>${this.actor.name}</strong> cannot attack due to an active condition.</p>`
+            });
+            return;
+        }
+        dicePool += condMods.bonusDice - condMods.penaltyDice;
 
         // Ensure minimum of 1 die
         dicePool = Math.max(1, dicePool);
@@ -2400,9 +2462,10 @@ export class TheFadeCharacterSheet extends ActorSheet {
                 ].filter(Boolean).join(', ')}` : null
         };
 
-        const content = await renderTemplate("systems/thefade/templates/chat/attack-roll.html", templateData);
+        const content = renderModifierHtml(condMods) +
+            await renderTemplate("systems/thefade/templates/chat/attack-roll.html", templateData);
 
-        // Display the result 
+        // Display the result
         roll.toMessage({
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
             flavor: `Attack with ${weapon.name} (${skillData.rank}) vs ${targetName}`,
@@ -2645,6 +2708,25 @@ export class TheFadeCharacterSheet extends ActorSheet {
                 break;
         }
 
+        // Apply active-condition modifiers
+        const condMods = this.actor.getConditionRollModifiers({
+            kind: "spell",
+            skillName: "Spellcasting",
+            skillCategory: skillData.category,
+            attributeName: attributeName
+        });
+        if (condMods.autoFail) {
+            ChatMessage.create({
+                speaker: ChatMessage.getSpeaker({ actor: this.actor }),
+                flavor: `Casting ${spell.name}`,
+                content: renderModifierHtml(condMods) +
+                    `<p><strong>${this.actor.name}</strong> cannot cast due to an active condition.</p>`
+            });
+            return;
+        }
+        dicePool += condMods.bonusDice - condMods.penaltyDice;
+        dicePool = Math.max(1, dicePool);
+
         // Roll the dice for spell casting check
         const roll = new Roll(`${dicePool}d12`);
         await roll.evaluate();
@@ -2790,7 +2872,8 @@ export class TheFadeCharacterSheet extends ActorSheet {
             time: spellData.time
         };
 
-        const content = await renderTemplate("systems/thefade/templates/chat/spell-cast.html", templateData);
+        const content = renderModifierHtml(condMods) +
+            await renderTemplate("systems/thefade/templates/chat/spell-cast.html", templateData);
 
         // Send the spell casting result to chat
         roll.toMessage({
@@ -3078,6 +3161,17 @@ export class TheFadeCharacterSheet extends ActorSheet {
         this._initializeExcessPenaltyTooltips(html);
 
         this._activateInventoryListeners(html);
+
+        // Combat-state: clear all conditions + stance
+        html.find('.combat-state-clear').on('click', async (ev) => {
+            ev.preventDefault();
+            const conditions = this.actor.system?.conditions || {};
+            const update = { "system.activeStance": "none" };
+            for (const key of Object.keys(conditions)) {
+                update[`system.conditions.${key}.active`] = false;
+            }
+            await this.actor.update(update);
+        });
 
         // Handle defense bonus changes
         html.find('input[name="system.defenses.resilienceBonus"], input[name="system.defenses.avoidBonus"], input[name="system.defenses.gritBonus"]').change(async (ev) => {

--- a/src/conditions.js
+++ b/src/conditions.js
@@ -1,0 +1,309 @@
+// Conditions engine for The Fade - Abyss.
+// Drives: passive actor-state deltas (Avoid/Grit/Resilience/speed/action economy)
+// and per-roll dice modifiers (attack, skill, spell, addiction).
+//
+// Rules source: Core Rulebook Conditions chapter. Default duration is 3 rounds
+// unless otherwise noted; conditions don't stack (higher severity wins; duration
+// resets). See AUDIT.md for traceability.
+
+export const CONDITION_INTENSITIES = ["trivial", "moderate", "severe"];
+
+// Effect primitives returned by state()/roll():
+//   state() → { avoidDelta, gritDelta, resilienceDelta, speedMultiplier,
+//               minorLoss, majorLoss, reactionLoss, reactionLimit,
+//               prone, helpless, immobile, unableToAct, noReactions, behavior }
+//   roll(ctx) → { bonusDice, penaltyDice, notes[], autoFail }
+//
+// Roll context shape:
+//   { kind: "skill"|"attack"|"spell"|"addiction"|"attribute"|"initiative",
+//     skillName?, skillCategory?, attributeName?, isRanged?, weaponSkill? }
+export const CONDITION_EFFECTS = {
+    bleed: {
+        label: "Bleed",
+        tiered: true,
+        intensities: {
+            trivial: { damagePerRound: 1 },
+            moderate: { damagePerRound: 3 },
+            severe: { damagePerRound: 5 }
+        }
+    },
+    blindness: {
+        label: "Blinded",
+        tiered: false,
+        state: () => ({ avoidDelta: -5 }),
+        roll: (ctx) => {
+            if (ctx?.kind === "attack") {
+                return { penaltyDice: 4, notes: ["Blindness: -4D to attack"] };
+            }
+            if (ctx?.skillName === "Sight") {
+                return { autoFail: true, notes: ["Blindness: cannot make Sight checks"] };
+            }
+            return {};
+        }
+    },
+    confusion: {
+        label: "Confused",
+        tiered: false,
+        roll: (ctx) => {
+            if (ctx?.kind === "attack") {
+                return { notes: ["Confusion: on failed attack, hit self or ally in reach/range"] };
+            }
+            return {};
+        }
+    },
+    dazed: {
+        label: "Dazed",
+        tiered: true,
+        intensities: {
+            trivial: { state: () => ({ avoidDelta: -1 }) },
+            moderate: { state: () => ({ minorLoss: 1 }) },
+            severe: { state: () => ({ majorLoss: 1 }) }
+        }
+    },
+    deafness: {
+        label: "Deafened",
+        tiered: false,
+        state: () => ({ avoidDelta: -2 }),
+        roll: (ctx) => {
+            if (ctx?.skillName === "Hearing") {
+                return { autoFail: true, notes: ["Deafness: cannot make Hearing checks"] };
+            }
+            return {};
+        }
+    },
+    fatigue: {
+        label: "Fatigued",
+        tiered: true,
+        intensities: {
+            trivial: { state: () => ({ speedMultiplier: 0.75 }) },
+            moderate: { state: () => ({ speedMultiplier: 0.5 }) },
+            severe: {
+                state: () => ({ speedMultiplier: 0.5 }),
+                roll: (ctx) => {
+                    if (ctx?.skillCategory === "Physical") {
+                        return { penaltyDice: 3, notes: ["Severe Fatigue: -3D to Physical skills"] };
+                    }
+                    return {};
+                }
+            }
+        }
+    },
+    fear: {
+        label: "Fear",
+        tiered: true,
+        intensities: {
+            trivial: {
+                state: () => ({ avoidDelta: -1 }),
+                roll: (ctx) => {
+                    if (ctx?.kind === "attack") {
+                        return { bonusDice: 1, notes: ["Fear (trivial): +1D to attack"] };
+                    }
+                    return {};
+                }
+            },
+            moderate: { state: () => ({ behavior: "run" }) },
+            severe: { state: () => ({ behavior: "cower" }) }
+        }
+    },
+    flatFooted: {
+        label: "Flat-Footed",
+        tiered: false,
+        state: () => ({ avoidDelta: -2, unableToAct: true, noReactions: true })
+    },
+    illness: {
+        label: "Ill",
+        tiered: true,
+        intensities: {
+            trivial: { state: () => ({ resilienceDelta: -1 }) },
+            moderate: { state: () => ({ resilienceDelta: -3 }) },
+            severe: { state: () => ({ resilienceDelta: -6, minorLoss: "all" }) }
+        }
+    },
+    pain: {
+        label: "In Pain",
+        tiered: true,
+        intensities: {
+            trivial: { state: () => ({ avoidDelta: -1, gritDelta: -1 }) },
+            moderate: { state: () => ({ avoidDelta: -3, gritDelta: -3 }) },
+            severe: { state: () => ({ avoidDelta: -6, gritDelta: -6, prone: true }) }
+        }
+    },
+    paralysis: {
+        label: "Paralyzed",
+        tiered: true,
+        intensities: {
+            trivial: { state: () => ({ avoidDelta: -2 }) },
+            moderate: { state: () => ({ avoidDelta: -4, speedMultiplier: 0.5 }) },
+            severe: { state: () => ({ helpless: true, immobile: true, unableToAct: true }) }
+        }
+    },
+    sleep: {
+        label: "Asleep",
+        tiered: false,
+        state: () => ({ prone: true, helpless: true, unableToAct: true, immobile: true })
+    },
+    staggered: {
+        label: "Staggered",
+        tiered: true,
+        intensities: {
+            trivial: { state: () => ({ reactionLimit: 1 }) },
+            moderate: { state: () => ({ reactionLoss: "all" }) },
+            severe: { state: () => ({ reactionLoss: "all", minorLoss: "all" }) }
+        }
+    },
+    stunned: {
+        label: "Stunned",
+        tiered: true,
+        intensities: {
+            trivial: { state: () => ({ avoidDelta: -1 }) },
+            moderate: { state: () => ({ avoidDelta: -3, speedMultiplier: 0.5 }) },
+            severe: { state: () => ({ immobile: true, unableToAct: true }) }
+        }
+    }
+};
+
+/**
+ * Walk active conditions and return the matching `state`/`roll` hook and
+ * effect record (tiered vs binary). Internal helper.
+ */
+function _forEachActive(conditions, cb) {
+    if (!conditions) return;
+    for (const [key, data] of Object.entries(conditions)) {
+        if (!data || !data.active) continue;
+        const def = CONDITION_EFFECTS[key];
+        if (!def) continue;
+        const intensity = def.tiered ? (data.intensity || "trivial") : null;
+        const source = def.tiered ? def.intensities?.[intensity] : def;
+        if (!source) continue;
+        cb(key, def, source, intensity);
+    }
+}
+
+/**
+ * Aggregate passive state modifiers from every active condition.
+ * Applied once per actor prepareData pass.
+ */
+export function aggregateConditionState(conditions) {
+    const out = {
+        avoidDelta: 0, gritDelta: 0, resilienceDelta: 0,
+        speedMultiplier: 1,
+        minorLoss: 0, majorLoss: 0, reactionLoss: 0, reactionLimit: null,
+        prone: false, helpless: false, immobile: false,
+        unableToAct: false, noReactions: false, behavior: null,
+        sources: []
+    };
+
+    _forEachActive(conditions, (key, def, source, intensity) => {
+        const effect = typeof source.state === "function" ? source.state() : null;
+        if (!effect) return;
+
+        out.sources.push({ key, label: def.label, intensity });
+
+        if (typeof effect.avoidDelta === "number") out.avoidDelta += effect.avoidDelta;
+        if (typeof effect.gritDelta === "number") out.gritDelta += effect.gritDelta;
+        if (typeof effect.resilienceDelta === "number") out.resilienceDelta += effect.resilienceDelta;
+        if (typeof effect.speedMultiplier === "number") {
+            out.speedMultiplier = Math.min(out.speedMultiplier, effect.speedMultiplier);
+        }
+
+        if (effect.minorLoss === "all") out.minorLoss = "all";
+        else if (typeof effect.minorLoss === "number" && out.minorLoss !== "all") out.minorLoss += effect.minorLoss;
+
+        if (effect.majorLoss === "all") out.majorLoss = "all";
+        else if (typeof effect.majorLoss === "number" && out.majorLoss !== "all") out.majorLoss += effect.majorLoss;
+
+        if (effect.reactionLoss === "all") out.reactionLoss = "all";
+        else if (typeof effect.reactionLoss === "number" && out.reactionLoss !== "all") out.reactionLoss += effect.reactionLoss;
+
+        if (typeof effect.reactionLimit === "number") {
+            out.reactionLimit = out.reactionLimit === null
+                ? effect.reactionLimit
+                : Math.min(out.reactionLimit, effect.reactionLimit);
+        }
+
+        if (effect.prone) out.prone = true;
+        if (effect.helpless) out.helpless = true;
+        if (effect.immobile) out.immobile = true;
+        if (effect.unableToAct) out.unableToAct = true;
+        if (effect.noReactions) out.noReactions = true;
+        if (effect.behavior) out.behavior = effect.behavior;
+    });
+
+    return out;
+}
+
+/**
+ * Per-roll dice modifiers from active conditions.
+ * `context.kind` is required; other fields are optional.
+ */
+export function computeRollModifiers(conditions, context) {
+    const out = { bonusDice: 0, penaltyDice: 0, notes: [], autoFail: false };
+
+    _forEachActive(conditions, (key, def, source) => {
+        if (typeof source.roll !== "function") return;
+        const r = source.roll(context) || {};
+        if (typeof r.bonusDice === "number") out.bonusDice += r.bonusDice;
+        if (typeof r.penaltyDice === "number") out.penaltyDice += r.penaltyDice;
+        if (r.autoFail) out.autoFail = true;
+        if (Array.isArray(r.notes) && r.notes.length) out.notes.push(...r.notes);
+    });
+
+    return out;
+}
+
+/**
+ * Collect per-round damage contributions (e.g. Bleed) for a turn-start hook.
+ * Returns [{ condition, intensity, damage, type }].
+ */
+export function computePerRoundDamage(conditions) {
+    const out = [];
+    _forEachActive(conditions, (key, def, source, intensity) => {
+        if (typeof source.damagePerRound === "number" && source.damagePerRound > 0) {
+            out.push({ condition: key, label: def.label, intensity, damage: source.damagePerRound });
+        }
+    });
+    return out;
+}
+
+/**
+ * HTML snippet summarizing the condition modifiers that applied to a roll.
+ * Injected at the top of chat card content. Returns "" if nothing applied.
+ */
+export function renderModifierHtml(mods) {
+    if (!mods) return "";
+    const hasDice = mods.bonusDice || mods.penaltyDice;
+    if (!hasDice && !mods.autoFail && (!mods.notes || !mods.notes.length)) return "";
+
+    const chips = [];
+    if (mods.autoFail) chips.push(`<strong>Auto-fail</strong>`);
+    if (mods.bonusDice) chips.push(`+${mods.bonusDice}D`);
+    if (mods.penaltyDice) chips.push(`-${mods.penaltyDice}D`);
+
+    const head = chips.length ? `<p class="thefade-cond-mods"><em>Condition effects:</em> ${chips.join(" · ")}</p>` : "";
+    const noteLines = (mods.notes || []).map(n => `<li>${n}</li>`).join("");
+    const notes = noteLines ? `<ul class="thefade-cond-notes">${noteLines}</ul>` : "";
+    return head + notes;
+}
+
+/**
+ * Debug summary of the passive state aggregate (shown on the character sheet).
+ */
+export function summarizeConditionState(state) {
+    if (!state) return null;
+    const parts = [];
+    if (state.avoidDelta) parts.push(`Avoid ${state.avoidDelta > 0 ? "+" : ""}${state.avoidDelta}`);
+    if (state.gritDelta) parts.push(`Grit ${state.gritDelta > 0 ? "+" : ""}${state.gritDelta}`);
+    if (state.resilienceDelta) parts.push(`Resilience ${state.resilienceDelta > 0 ? "+" : ""}${state.resilienceDelta}`);
+    if (state.speedMultiplier !== 1) parts.push(`Speed ×${state.speedMultiplier}`);
+    if (state.minorLoss) parts.push(`Lose ${state.minorLoss === "all" ? "all" : state.minorLoss} Minor`);
+    if (state.majorLoss) parts.push(`Lose ${state.majorLoss === "all" ? "all" : state.majorLoss} Major`);
+    if (state.reactionLoss === "all") parts.push("No Reactions");
+    else if (state.reactionLimit !== null) parts.push(`Reactions ≤ ${state.reactionLimit}`);
+    if (state.prone) parts.push("Prone");
+    if (state.helpless) parts.push("Helpless");
+    if (state.immobile) parts.push("Immobile");
+    if (state.unableToAct) parts.push("Cannot act");
+    if (state.behavior === "run") parts.push("Runs from fear (fights if cornered)");
+    if (state.behavior === "cower") parts.push("Drops items and cowers");
+    return parts.join(" · ");
+}

--- a/src/stances.js
+++ b/src/stances.js
@@ -1,0 +1,134 @@
+// Defensive-stance engine for The Fade - Abyss.
+// Each stance costs both Minor Actions; effects last until the start of the
+// stancee's next turn. Only one stance active at a time.
+//
+// Rules source: Core Rulebook "Entering Defensive Stances" (PDF p.941-968).
+
+export const STANCES = {
+    none: {
+        key: "none",
+        label: "None",
+        description: "No stance; default passive defenses apply."
+    },
+    dodgeStance: {
+        key: "dodgeStance",
+        label: "Dodge Stance",
+        description: "Add half Finesse OR your full Acrobatics dice to Avoid. Costs both Minor Actions."
+    },
+    parryingStance: {
+        key: "parryingStance",
+        label: "Parrying Stance",
+        description: "Passive Parry applies to Back Flanks. On a failed attack against you, Riposte as a Reaction."
+    },
+    brace: {
+        key: "brace",
+        label: "Brace for Impact",
+        description: "Excess damage past AP/Deflection doesn't carry to HP; HP damage is halved (min 1)."
+    },
+    toughItOut: {
+        key: "toughItOut",
+        label: "Tough it Out",
+        description: "Add full Physique to Resilience instead of half."
+    },
+    resoluteWill: {
+        key: "resoluteWill",
+        label: "Resolute Will",
+        description: "Add full Mind to Grit instead of half."
+    }
+};
+
+/**
+ * Return the stance record, or the "none" record if unset/unknown.
+ */
+export function getStance(stance) {
+    return STANCES[stance] || STANCES.none;
+}
+
+/**
+ * Lift base defenses for Tough-It-Out / Resolute-Will: the rule replaces
+ * "half attribute" with "full attribute" for one defense. Call before
+ * facing/condition modifiers so the higher value flows through consistently.
+ *
+ * Mutates data.defenses.resilience and data.defenses.grit in place; also
+ * re-derives data.totalResilience / data.totalGrit so downstream code
+ * sees the new base.
+ */
+export function applyBaseDefenseStances(data) {
+    const stance = data.activeStance || "none";
+    if (!data.attributes || !data.defenses) return;
+
+    if (stance === "toughItOut") {
+        const full = Math.max(1, data.attributes.physique?.value || 1);
+        data.defenses.resilience = full;
+        data.totalResilience = Math.max(1, full + Number(data.defenses.resilienceBonus || 0));
+    }
+
+    if (stance === "resoluteWill") {
+        const full = Math.max(1, data.attributes.mind?.value || 1);
+        data.defenses.grit = full;
+        data.totalGrit = Math.max(1, full + Number(data.defenses.gritBonus || 0));
+    }
+}
+
+/**
+ * Post-facing stance effects:
+ *   - Dodge Stance: bump totalAvoid by max(half Finesse, full Acrobatics dice)
+ *   - Parrying Stance: restore Passive Parry when facing = backflank
+ *
+ * `acrobaticsDodgeDice` is the already-computed dice value from actor prep
+ * (max Acrobatics rank → 0/1/1/2/3 dice).
+ */
+export function applyPassiveStances(data, acrobaticsDodgeDice = 0) {
+    const stance = data.activeStance || "none";
+    if (!data.defenses) return;
+
+    if (stance === "dodgeStance") {
+        const halfFinesse = Math.floor((data.attributes?.finesse?.value || 0) / 2);
+        const bonus = Math.max(halfFinesse, acrobaticsDodgeDice);
+        if (bonus > 0) {
+            data.totalAvoid = Math.max(0, (data.totalAvoid || 0) + bonus);
+            data.defenses.dodgeStanceBonus = bonus;
+        }
+    } else {
+        data.defenses.dodgeStanceBonus = 0;
+    }
+
+    if (stance === "parryingStance") {
+        const facing = data.defenses.facing || "front";
+        if (facing === "backflank") {
+            data.defenses.passiveParry = data.defenses.basePassiveParry || 0;
+        }
+    }
+}
+
+/**
+ * Damage-mitigation flags consumed by attack resolution (Brace for Impact).
+ */
+export function getDamageMitigation(activeStance) {
+    if (activeStance === "brace") {
+        return { noExcessToHp: true, halveHp: true };
+    }
+    return { noExcessToHp: false, halveHp: false };
+}
+
+/**
+ * Per-roll effects from the active stance (placeholder for future: Parrying
+ * Stance may later contribute a Riposte reaction trigger). Returns empty
+ * for now — stance effects are currently all passive.
+ */
+export function computeStanceRollModifiers() {
+    return { bonusDice: 0, penaltyDice: 0, notes: [] };
+}
+
+/**
+ * Short descriptor for the sheet summary row, e.g. "Dodge Stance (+3 Avoid)".
+ */
+export function summarizeStance(data) {
+    const stance = getStance(data?.activeStance);
+    if (stance.key === "none") return null;
+    if (stance.key === "dodgeStance") {
+        const bonus = data?.defenses?.dodgeStanceBonus || 0;
+        return bonus ? `${stance.label} (+${bonus} Avoid)` : stance.label;
+    }
+    return stance.label;
+}

--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -8032,3 +8032,218 @@ select[name="system.aura.color"] option[value="white"] {
     background: transparent;
     padding: 0;
 }
+
+/* ==========================================================================
+   Combat State panel (stances + conditions + aggregate summary)
+   ========================================================================== */
+
+.combat-state.panel {
+    border: 1px solid var(--accent-gold, #b8902c);
+    border-radius: 6px;
+    padding: 10px 12px;
+    margin: 10px 0;
+    background: rgba(0, 0, 0, 0.15);
+}
+
+.combat-state-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid rgba(184, 144, 44, 0.3);
+}
+
+.combat-state-header h2 {
+    margin: 0;
+    font-size: 1.1em;
+    color: var(--accent-gold, #b8902c);
+}
+
+.combat-state-clear {
+    font-size: 0.85em;
+    padding: 3px 8px;
+    cursor: pointer;
+    background: rgba(120, 40, 40, 0.3);
+    border: 1px solid #8a3a3a;
+    color: #eee;
+    border-radius: 3px;
+}
+
+.combat-state-clear:hover {
+    background: rgba(170, 60, 60, 0.5);
+}
+
+/* Stance selector row */
+.stance-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+    flex-wrap: wrap;
+}
+
+.stance-label {
+    font-weight: bold;
+    color: var(--accent-gold, #b8902c);
+    min-width: 100px;
+}
+
+.stance-options {
+    display: flex;
+    gap: 4px;
+    flex-wrap: wrap;
+}
+
+.stance-opt {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 8px;
+    border: 1px solid rgba(184, 144, 44, 0.4);
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 0.9em;
+    background: rgba(0, 0, 0, 0.2);
+}
+
+.stance-opt input[type="radio"] {
+    margin: 0;
+}
+
+.stance-opt:has(input:checked) {
+    background: rgba(184, 144, 44, 0.25);
+    border-color: var(--accent-gold, #b8902c);
+    color: #fff;
+}
+
+/* Active stance summary */
+.stance-summary {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    margin: 8px 0;
+    padding: 6px 10px;
+    background: rgba(70, 110, 180, 0.18);
+    border-left: 3px solid #4a7dc1;
+    border-radius: 3px;
+    font-size: 0.9em;
+    flex-wrap: wrap;
+}
+
+.stance-summary-label {
+    font-weight: bold;
+    color: #9fc4ff;
+    white-space: nowrap;
+}
+
+.stance-summary-label i {
+    margin-right: 4px;
+}
+
+.stance-summary-text {
+    color: #eee;
+}
+
+/* Aggregate condition effects summary */
+.condition-summary {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    margin: 8px 0;
+    padding: 6px 10px;
+    background: rgba(170, 60, 60, 0.18);
+    border-left: 3px solid #aa4444;
+    border-radius: 3px;
+    font-size: 0.9em;
+    flex-wrap: wrap;
+}
+
+.condition-summary-label {
+    font-weight: bold;
+    color: #ffb0b0;
+    white-space: nowrap;
+}
+
+.condition-summary-label i {
+    margin-right: 4px;
+}
+
+.condition-summary-text {
+    color: #eee;
+    font-style: italic;
+}
+
+/* Conditions grid */
+.conditions-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: 6px;
+}
+
+.condition-card {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 5px 7px;
+    border: 1px solid rgba(184, 144, 44, 0.25);
+    border-radius: 3px;
+    background: rgba(0, 0, 0, 0.2);
+    transition: all 0.15s ease;
+}
+
+.condition-card.is-active {
+    border-color: #aa4444;
+    background: rgba(170, 60, 60, 0.2);
+}
+
+.condition-toggle {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+}
+
+.condition-name {
+    font-weight: bold;
+    font-size: 0.95em;
+}
+
+.condition-intensity {
+    display: flex;
+    gap: 3px;
+    opacity: 0.4;
+    transition: opacity 0.15s ease;
+}
+
+.condition-card.is-active .condition-intensity {
+    opacity: 1;
+}
+
+.int-opt {
+    flex: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    padding: 2px 4px;
+    border: 1px solid rgba(184, 144, 44, 0.3);
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 0.8em;
+}
+
+.int-opt input[type="radio"] {
+    display: none;
+}
+
+.int-opt:has(input:checked) {
+    background: rgba(184, 144, 44, 0.3);
+    border-color: var(--accent-gold, #b8902c);
+    color: #fff;
+    font-weight: bold;
+}
+
+.condition-card.condition-binary {
+    justify-content: center;
+}

--- a/templates/actor/character-sheet.html
+++ b/templates/actor/character-sheet.html
@@ -241,6 +241,8 @@
                 </tbody>
             </table>
 
+            {{> "systems/thefade/templates/actor/parts/combat-state.html"}}
+
             {{!-- Species + Aura side-by-side --}}
             <div class="identity-row">
                 <div class="species-item" data-item-id="{{species._id}}">

--- a/templates/actor/parts/combat-state.html
+++ b/templates/actor/parts/combat-state.html
@@ -44,6 +44,22 @@
         </div>
     </div>
 
+    {{!-- Stance summary (visible when a stance other than None is active) --}}
+    {{#if system.stanceSummary}}
+    <div class="stance-summary" title="Defensive stance benefits">
+        <span class="stance-summary-label"><i class="fas fa-shield-alt"></i> Stance:</span>
+        <span class="stance-summary-text">{{system.stanceSummary}}</span>
+    </div>
+    {{/if}}
+
+    {{!-- Aggregate condition effects summary (only visible when any condition is active) --}}
+    {{#if system.conditionSummary}}
+    <div class="condition-summary" title="Combined passive effects from all active conditions">
+        <span class="condition-summary-label"><i class="fas fa-bolt"></i> Active Effects:</span>
+        <span class="condition-summary-text">{{system.conditionSummary}}</span>
+    </div>
+    {{/if}}
+
     {{!-- Conditions grid --}}
     <div class="conditions-grid">
 

--- a/thefade.js
+++ b/thefade.js
@@ -10,6 +10,7 @@ import { TheFadeActor } from './src/actor.js';
 import { TheFadeItem } from './src/item.js';
 import { TheFadeItemSheet } from './src/item-sheet.js';
 import { TheFadeCharacterSheet } from './src/character-sheet.js';
+import { computePerRoundDamage, CONDITION_EFFECTS } from './src/conditions.js';
 
 
 /**
@@ -50,6 +51,38 @@ Hooks.on("renderDialog", (app, html, data) => {
     const el = html?.[0] ?? html;
     if (el && el.classList && !el.classList.contains("thefade")) {
         el.classList.add("thefade");
+    }
+});
+
+/**
+ * Turn-start periodic damage hook: applies Bleed (and any future
+ * damage-per-round condition) to the combatant whose turn just started.
+ * Only the active GM executes the update to avoid duplicate damage.
+ */
+Hooks.on("combatTurn", async (combat, updateData, updateOptions) => {
+    if (!game.user?.isGM) return;
+    try {
+        const nextTurnIndex = updateData?.turn ?? combat?.turn;
+        const combatant = combat?.turns?.[nextTurnIndex];
+        const actor = combatant?.actor;
+        if (!actor || actor.type !== "character") return;
+
+        const ticks = computePerRoundDamage(actor.system?.conditions);
+        if (!ticks.length) return;
+
+        const total = ticks.reduce((sum, t) => sum + t.damage, 0);
+        const currentHP = Number(actor.system?.hp?.value ?? 0);
+        const newHP = currentHP - total;
+
+        await actor.update({ "system.hp.value": newHP });
+
+        const lines = ticks.map(t => `<li>${t.label} (${t.intensity}): ${t.damage} damage</li>`).join("");
+        ChatMessage.create({
+            speaker: ChatMessage.getSpeaker({ actor }),
+            content: `<p><strong>${actor.name}</strong> suffers periodic damage at turn start:</p><ul>${lines}</ul><p>HP ${currentHP} → ${newHP}</p>`
+        });
+    } catch (err) {
+        console.error("The Fade: error applying turn-start condition damage", err);
     }
 });
 
@@ -147,6 +180,7 @@ Hooks.once('init', async function () {
         "systems/thefade/templates/actor/parts/inventory.html",
         "systems/thefade/templates/actor/parts/paths.html",
         "systems/thefade/templates/actor/parts/spells.html",
+        "systems/thefade/templates/actor/parts/combat-state.html",
         "systems/thefade/templates/chat/attack-roll.html",
         "systems/thefade/templates/chat/skill-roll.html",
         "systems/thefade/templates/chat/spell-cast.html",


### PR DESCRIPTION
## Summary

Implements the first two sections of the Core Rulebook automation audit (see `AUDIT.md`): the **Conditions engine** (P0 #1) and **Defensive Stances** (P0 #2). Both previously existed as inert data — this PR makes them actually affect the character.

## What changed

### Conditions engine (`src/conditions.js`, new)

- Data table for all 14 conditions from the Core Rulebook (9 severity-tiered, 5 binary).
- `aggregateConditionState(conditions)` rolls up passive deltas (Avoid/Grit/Resilience, speed multiplier, minor/major/reaction losses, prone/helpless/immobile/unableToAct/noReactions, fear behavior).
- `computeRollModifiers(conditions, context)` returns `{ bonusDice, penaltyDice, notes, autoFail }` for a given roll — skill/attack/spell/attribute.
- `computePerRoundDamage(conditions)` drives Bleed ticks.
- `renderModifierHtml(mods)` and `summarizeConditionState(state)` for chat cards and the sheet.

### Stances (`src/stances.js`, new)

- All 5 stances: Dodge, Parrying, Brace for Impact, Tough it Out, Resolute Will.
- **Tough it Out / Resolute Will**: `applyBaseDefenseStances` replaces half-attribute with full-attribute in Resilience / Grit base.
- **Dodge Stance**: `applyPassiveStances` adds `max(floor(Finesse/2), Acrobatics dice)` to Avoid.
- **Parrying Stance**: restores Passive Parry on Back Flank facing.
- **Brace for Impact**: exposes `data.damageMitigation = { noExcessToHp, halveHp }` for the upcoming attack-resolution overhaul.

### Actor pipeline (`src/actor.js`)

- `_calculateBaseDefenses` now calls `applyBaseDefenseStances` and stashes `acrobaticsDodgeDice` on defenses so Dodge Stance can use it.
- `_applyFacingModifiers` now calls `applyPassiveStances`, writes `data.stanceSummary`, and exposes `data.damageMitigation`.
- New `_applyConditionState(data)` runs after facing: mutates totalAvoid/Grit/Resilience by condition deltas, computes `data.effectiveMovement` via speedMultiplier (zero if immobile), stores `data.conditionState` / `data.conditionSummary`.
- New public `getConditionRollModifiers(context)` — roll handlers call this after assembling the pool.

### Roll handlers (`src/character-sheet.js`)

- Skill rolls, attack rolls (both trained and untrained paths), and spell casting all call `getConditionRollModifiers`, apply `bonusDice - penaltyDice` to the pool, handle `autoFail`, and prepend `renderModifierHtml` to the chat card.
- Clear-conditions button wired.

### Turn-start hook (`thefade.js`)

- `Hooks.on('combatTurn', ...)` on the GM client: at turn start, applies periodic condition damage (Bleed 1/3/5 per intensity) and posts a chat card showing HP before / after.
- Registers `templates/actor/parts/combat-state.html` partial.

### UI (`templates/actor/character-sheet.html`, `templates/actor/parts/combat-state.html`, `styles/thefade.css`)

- Combat State panel now renders in the main tab with: stance radio row, stance summary strip, condition aggregate summary strip, and a grid of all 14 condition toggles with severity radios.
- ~200 lines of new CSS for the panel (matches the existing dark theme).

### Documentation (`AUDIT.md`, new)

- Full gap analysis of the system vs. the 554-page Core Rulebook, ordered P0 → P3 across Combat, Magic, Skills, Character Creation. The remaining work beyond this PR (attack resolution, Sin/Dark Magic, mishap tables, etc.) is all tracked there.

### Ignored

- `.pdf-extract/` added to `.gitignore` — this is a local 1.2MB `pdftotext` extract of the copyrighted rulebook and should not be committed.

## Why

The previous codebase stored condition data and stance selection but never applied the mechanical effects — Pain's -6 Avoid, Stunned's action loss, Bleed's per-round damage, Dodge Stance's Avoid bonus, etc. were all invisible to roll handlers and damage resolution. This PR routes them through the actor's `prepareData` pipeline so every downstream system (defenses, rolls, chat cards) sees the effective values. It also sets up the primitives (`data.damageMitigation`, `computeRollModifiers`) that the next PR (attack-resolution overhaul) will consume.

## Test plan

- [ ] Toggle each condition on a character — verify `totalAvoid` / `totalGrit` / `totalResilience` reflect the expected deltas per the severity radios
- [ ] Turn on Pain (severe) — character sheet should show prone, -6 Avoid, -6 Grit in the summary strip
- [ ] Turn on Stunned (severe) — effective movement drops to 0 and summary says "Cannot act"
- [ ] Turn on Blindness, roll a Sight skill check — should autoFail with a chat card explaining why
- [ ] Turn on Blindness, roll an attack — pool should drop by 4D with a note
- [ ] Turn on Fatigue (severe), roll a Physical skill — pool should drop by 3D
- [ ] Turn on Bleed (moderate), advance the combat turn as GM — 3 HP should tick off with a chat card
- [ ] Select each stance, verify the summary strip updates and defenses change (Tough It Out doubles Resilience base from floor(Phy/2) to full Phy; Dodge Stance adds to Avoid; Parrying Stance restores Parry on Back Flank)
- [ ] Clear button zeros all conditions and returns stance to None

## Not yet in this PR (tracked in `AUDIT.md`)

- Step 3 (next): attack resolution vs. passive Dodge/Parry, crit damage, auto-apply damage with Brace mitigation, HP threshold states
- Step 4: Sin / Dark Magic auto-enforcement on spell cast
- Step 5-9: Mishap tables, creation wizard, ability systems, opposed rolls, polish

🤖 Generated with [Claude Code](https://claude.com/claude-code)