### PR TITLE
Character creation: point-buy, attribute roll, talent prereqs

### DIFF
--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -677,6 +677,25 @@ export class TheFadeCharacterSheet extends ActorSheet {
             }
         }
 
+        // Point-buy status: budget is 20 points above baseline 1-in-each
+        // (rules: attributes start at 1, max 10, spend 20 to raise).
+        const attrNames = ["physique", "finesse", "mind", "presence", "soul"];
+        const pointBuyBudget = 20;
+        let spent = 0;
+        let capExceeded = false;
+        for (const a of attrNames) {
+            const v = Number(data.attributes?.[a]?.value) || 0;
+            spent += Math.max(0, v - 1);
+            if (v > 10) capExceeded = true;
+        }
+        data.pointBuy = {
+            spent,
+            budget: pointBuyBudget,
+            remaining: pointBuyBudget - spent,
+            over: spent > pointBuyBudget,
+            capExceeded
+        };
+
         // Initialize minimal defense data to prevent template errors
         if (!data.defenses) {
             data.defenses = {
@@ -2641,6 +2660,42 @@ export class TheFadeCharacterSheet extends ActorSheet {
     }
 
     /**
+    * Roll five exploding d6 and fill the five attributes. Confirms
+    * first so the click doesn't wipe an existing character.
+    * @param {Event} event
+    * @private
+    */
+    async _onRollAttributes(event) {
+        event.preventDefault();
+        const confirmed = await Dialog.confirm({
+            title: "Roll Attributes",
+            content: "<p>Replace the five attribute values with random rolls (1d6 exploding on 6)? This cannot be undone.</p>",
+            yes: () => true,
+            no: () => false,
+            defaultYes: false
+        });
+        if (!confirmed) return;
+
+        const attrNames = ["physique", "finesse", "mind", "presence", "soul"];
+        const results = {};
+        const chatRows = [];
+        for (const a of attrNames) {
+            const roll = await new Roll("1d6x6").evaluate({ async: true });
+            // Clamp at the 10 cap.
+            const total = Math.min(10, roll.total);
+            results[`system.attributes.${a}.value`] = total;
+            const dice = roll.dice[0]?.results?.map(r => r.result).join(", ") || roll.total;
+            chatRows.push(`<li><strong>${a[0].toUpperCase()}${a.slice(1)}:</strong> ${total} <em>(${dice})</em></li>`);
+        }
+        await this.actor.update(results);
+
+        ChatMessage.create({
+            speaker: ChatMessage.getSpeaker({ actor: this.actor }),
+            content: `<div class="thefade-attr-roll"><p><strong>${this.actor.name}</strong> rolls attributes (1d6! × 5):</p><ul>${chatRows.join("")}</ul></div>`
+        });
+    }
+
+    /**
     * Handle casting a spell
     * @param {Event} event   The originating click event
     * @private
@@ -3542,6 +3597,7 @@ export class TheFadeCharacterSheet extends ActorSheet {
         html.find('.roll-dice').click(this._onRollDice.bind(this));
         html.find('.roll-addiction').click(this._onDarkMagicAddictionRoll.bind(this));
         html.find('.rest-daily').click(this._onRestDaily.bind(this));
+        html.find('.roll-attributes').click(this._onRollAttributes.bind(this));
 
         html.find('.level-up-btn').click(this._onLevelUp.bind(this));
         html.find('.experience-check-btn').click(this._onExperienceCheck.bind(this));

--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -8303,3 +8303,33 @@ select[name="system.aura.color"] option[value="white"] {
     font-size: 0.95em;
     line-height: 1.4;
 }
+
+/* Point-buy panel (creation wizard) */
+.thefade .attribute-pointbuy-panel {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    margin-bottom: 8px;
+    background: rgba(0, 0, 0, 0.04);
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 0.95em;
+    flex-wrap: wrap;
+}
+.thefade .attribute-pointbuy-panel .pointbuy-label { color: #555; }
+.thefade .attribute-pointbuy-panel .pointbuy-remaining { color: #777; font-style: italic; }
+.thefade .attribute-pointbuy-panel .pointbuy-warning {
+    color: #aa4444; font-weight: bold;
+}
+.thefade .attribute-pointbuy-panel.over-budget,
+.thefade .attribute-pointbuy-panel.cap-exceeded {
+    border-color: #aa4444;
+    background: #fff2f2;
+}
+.thefade .attribute-pointbuy-panel .roll-attributes {
+    margin-left: auto;
+    padding: 2px 10px;
+    font-size: 0.9em;
+    cursor: pointer;
+}

--- a/templates/actor/parts/attributes.html
+++ b/templates/actor/parts/attributes.html
@@ -1,4 +1,14 @@
 <h2>Ability Scores</h2>
+
+<div class="attribute-pointbuy-panel {{#if pointBuy.over}}over-budget{{/if}} {{#if pointBuy.capExceeded}}cap-exceeded{{/if}}">
+    <span class="pointbuy-label">Point buy:</span>
+    <strong>{{pointBuy.spent}}</strong> / {{pointBuy.budget}} spent
+    <span class="pointbuy-remaining">({{pointBuy.remaining}} remaining)</span>
+    {{#if pointBuy.over}}<span class="pointbuy-warning">Over budget!</span>{{/if}}
+    {{#if pointBuy.capExceeded}}<span class="pointbuy-warning">Attribute above 10!</span>{{/if}}
+    <button class="roll-attributes" type="button" title="Roll 1d6 per attribute (explodes on 6)">Roll 1d6 (exploding) &times; 5</button>
+</div>
+
 <div class="grid grid-5col">
 
     <div class="attribute panel">

--- a/thefade.js
+++ b/thefade.js
@@ -469,10 +469,9 @@ Hooks.on("createItem", async (item, options, userId) => {
 
 
             // Show results
-            let message = [];
-            if (skillsModified > 0) message.push(`${skillsModified} skills improved`);
-            if (customSkillsCreated > 0) message.push(`${customSkillsCreated} custom skills added`);
-            if (choicesMade > 0) message.push(`${choicesMade} skill choices made`);
+            const message = [];
+            if (skillsToAdd.length > 0) message.push(`${skillsToAdd.length} skills added`);
+            if (skillsUpgraded > 0) message.push(`${skillsUpgraded} skills upgraded`);
 
             if (message.length > 0) {
                 ui.notifications.info(`${path.name} applied to ${actor.name}: ${message.join(', ')}`);
@@ -562,6 +561,25 @@ Hooks.on("createItem", async (item, options, userId) => {
         });
 
         ui.notifications.info(`Applied ${species.name} species to ${actor.name}.`);
+    }
+
+    // Talent prereq acknowledgement: we can't parse free-text, but we
+    // can surface the prerequisites and require the player/GM to
+    // confirm eligibility. Declining deletes the just-added talent.
+    if (item.type === 'talent' && item.parent && item.parent.type === 'character' && game.user.id === userId) {
+        const prereqs = (item.system.prerequisites || "").trim();
+        if (!prereqs) return;
+        const keep = await Dialog.confirm({
+            title: `Talent Prerequisites: ${item.name}`,
+            content: `<p><strong>${item.name}</strong> lists prerequisites:</p><blockquote>${prereqs}</blockquote><p>Does <strong>${item.parent.name}</strong> meet them?</p>`,
+            yes: () => true,
+            no: () => false,
+            defaultYes: true
+        });
+        if (!keep) {
+            await item.delete();
+            ui.notifications.warn(`${item.name} removed: prerequisites not met.`);
+        }
     }
 });
 


### PR DESCRIPTION
## Summary
- Attribute tab now shows a **point-buy status panel**: points spent vs 20 budget, warnings when over budget or any attribute exceeds the 10 cap.
- **Roll attributes button**: rolls 1d6 (exploding on 6) for each of the five attributes, clamps each at 10, overwrites values, posts results to chat. Confirmation dialog guards against accidental overwrites.
- **Talent prerequisite acknowledgement**: when a talent with non-empty prerequisites is dropped on a character, a confirmation dialog shows the prereq text and asks if the character meets them. Declining deletes the talent.
- **Path add log fixed**: the post-add notification referenced three undeclared variables (skillsModified/customSkillsCreated/choicesMade) — now uses the real counters (skillsToAdd.length, skillsUpgraded).

## Scope notes
- Prereq text is free-form, so this is an acknowledgement prompt, not a real parser. Structured prereqs are out of scope.
- Species bonus auto-apply (AUDIT #13) was already implemented at thefade.js:540; no change needed there.
- Path ability *effects* (as opposed to rendering) belong to Step 7's ability data model.

## Test plan
- [ ] Open an attribute tab — panel shows spent/remaining against 20
- [ ] Raise an attribute above 10 — panel turns red, warns \"Attribute above 10!\"
- [ ] Exceed 20 total spend — panel turns red, warns \"Over budget!\"
- [ ] Click Roll button → confirm → five attributes fill with exploding d6 results, chat card posts breakdown
- [ ] Decline the confirm dialog → nothing changes
- [ ] Drop a talent with prerequisites → dialog shows the prereq text, Yes keeps, No deletes
- [ ] Drop a talent without prerequisites → no dialog, just adds
- [ ] Drop a path with pathSkills → chat notification reports \"N skills added, M skills upgraded\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)