### PR TITLE
Fix point buy tracker visibility and token facing 90 degree offset

### DIFF
--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -3139,8 +3139,9 @@ export class TheFadeCharacterSheet extends ActorSheet {
         const dx = attackerCenter.x - targetCenter.x;
         const dy = attackerCenter.y - targetCenter.y;
 
-        // Convert vector to degrees, normalized to 0-360.
-        const angleToAttacker = ((Math.atan2(dy, dx) * (180 / Math.PI)) + 360) % 360;
+        // Foundry's token rotation uses 0° = north (up); atan2 returns 0 for
+        // east. Add 90° so both reference the same "rotation=0 ⇒ up" frame.
+        const angleToAttacker = ((Math.atan2(dy, dx) * (180 / Math.PI)) + 90 + 360) % 360;
         const targetRotation = ((targetToken.document?.rotation ?? targetToken.rotation ?? 0) + 360) % 360;
 
         // Signed delta in range [-180, 180].

--- a/src/token-facing.js
+++ b/src/token-facing.js
@@ -1,8 +1,11 @@
 // Token facing visual indicator and Token HUD "Set Facing" control.
 // The front arc spans ±45° from the token's rotation, matching the
 // front/flank boundaries used in character-sheet.js _calculateFacingFromTokens.
+// Foundry's token.document.rotation uses 0° = north (up); atan2(dy, dx)
+// returns 0 for east. The +90° offset below bridges those conventions.
 
 const FRONT_ARC_HALF_DEG = 45;
+const FOUNDRY_ROTATION_OFFSET_DEG = 90;
 const ARC_COLOR = 0xF5C542;
 const ARC_FILL_ALPHA = 0.15;
 const ARC_LINE_ALPHA = 0.7;
@@ -35,7 +38,8 @@ function drawFacingIndicator(token) {
     g.endFill();
 
     g.position.set(width / 2, height / 2);
-    g.rotation = ((token.document?.rotation ?? 0) * Math.PI) / 180;
+    const rotationDeg = (token.document?.rotation ?? 0) - FOUNDRY_ROTATION_OFFSET_DEG;
+    g.rotation = (rotationDeg * Math.PI) / 180;
     g.zIndex = -1;
 
     token.addChild(g);
@@ -54,8 +58,9 @@ async function setTokenFacingToward(token, point) {
     if (!center) return;
     const dx = point.x - center.x;
     const dy = point.y - center.y;
-    const angle = ((Math.atan2(dy, dx) * 180) / Math.PI + 360) % 360;
-    await token.document.update({ rotation: angle });
+    const mathAngle = (Math.atan2(dy, dx) * 180) / Math.PI;
+    const rotation = (mathAngle + FOUNDRY_ROTATION_OFFSET_DEG + 360) % 360;
+    await token.document.update({ rotation });
 }
 
 Hooks.on("drawToken", drawFacingIndicator);

--- a/templates/actor/parts/attributes.html
+++ b/templates/actor/parts/attributes.html
@@ -1,16 +1,16 @@
 <h2>Ability Scores</h2>
 
-{{#if (eq creationMode "pointbuy")}}
-<div class="attribute-pointbuy-panel {{#if pointBuy.over}}over-budget{{/if}} {{#if pointBuy.capExceeded}}cap-exceeded{{/if}}">
+{{#if (eq system.creationMode "pointbuy")}}
+<div class="attribute-pointbuy-panel {{#if system.pointBuy.over}}over-budget{{/if}} {{#if system.pointBuy.capExceeded}}cap-exceeded{{/if}}">
     <span class="pointbuy-label">Point buy:</span>
-    <strong>{{pointBuy.spent}}</strong> / {{pointBuy.budget}} spent
-    <span class="pointbuy-remaining">({{pointBuy.remaining}} remaining)</span>
-    {{#if pointBuy.over}}<span class="pointbuy-warning">Over budget!</span>{{/if}}
-    {{#if pointBuy.capExceeded}}<span class="pointbuy-warning">Attribute above 10!</span>{{/if}}
+    <strong>{{system.pointBuy.spent}}</strong> / {{system.pointBuy.budget}} spent
+    <span class="pointbuy-remaining">({{system.pointBuy.remaining}} remaining)</span>
+    {{#if system.pointBuy.over}}<span class="pointbuy-warning">Over budget!</span>{{/if}}
+    {{#if system.pointBuy.capExceeded}}<span class="pointbuy-warning">Attribute above 10!</span>{{/if}}
 </div>
 {{/if}}
 
-{{#if (eq creationMode "random")}}
+{{#if (eq system.creationMode "random")}}
 <div class="attribute-randomroll-panel">
     <span class="pointbuy-label">Random roll:</span>
     <button class="roll-attributes" type="button" title="Roll 1d6 per attribute (explodes on 6)">Roll 1d6 (exploding) &times; 5</button>


### PR DESCRIPTION
## Summary

Two fixes on top of [#20](https://github.com/colearkenach/thefade/pull/20):

1. **Point buy tracker now renders.** The template was reading `{{pointBuy.X}}` at the root, but the data is stored on `actor.system` (because `_prepareCharacterData` aliases its local `data` to `sheetData.actor.system`), so the real path is `{{system.pointBuy.X}}`. This was a pre-existing bug from the original character-creation-wizard PR — the tracker never actually displayed. The new `creationMode` field had the same issue. Template now uses `{{system.pointBuy.X}}` and `{{system.creationMode}}`, matching the `{{system.attributes.physique.value}}` convention the attribute grid already uses.

2. **Token facing no longer rotates 90° off.** Foundry's `document.rotation = 0` means **north/up**, but `Math.atan2(dy, dx) = 0` means **east/right**. The new Set Facing button was setting `rotation = atan2Result` directly, so pointing a token at a target to the west rotated the token to face south. Added a `+90°` bridge in three places so everything references the same frame:
   - Visual cone (`src/token-facing.js`) — local rotation is now `(document.rotation − 90)°`
   - `setTokenFacingToward` — adds 90° when converting atan2 result to Foundry rotation
   - `_calculateFacingFromTokens` (`src/character-sheet.js`) — adds 90° to `angleToAttacker` so the attack-dialog auto-detect agrees with the cone. This was a latent pre-existing bug; fixing it keeps defense calculations consistent with the new visual indicator.

## Why now

Neither fix was caught during #20 because:
- The point buy tracker has been broken since it was introduced; I assumed it worked because the data-prep code looked correct on its own.
- The facing offset only becomes obvious once there's a visual cue — the previous auto-detect bug was invisible without the cone overlay.

## Test plan

- [ ] Open a character sheet with Character Creation Mode = **Point Buy**; the point-buy tracker displays spent/budget/remaining above the attribute grid.
- [ ] Change attribute values; tracker updates (over-budget and cap-exceeded warnings appear when appropriate).
- [ ] Switch the world setting to **Random Roll**; tracker disappears and the "Roll 1d6 (exploding) × 5" button shows instead.
- [ ] Place a character token. The yellow front-arc cone points in the same direction the token art is facing.
- [ ] Target a token to the **west** of a selected character token, click the Set Facing compass button; the token rotates to face west (not south).
- [ ] Repeat for targets north/east/south — each results in the token pointing at the target.
- [ ] In an attack roll, with facing auto-detect on, position the attacker directly in front of the defender (same visual direction as the defender's cone); auto-detect returns `front`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)