### PR TITLE
Dark Magic: Sin accrual, addiction progression, daily reset

### DIFF
--- a/src/actor.js
+++ b/src/actor.js
@@ -2,6 +2,7 @@
 import { BODY_PARTS, FALLBACK_ACTOR_DATA } from './constants.js';
 import { aggregateConditionState, computeRollModifiers, summarizeConditionState } from './conditions.js';
 import { applyBaseDefenseStances, applyPassiveStances, summarizeStance, getDamageMitigation } from './stances.js';
+import { applyAddictionPenalties, resetDailySin } from './dark-magic.js';
 
 /**
 * Base Actor class for The Fade system
@@ -234,6 +235,9 @@ export class TheFadeActor extends Actor {
 
             // Calculate Sin Threshold for dark magic
             this._calculateSinThreshold(data);
+
+            // Apply addiction-stage passive penalties (Grit/Sanity/Soul).
+            applyAddictionPenalties(data);
 
             this._calculateOverlandMovement(data);
 
@@ -659,6 +663,18 @@ export class TheFadeActor extends Actor {
         data['overland-movement'].swimOverland = swim * 6;
         data['overland-movement'].climbOverland = climb * 6;
         data['overland-movement'].burrowOverland = burrow * 6;
+    }
+
+    /**
+     * Daily rest: scrub transient accumulators (currently Sin).
+     * Addiction stages persist — rest does not reverse them.
+     */
+    async restDaily() {
+        await resetDailySin(this);
+        ChatMessage.create({
+            speaker: ChatMessage.getSpeaker({ actor: this }),
+            content: `<p><strong>${this.name}</strong> rests — Sin cleared.</p>`
+        });
     }
 
 }

--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -8,6 +8,7 @@ import {
     createCustomSkill, showCustomSkillDialog
 } from './helpers.js';
 import { renderModifierHtml } from './conditions.js';
