### PR TITLE
Character creation mode setting and token facing indicator

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -17,6 +17,15 @@
   "THEFADE.DefensePassiveParry": "Passive Parry",
   "THEFADE.DefenseFacing": "Facing",
 
+  "THEFADE.SettingCreationMode": "Character Creation Mode",
+  "THEFADE.SettingCreationModeHint": "Choose how players generate attribute scores for new characters. Point Buy shows the 20-point budget tracker; Random Roll shows the 1d6 (exploding) roller.",
+  "THEFADE.SettingCreationModePointBuy": "Point Buy",
+  "THEFADE.SettingCreationModeRandom": "Random Roll",
+
+  "THEFADE.SetFacing": "Set Facing (to target, or click a point)",
+  "THEFADE.SetFacingTargeted": "{token} now faces {target}.",
+  "THEFADE.SetFacingClickPrompt": "Click a point on the canvas to set this token's facing.",
+
   "THEFADE.FacingFront": "Front",
   "THEFADE.FacingFlank": "Flank",
   "THEFADE.FacingBackFlank": "Back Flank",

--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -697,6 +697,8 @@ export class TheFadeCharacterSheet extends ActorSheet {
             capExceeded
         };
 
+        data.creationMode = game.settings.get("thefade", "characterCreationMode");
+
         // Initialize minimal defense data to prevent template errors
         if (!data.defenses) {
             data.defenses = {

--- a/src/token-facing.js
+++ b/src/token-facing.js
@@ -1,0 +1,110 @@
+// Token facing visual indicator and Token HUD "Set Facing" control.
+// The front arc spans ±45° from the token's rotation, matching the
+// front/flank boundaries used in character-sheet.js _calculateFacingFromTokens.
+
+const FRONT_ARC_HALF_DEG = 45;
+const ARC_COLOR = 0xF5C542;
+const ARC_FILL_ALPHA = 0.15;
+const ARC_LINE_ALPHA = 0.7;
+
+function isFacingEligible(token) {
+    return token?.actor?.type === "character";
+}
+
+function drawFacingIndicator(token) {
+    if (!token) return;
+
+    if (token.thefadeFacingGraphic) {
+        try { token.thefadeFacingGraphic.destroy(); } catch (_) { /* already gone */ }
+        token.thefadeFacingGraphic = null;
+    }
+
+    if (!isFacingEligible(token)) return;
+
+    const width = token.w ?? token.width ?? 100;
+    const height = token.h ?? token.height ?? 100;
+    const radius = Math.max(width, height) * 0.65;
+    const halfArc = FRONT_ARC_HALF_DEG * Math.PI / 180;
+
+    const g = new PIXI.Graphics();
+    g.beginFill(ARC_COLOR, ARC_FILL_ALPHA);
+    g.lineStyle(2, ARC_COLOR, ARC_LINE_ALPHA);
+    g.moveTo(0, 0);
+    g.arc(0, 0, radius, -halfArc, halfArc);
+    g.lineTo(0, 0);
+    g.endFill();
+
+    g.position.set(width / 2, height / 2);
+    g.rotation = ((token.document?.rotation ?? 0) * Math.PI) / 180;
+    g.zIndex = -1;
+
+    token.addChild(g);
+    token.thefadeFacingGraphic = g;
+}
+
+function removeFacingIndicator(token) {
+    if (!token?.thefadeFacingGraphic) return;
+    try { token.thefadeFacingGraphic.destroy(); } catch (_) { /* already gone */ }
+    token.thefadeFacingGraphic = null;
+}
+
+async function setTokenFacingToward(token, point) {
+    if (!token || !point) return;
+    const center = token.center;
+    if (!center) return;
+    const dx = point.x - center.x;
+    const dy = point.y - center.y;
+    const angle = ((Math.atan2(dy, dx) * 180) / Math.PI + 360) % 360;
+    await token.document.update({ rotation: angle });
+}
+
+Hooks.on("drawToken", drawFacingIndicator);
+Hooks.on("refreshToken", drawFacingIndicator);
+Hooks.on("destroyToken", removeFacingIndicator);
+
+Hooks.on("renderTokenHUD", (hud, html, data) => {
+    const token = hud?.object;
+    if (!isFacingEligible(token)) return;
+
+    const root = html?.[0] ?? html;
+    if (!root) return;
+    const column = root.querySelector(".col.left") ?? root.querySelector(".col");
+    if (!column) return;
+
+    const button = document.createElement("div");
+    button.className = "control-icon thefade-set-facing";
+    button.title = game.i18n.localize("THEFADE.SetFacing");
+    button.innerHTML = '<i class="fas fa-compass"></i>';
+    button.addEventListener("click", async (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        const target = game.user.targets?.first();
+        if (target && target !== token) {
+            await setTokenFacingToward(token, target.center);
+            ui.notifications.info(
+                game.i18n.format("THEFADE.SetFacingTargeted", {
+                    token: token.name,
+                    target: target.name
+                })
+            );
+            return;
+        }
+
+        ui.notifications.info(game.i18n.localize("THEFADE.SetFacingClickPrompt"));
+        const onCanvasClick = async (clickEvent) => {
+            try {
+                const point = clickEvent.data?.getLocalPosition
+                    ? clickEvent.data.getLocalPosition(canvas.stage)
+                    : clickEvent.interactionData?.origin ?? clickEvent.data?.origin;
+                if (!point) return;
+                await setTokenFacingToward(token, point);
+            } finally {
+                canvas.stage.off("mousedown", onCanvasClick);
+            }
+        };
+        canvas.stage.once("mousedown", onCanvasClick);
+    });
+
+    column.appendChild(button);
+});

--- a/templates/actor/parts/attributes.html
+++ b/templates/actor/parts/attributes.html
@@ -1,13 +1,21 @@
 <h2>Ability Scores</h2>
 
+{{#if (eq creationMode "pointbuy")}}
 <div class="attribute-pointbuy-panel {{#if pointBuy.over}}over-budget{{/if}} {{#if pointBuy.capExceeded}}cap-exceeded{{/if}}">
     <span class="pointbuy-label">Point buy:</span>
     <strong>{{pointBuy.spent}}</strong> / {{pointBuy.budget}} spent
     <span class="pointbuy-remaining">({{pointBuy.remaining}} remaining)</span>
     {{#if pointBuy.over}}<span class="pointbuy-warning">Over budget!</span>{{/if}}
     {{#if pointBuy.capExceeded}}<span class="pointbuy-warning">Attribute above 10!</span>{{/if}}
+</div>
+{{/if}}
+
+{{#if (eq creationMode "random")}}
+<div class="attribute-randomroll-panel">
+    <span class="pointbuy-label">Random roll:</span>
     <button class="roll-attributes" type="button" title="Roll 1d6 per attribute (explodes on 6)">Roll 1d6 (exploding) &times; 5</button>
 </div>
+{{/if}}
 
 <div class="grid grid-5col">
 

--- a/thefade.js
+++ b/thefade.js
@@ -11,6 +11,7 @@ import { TheFadeItem } from './src/item.js';
 import { TheFadeItemSheet } from './src/item-sheet.js';
 import { TheFadeCharacterSheet } from './src/character-sheet.js';
 import { computePerRoundDamage, CONDITION_EFFECTS } from './src/conditions.js';
+import './src/token-facing.js';
 
 
 /**
@@ -143,6 +144,30 @@ Hooks.once('init', async function () {
         magicitem: "TYPES.Item.magicitem",
         clothing: "TYPES.Item.clothing"
     };
+
+    // --------------------------------------------------------------------
+    // WORLD SETTINGS
+    // --------------------------------------------------------------------
+
+    game.settings.register("thefade", "characterCreationMode", {
+        name: "THEFADE.SettingCreationMode",
+        hint: "THEFADE.SettingCreationModeHint",
+        scope: "world",
+        config: true,
+        type: String,
+        choices: {
+            pointbuy: "THEFADE.SettingCreationModePointBuy",
+            random: "THEFADE.SettingCreationModeRandom"
+        },
+        default: "pointbuy",
+        onChange: () => {
+            for (const app of Object.values(ui.windows)) {
+                if (app?.actor?.type === "character" && typeof app.render === "function") {
+                    app.render(false);
+                }
+            }
+        }
+    });
 
     // --------------------------------------------------------------------
     // SHEET REGISTRATION


### PR DESCRIPTION
## Summary

- Adds a **Character Creation Mode** world setting (Point Buy vs. Random Roll). The character sheet now shows only one workflow at a time — the 20-point budget tracker or the "Roll 1d6 (exploding) × 5" button — based on what the GM selects. Both flows were already implemented but were always shown together.
- Adds a **visual facing indicator** to character tokens: a translucent yellow front-arc cone (±45°, matching the boundaries used by `_calculateFacingFromTokens` in `src/character-sheet.js`) that follows the token's rotation.
- Adds a **Set Facing** compass button to the Token HUD for character tokens. Click it with a token targeted to rotate the selected token to face that target; click it without a target to enter "click a point" mode where the next canvas click sets forward.

## Why

The system had both point-buy and random-roll paths live simultaneously on the sheet, which tables wanted to pick between. Facing already drove defense modifiers (dodge/parry/avoid) but there was no on-canvas cue for which direction a token was facing and no quick way to point a token at something — it was all inferred from `token.document.rotation`.

## Files touched

- `thefade.js` — registers the `characterCreationMode` setting (world scope) and imports the new `src/token-facing.js` module. Setting changes re-render open character sheets.
- `src/character-sheet.js` — exposes `data.creationMode` so the template can branch.
- `templates/actor/parts/attributes.html` — `{{#if (eq creationMode ...)}}` around the two panels; the `eq` helper was already registered at `thefade.js:282`.
- `src/token-facing.js` *(new)* — `drawToken`/`refreshToken`/`destroyToken` hooks for the cone graphic, `renderTokenHUD` hook for the button.
- `lang/en.json` — localization strings for the setting label/hint/choices and the HUD tooltip/prompts.

## Test plan

- [ ] Open **Configure Settings → System Settings**, confirm "Character Creation Mode" appears with Point Buy / Random Roll options.
- [ ] With mode = Point Buy, open a character sheet → only the point-buy tracker is visible above attributes.
- [ ] Switch to Random Roll → the tracker is replaced by the "Roll 1d6 (exploding) × 5" button; clicking it still rolls and posts to chat.
- [ ] Place a character token on a scene → a yellow front-arc cone is rendered and rotates with the token.
- [ ] Select a character token, target another token, click the compass icon on the HUD → the selected token rotates to face the target.
- [ ] Same button, no target set → a prompt appears; clicking on the canvas rotates the token toward that point.
- [ ] Non-character tokens do not get the cone or the HUD button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)