### PR TITLE
Make Token HUD facing button render in Foundry v13

### DIFF
--- a/src/token-facing.js
+++ b/src/token-facing.js
@@ -18,7 +18,10 @@ const ARROWHEAD_LENGTH = 10;
 const ARROWHEAD_HALF_WIDTH = 6;
 
 function isFacingEligible(token) {
-    return token?.actor?.type === "character";
+    // Any token with an actor qualifies. The system only defines "character",
+    // but leaving this permissive avoids silently failing if a token is
+    // actorless or uses a custom document class.
+    return !!token?.actor;
 }
 
 export function getTokenFacing(token) {
@@ -99,19 +102,14 @@ Hooks.on("updateToken", (tokenDoc, change) => {
     if (token) drawFacingIndicator(token);
 });
 
-Hooks.on("renderTokenHUD", (hud, html, data) => {
-    const token = hud?.object;
-    if (!isFacingEligible(token)) return;
-
-    const root = html?.[0] ?? html;
-    if (!root) return;
-    const column = root.querySelector(".col.left") ?? root.querySelector(".col");
-    if (!column) return;
-
-    const button = document.createElement("div");
+function buildFacingButton(token) {
+    // Match Foundry v13's native HUD button markup so core styling applies.
+    const button = document.createElement("button");
+    button.type = "button";
     button.className = "control-icon thefade-set-facing";
+    button.setAttribute("data-tooltip", "THEFADE.SetFacing");
     button.title = game.i18n.localize("THEFADE.SetFacing");
-    button.innerHTML = '<i class="fas fa-compass"></i>';
+    button.innerHTML = '<i class="fa-solid fa-compass" inert></i>';
     button.addEventListener("click", async (event) => {
         event.preventDefault();
         event.stopPropagation();
@@ -142,6 +140,42 @@ Hooks.on("renderTokenHUD", (hud, html, data) => {
         };
         canvas.stage.once("mousedown", onCanvasClick);
     });
+    return button;
+}
 
-    column.appendChild(button);
-});
+function injectFacingButton(hud, html) {
+    console.debug("TheFade: renderTokenHUD fired", { hud, html });
+    const token = hud?.object;
+    if (!token) {
+        console.warn("TheFade: renderTokenHUD fired without a token object", hud);
+        return;
+    }
+    if (!isFacingEligible(token)) {
+        console.debug("TheFade: skipping facing button (no actor)", token);
+        return;
+    }
+
+    // v12 passed a jQuery object, v13 passes an HTMLElement. Accept either.
+    const root = (html instanceof HTMLElement) ? html : (html?.[0] ?? html);
+    if (!root?.querySelector) {
+        console.warn("TheFade: renderTokenHUD received unexpected html", html);
+        return;
+    }
+
+    // Avoid double-inject if the hook fires twice for the same render.
+    if (root.querySelector(".thefade-set-facing")) return;
+
+    const column =
+        root.querySelector(".col.left") ??
+        root.querySelector("[data-column='left']") ??
+        root.querySelector(".left") ??
+        root.querySelector(".col") ??
+        root;
+    if (column === root) {
+        console.warn("TheFade: no column container found in TokenHUD; appending to root", root);
+    }
+
+    column.appendChild(buildFacingButton(token));
+}
+
+Hooks.on("renderTokenHUD", injectFacingButton);


### PR DESCRIPTION
## Summary

The compass button on the Token HUD wasn't appearing. Three fixes in `src/token-facing.js`:

1. **Use a real `<button>` element with `data-tooltip`** — matches Foundry v13's native HUD markup ([Foundry core template](https://foundryvtt.com/api/classes/foundry.applications.hud.TokenHUD.html)). The previous `<div>` with a plain `title` attribute was being laid out inconsistently by core CSS.
2. **Fallback selector chain for the left column** — `.col.left` → `[data-column='left']` → `.left` → `.col` → root. If none match, the button still appends to the HUD root and a warning is logged instead of bailing silently. Also now handles both the v12 jQuery-wrapped `html` argument and the v13 plain `HTMLElement`.
3. **Loosen the actor-type guard** — `isFacingEligible` now just checks `token.actor` exists. The `type === "character"` check was correct in principle (this system only declares that type in `template.json`) but any edge case — unlinked token, load-order race — caused total silence. The permissive check plus a `console.debug` on skip makes future regressions visible.

Also adds a `console.debug("TheFade: renderTokenHUD fired", ...)` at the top of the hook so it's obvious whether the issue (if one recurs) is "hook didn't fire" vs "DOM not found" vs "skipped by guard".

## Why

User reported on the merged facing-rewrite PR: *"What set facing button... I don't see one. There's no compass."* The screenshot showed a fully-rendered v13 Token HUD with elevation/gear on the left and status icons on the right — the slot my code was targeting — but no compass. No way to know from the outside whether the hook fired at all, so the new log lines answer that directly if it still misbehaves.

## Test plan

- [ ] Select a character token in a v13 scene. The Token HUD shows a compass icon in the left column alongside the elevation, up/down, and gear buttons.
- [ ] Click it with a target set — selected token rotates (via the facing flag) toward the target; a chat/notification confirms.
- [ ] Click it with no target set — notification prompts to click a canvas point; clicking sets facing toward that point.
- [ ] Dev tools console shows `TheFade: renderTokenHUD fired` each time a token is selected. No `no column container found` warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)