+import { handleDarkCast } from './dark-magic.js';
 
 /**
 * Character Sheet class for The Fade system
@@ -2626,6 +2627,16 @@ export class TheFadeCharacterSheet extends ActorSheet {
     }
 
     /**
+    * Handle a daily rest click: scrubs accumulated Sin. Stages persist.
+    * @param {Event} event
+    * @private
+    */
+    async _onRestDaily(event) {
+        event.preventDefault();
+        await this.actor.restDaily();
+    }
+
+    /**
     * Handle casting a spell
     * @param {Event} event   The originating click event
     * @private
@@ -2884,6 +2895,16 @@ export class TheFadeCharacterSheet extends ActorSheet {
             flavor: `Casting ${spell.name}`,
             content: content
         });
+
+        // Dark Magic: every cast (success or not) accrues Sin and may
+        // trigger the addiction resistance roll.
+        if (spell.system.isDarkMagic) {
+            try {
+                await handleDarkCast(this.actor, spell);
+            } catch (err) {
+                console.error("handleDarkCast failed:", err);
+            }
+        }
     }
 
     // --------------------------------------------------------------------
@@ -3516,6 +3537,7 @@ export class TheFadeCharacterSheet extends ActorSheet {
         html.find('.initiative-roll').click(this._onInitiativeRoll.bind(this));
         html.find('.roll-dice').click(this._onRollDice.bind(this));
         html.find('.roll-addiction').click(this._onDarkMagicAddictionRoll.bind(this));
+        html.find('.rest-daily').click(this._onRestDaily.bind(this));
 
         html.find('.level-up-btn').click(this._onLevelUp.bind(this));
         html.find('.experience-check-btn').click(this._onExperienceCheck.bind(this));

--- a/src/dark-magic.js
+++ b/src/dark-magic.js
@@ -1,0 +1,188 @@
+// Sin / Dark Magic enforcement for The Fade - Abyss.
+//
+// Casting a dark spell pushes current Sin up by the spell's required
+// successes (its "DT"). If that pushes current Sin above the actor's
+// Sin Threshold (Soul - dark spells learned + bonus), they roll Grit
+// vs the excess; failure advances the addiction stage by one step.
+//
+// Addiction stages carry passive penalties applied during actor data
+// prep: Early = -1 Grit, Middle = -2 Grit, Late = -1 Grit and reduced
+// Sanity max, Terminal = Soul halved for sin-threshold purposes.
+//
+// Daily reset (TheFadeActor.restDaily) zeroes currentSin so overnight
+// rest scrubs the day's accumulation — stages persist.
+//
+// Rules source: Core Rulebook Dark Magic chapter (Sin Threshold,
+// Addiction progression); AUDIT.md P0 #3.
+
+/**
+ * Ordered addiction stage progression.
+ */
+export const ADDICTION_STAGES = ["none", "early", "middle", "late", "terminal"];
+
+/**
+ * Passive effects applied to actor data for each stage.
+ * gritDelta / sanityDelta are added to totalGrit / sanity max.
+ * soulDivisor halves effective Soul for sin-threshold purposes only
+ * (we do not mutate attributes.soul.value).
+ */
+export const ADDICTION_STAGE_EFFECTS = {
+    none:     { gritDelta:  0, sanityDelta: 0, soulDivisor: 1 },
+    early:    { gritDelta: -1, sanityDelta: 0, soulDivisor: 1 },
+    middle:   { gritDelta: -2, sanityDelta: 0, soulDivisor: 1 },
+    late:     { gritDelta: -2, sanityDelta: -2, soulDivisor: 1 },
+    terminal: { gritDelta: -2, sanityDelta: -4, soulDivisor: 2 }
+};
+
+/**
+ * Extract the effective Sin threshold the way _calculateSinThreshold does,
+ * but apply the terminal soul-halving. This runs during prep so the sheet
+ * shows the penalized value.
+ *
+ * @param {Object} data - system data (mutates data.darkMagic.sinThreshold)
+ */
+export function applyAddictionPenalties(data) {
+    if (!data.darkMagic || typeof data.darkMagic !== "object") return;
+    const stage = data.darkMagic.addictionLevel || "none";
+    const effects = ADDICTION_STAGE_EFFECTS[stage] || ADDICTION_STAGE_EFFECTS.none;
+
+    // Grit penalty stacks on whatever's already there (condition + stance).
+    if (effects.gritDelta) {
+        data.totalGrit = Math.max(0, (data.totalGrit || 0) + effects.gritDelta);
+    }
+    // Sanity cap shrinks under late/terminal pressure.
+    if (effects.sanityDelta && data.sanity) {
+        data.sanity.max = Math.max(1, (data.sanity.max || 1) + effects.sanityDelta);
+        if (data.sanity.value > data.sanity.max) data.sanity.value = data.sanity.max;
+        data.maxSanity = data.sanity.max;
+    }
+    // Terminal halves the Soul input to sin-threshold recomputation.
+    if (effects.soulDivisor > 1) {
+        const soul = data.attributes?.soul?.value || 1;
+        const spells = Object.values(data.darkMagic.spellsLearned || {}).filter(Boolean).length;
+        const bonus = Number(data.darkMagic.sinThresholdBonus) || 0;
+        data.darkMagic.sinThreshold = Math.max(0,
+            Math.floor(soul / effects.soulDivisor) - spells + bonus);
+    }
+
+    // Expose a UI-friendly summary so the sheet can render it without
+    // duplicating the table.
+    data.darkMagic.stageSummary = summarizeStage(stage);
+}
+
+/**
+ * Short human-readable blurb for the current addiction stage.
+ */
+function summarizeStage(stage) {
+    switch (stage) {
+        case "early":    return "Early: -1 Grit";
+        case "middle":   return "Middle: -2 Grit";
+        case "late":     return "Late: -2 Grit, -2 Sanity max; risk of Meltdowns";
+        case "terminal": return "Terminal: Soul halved, -2 Grit, -4 Sanity max";
+        default:         return "None";
+    }
+}
+
+/**
+ * Advance an actor's addiction stage by one step (clamped at terminal).
+ * Returns the new stage.
+ */
+export async function advanceAddictionStage(actor) {
+    const current = actor.system.darkMagic?.addictionLevel || "none";
+    const idx = ADDICTION_STAGES.indexOf(current);
+    if (idx < 0) return current;
+    if (idx >= ADDICTION_STAGES.length - 1) return current;
+    const next = ADDICTION_STAGES[idx + 1];
+    await actor.update({ "system.darkMagic.addictionLevel": next });
+    return next;
+}
+
+/**
+ * Reset currentSin to 0 (daily). Stage progression is persistent.
+ */
+export async function resetDailySin(actor) {
+    await actor.update({ "system.darkMagic.currentSin": 0 });
+}
+
+/**
+ * Handle a dark-spell cast. Increments Sin by the spell DT; if the new
+ * total is over threshold, rolls a Grit test with dice equal to the
+ * excess. Failure advances the addiction stage. Posts a summary card.
+ *
+ * @param {Actor} actor - the caster
+ * @param {Item} spell - the spell item
+ * @returns {Promise<{sinBefore, sinAfter, threshold, overflow,
+ *                    resistSuccesses?, gritTarget?, resisted?, stageAdvanced?}>}
+ */
+export async function handleDarkCast(actor, spell) {
+    if (!spell?.system?.isDarkMagic) return null;
+
+    const dt = Math.max(1, parseInt(spell.system.successes) || 1);
+    const sinBefore = Number(actor.system.darkMagic?.currentSin || 0);
+    const threshold = Number(actor.system.darkMagic?.sinThreshold || 0);
+    const sinAfter = sinBefore + dt;
+
+    const updates = { "system.darkMagic.currentSin": sinAfter };
+    let overflow = sinAfter - threshold;
+    let resistSuccesses = null;
+    let gritTarget = null;
+    let resisted = null;
+    let stageAdvanced = null;
+
+    if (overflow > 0) {
+        // Grit test: dice = overflow, target = totalGrit.
+        gritTarget = Number(actor.system.totalGrit || actor.system.defenses?.grit || 1);
+        const pool = Math.max(1, overflow);
+        const roll = await new Roll(`${pool}d12`).evaluate({ async: true });
+        resistSuccesses = 0;
+        roll.terms[0].results.forEach(die => {
+            if (die.result >= 12) resistSuccesses += 2;
+            else if (die.result >= 8) resistSuccesses += 1;
+        });
+        resisted = resistSuccesses >= gritTarget;
+        if (!resisted) {
+            const prior = actor.system.darkMagic?.addictionLevel || "none";
+            const idx = ADDICTION_STAGES.indexOf(prior);
+            if (idx >= 0 && idx < ADDICTION_STAGES.length - 1) {
+                updates["system.darkMagic.addictionLevel"] = ADDICTION_STAGES[idx + 1];
+                stageAdvanced = ADDICTION_STAGES[idx + 1];
+            }
+        }
+    }
+
+    await actor.update(updates);
+
+    const summary = buildSummary({
+        actor: actor.name,
+        spell: spell.name,
+        dt, sinBefore, sinAfter, threshold, overflow,
+        resistSuccesses, gritTarget, resisted, stageAdvanced
+    });
+
+    await ChatMessage.create({
+        speaker: ChatMessage.getSpeaker({ actor }),
+        content: summary
+    });
+
+    return { sinBefore, sinAfter, threshold, overflow,
+             resistSuccesses, gritTarget, resisted, stageAdvanced };
+}
+
+function buildSummary(o) {
+    const parts = [];
+    parts.push(`<p><strong>${o.actor}</strong> casts <em>${o.spell}</em> (Dark Magic, DT ${o.dt}).</p>`);
+    parts.push(`<p>Sin: ${o.sinBefore} → <strong>${o.sinAfter}</strong> (threshold ${o.threshold}).</p>`);
+    if (o.overflow > 0) {
+        parts.push(`<p>Sin exceeds threshold by ${o.overflow}. Grit test (${o.overflow}d12 vs ${o.gritTarget}): <strong>${o.resistSuccesses}</strong> successes.</p>`);
+        if (o.resisted) {
+            parts.push(`<p class="success">The pull is resisted.</p>`);
+        } else if (o.stageAdvanced) {
+            parts.push(`<p class="failure">The dark takes hold — addiction advances to <strong>${o.stageAdvanced}</strong>.</p>`);
+        } else {
+            parts.push(`<p class="failure">The dark takes hold — already at terminal stage.</p>`);
+        }
+    } else {
+        parts.push(`<p>Within threshold — no resistance roll required.</p>`);
+    }
+    return `<div class="thefade-sin-summary">${parts.join("")}</div>`;
+}

