### PR TITLE
Preserve sheet scroll position across re-renders

### DIFF
--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -23,7 +23,10 @@ export class TheFadeCharacterSheet extends ActorSheet {
             template: "systems/thefade/templates/actor/character-sheet.html",
             width: 800,
             height: 950,
-            tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "main" }]
+            tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "main" }],
+            // Preserve scroll position across re-renders so editing a field
+            // doesn't yank the user back to the top of the sheet.
+            scrollY: [".sheet-body", ".tab[data-group='primary']"]
         });
     }
 

--- a/src/item-sheet.js
+++ b/src/item-sheet.js
@@ -16,7 +16,8 @@ export class TheFadeItemSheet extends ItemSheet {
             classes: ["thefade", "sheet", "item", "species"],
             width: 520,
             height: 480,
-            tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description" }]
+            tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description" }],
+            scrollY: [".sheet-body", ".tab"]
         });
     }
 


### PR DESCRIPTION
## Summary

Fixes the long-standing bug where editing any field on the character sheet (or item sheet) flashes and jumps back to the top of the sheet, making any edit below the fold extremely painful.

## Root cause

Foundry's `ActorSheet` / `ItemSheet` re-render the whole DOM on every actor update (which is the default `submitOnChange: true` behavior — every input change submits the form, which updates the actor, which triggers a full sheet render). Without `scrollY` registered in `defaultOptions`, Foundry has no way to know which elements hold scroll state, so every re-render resets `scrollTop = 0` on every scrollable container. The user sees this as "flash, jump to top."

## Fix

Register the scrollable containers in `defaultOptions.scrollY`. Foundry then reads each matched element's `scrollTop` before the render, and restores it after. One-line change per sheet:

- [src/character-sheet.js](src/character-sheet.js): `scrollY: [".sheet-body", ".tab[data-group='primary']"]` — covers the outer sheet-body scrollbar and any per-tab internal scroll (tabs share scroll state across re-renders).
- [src/item-sheet.js](src/item-sheet.js): `scrollY: [".sheet-body", ".tab"]` — same idea for item sheets.

The flash itself (inherent to the re-render) isn't eliminated, but without the scroll jump it's barely noticeable.

## Test plan

- [ ] Open a character sheet, scroll down to the Defenses or Paths section, edit a field — verify scroll position is preserved (no jump to top)
- [ ] Do the same on an item sheet
- [ ] Switch between sheet tabs (Stats & Info → Skills → back) — verify tab scroll positions are remembered

🤖 Generated with [Claude Code](https://claude.com/claude-code)