--- a/templates/actor/parts/spells.html
+++ b/templates/actor/parts/spells.html
@@ -63,8 +63,12 @@
 
             <div class="form-group">
                 <button class="roll-addiction" type="button">Roll for Dark Magic Addiction</button>
+                <button class="rest-daily" type="button" title="Scrub accumulated Sin for the day (stages persist)">Rest (Clear Sin)</button>
             </div>
         </div>
+        {{#if system.darkMagic.stageSummary}}
+        <p class="addiction-stage-summary"><em>Addiction: {{system.darkMagic.stageSummary}}</em></p>
+        {{/if}}
     </div>
 
     <hr />


### PR DESCRIPTION
## Summary
- Casting a dark spell increments `currentSin` by the spell's required successes (its DT).
- If Sin exceeds threshold, auto-rolls a Grit resistance test with dice equal to the excess; failure advances addiction stage.
- Addiction stages apply passively during data prep: **early** -1 Grit, **middle** -2 Grit, **late** -2 Grit + -2 Sanity max, **terminal** Soul halved for threshold + -2 Grit + -4 Sanity max.
- `restDaily()` method on `TheFadeActor` (plus a sheet button) zeroes Sin for the day — stages persist.
- New `src/dark-magic.js` keeps the rules in one place.

## Scope notes
- Addiction penalties are numeric (Grit/Sanity) — late-stage "Meltdowns / Sanity Breaks" events aren't auto-fired; GM can trigger manually.
- Rest-daily is player-initiated via a sheet button; no calendar/time hook.

## Test plan
- [ ] Cast a dark spell with DT 2 while Sin < threshold → Sin increments by 2, no resistance roll, summary card shows \"within threshold\"
- [ ] Push Sin over threshold → summary shows Grit test; on pass, stage unchanged; on fail, stage advances (none→early→middle→…)
- [ ] Set addiction to `early` → sheet Grit drops by 1; `middle` → drops by 2
- [ ] Set addiction to `late` → Sanity max drops by 2 and caps value
- [ ] Set addiction to `terminal` → Sin threshold recomputes with Soul halved
- [ ] Click Rest (Clear Sin) → currentSin → 0, stage unchanged, chat posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)