### PR TITLE
Fix armor/ND reset bug and add called-shot hit location

### DIFF
--- a/src/abilities.js
+++ b/src/abilities.js
@@ -104,9 +104,10 @@ export const UNIVERSAL_ABILITIES = {
             if (!data.naturalDeflection) data.naturalDeflection = {};
             if (!data.naturalDeflection.body) data.naturalDeflection.body = { current: 0, max: 0, stacks: false };
             data.naturalDeflection.body.max = Math.max(data.naturalDeflection.body.max || 0, amount);
-            if ((data.naturalDeflection.body.current || 0) < amount) {
-                data.naturalDeflection.body.current = amount;
-            }
+            // Do NOT auto-raise current here. Damage drops current toward 0 and
+            // must persist — re-raising on every prepareData would silently
+            // refill broken ND. Players use the "Reset ND" button on the sheet
+            // to refresh a location after repair/recovery.
         }
     },
     "Fire Resistance": {

--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -10,6 +10,7 @@ import {
 import { renderModifierHtml } from './conditions.js';
 import { handleDarkCast } from './dark-magic.js';
 import { openOpposedRollDialog, openAidAnotherDialog } from './opposed.js';
+import { rollHitLocation, locationLabel } from './hit-location.js';
 
 /**
 * Character Sheet class for The Fade system
@@ -2223,6 +2224,12 @@ export class TheFadeCharacterSheet extends ActorSheet {
             if (!isRanged) defaultDT += tempParry;
         }
 
+        // Hit location inputs (from target dialog). Called Shot = −2D to the
+        // attack pool, and only called shots apply status effects on hit.
+        const hitLocationMode = targetInfo?.hitLocationMode || "random";
+        const calledShot = hitLocationMode === "called";
+        const calledShotLocation = targetInfo?.calledShotLocation || "body";
+
         // Get final DT from user
         const dt = await this._getDifficultyThreshold("Attack Difficulty", defaultDT);
         if (dt === null) return; // User cancelled the dialog
@@ -2275,6 +2282,9 @@ export class TheFadeCharacterSheet extends ActorSheet {
             }
             dicePool += condModsUntrained.bonusDice - condModsUntrained.penaltyDice;
 
+            // Called Shot: rulebook −2D to the attack roll.
+            if (calledShot) dicePool -= 2;
+
             // Ensure minimum of 1 die
             dicePool = Math.max(1, dicePool);
 
@@ -2303,6 +2313,25 @@ export class TheFadeCharacterSheet extends ActorSheet {
             // Check against DT
             const attackSucceeds = successes >= dt;
 
+            // Resolve hit location on a hit: Called = chosen + status effects;
+            // Default = body, no status effects; Random = 1d12 on attacker
+            // facing column, no status effects.
+            let resolvedLocation = null;
+            let locationRollDetail = null;
+            if (attackSucceeds) {
+                if (calledShot) {
+                    resolvedLocation = calledShotLocation;
+                } else if (hitLocationMode === "default") {
+                    resolvedLocation = "body";
+                } else {
+                    const r = await rollHitLocation(targetInfo?.facing || "front");
+                    resolvedLocation = r.location;
+                    locationRollDetail = r.sideRoll
+                        ? `1d12=${r.roll} (${r.column}), 1d2=${r.sideRoll}`
+                        : `1d12=${r.roll} (${r.column})`;
+                }
+            }
+
             const templateData = {
                 actor: this.actor.name,
                 weaponName: weapon.name,
@@ -2321,6 +2350,10 @@ export class TheFadeCharacterSheet extends ActorSheet {
                 target: targetName,
                 targetUuid: targetActor?.uuid || "",
                 attackerUuid: this.actor.uuid,
+                hitLocation: resolvedLocation,
+                hitLocationLabel: resolvedLocation ? locationLabel(resolvedLocation) : null,
+                hitLocationRollDetail: locationRollDetail,
+                calledShot: calledShot,
                 bonusDice: weaponData.miscBonus ? `Includes +${weaponData.miscBonus} bonus dice` : null
             };
 
@@ -2403,6 +2436,9 @@ export class TheFadeCharacterSheet extends ActorSheet {
         }
         dicePool += condMods.bonusDice - condMods.penaltyDice;
 
+        // Called Shot: rulebook −2D to the attack roll.
+        if (calledShot) dicePool -= 2;
+
         // Ensure minimum of 1 die
         dicePool = Math.max(1, dicePool);
 
@@ -2464,6 +2500,25 @@ export class TheFadeCharacterSheet extends ActorSheet {
             totalDamage = weaponData.totalDamage;
         }
 
+        // Resolve hit location on a hit: Called = chosen + status effects;
+        // Default = body, no status effects; Random = 1d12 on attacker
+        // facing column, no status effects.
+        let resolvedLocation = null;
+        let locationRollDetail = null;
+        if (attackSucceeds) {
+            if (calledShot) {
+                resolvedLocation = calledShotLocation;
+            } else if (hitLocationMode === "default") {
+                resolvedLocation = "body";
+            } else {
+                const r = await rollHitLocation(targetInfo?.facing || "front");
+                resolvedLocation = r.location;
+                locationRollDetail = r.sideRoll
+                    ? `1d12=${r.roll} (${r.column}), 1d2=${r.sideRoll}`
+                    : `1d12=${r.roll} (${r.column})`;
+            }
+        }
+
         const templateData = {
             actor: this.actor.name,
             weaponName: weapon.name,
@@ -2485,6 +2540,10 @@ export class TheFadeCharacterSheet extends ActorSheet {
             target: targetName,
             targetUuid: targetActor?.uuid || "",
             attackerUuid: this.actor.uuid,
+            hitLocation: resolvedLocation,
+            hitLocationLabel: resolvedLocation ? locationLabel(resolvedLocation) : null,
+            hitLocationRollDetail: locationRollDetail,
+            calledShot: calledShot,
             bonusDice: (skillData.miscBonus || weaponData.miscBonus) ?
                 `Includes bonus dice: ${[
                     skillData.miscBonus ? `+${skillData.miscBonus} from skill` : '',
@@ -3053,6 +3112,26 @@ export class TheFadeCharacterSheet extends ActorSheet {
                         </select>
                         <p class="hint" id="facing-hint">Auto-detected from token positions and target rotation when possible.</p>
                     </div>
+                    <div class="form-group">
+                        <label>Hit Location:</label>
+                        <select id="hit-location-mode" name="hitLocationMode">
+                            <option value="random" selected>Random (1d12 on hit)</option>
+                            <option value="default">Default (Body)</option>
+                            <option value="called">Called Shot (&minus;2D)</option>
+                        </select>
+                    </div>
+                    <div class="form-group" id="called-shot-row" style="display:none;">
+                        <label>Called Shot Location:</label>
+                        <select id="called-shot-location" name="calledShotLocation">
+                            <option value="head">Head</option>
+                            <option value="body">Body</option>
+                            <option value="leftarm">Left Arm</option>
+                            <option value="rightarm">Right Arm</option>
+                            <option value="leftleg">Left Leg</option>
+                            <option value="rightleg">Right Leg</option>
+                        </select>
+                        <p class="hint">Called shots apply status effects on hit but cost 2 dice from the attack pool.</p>
+                    </div>
                 </form>
             `,
                 buttons: {
@@ -3062,7 +3141,9 @@ export class TheFadeCharacterSheet extends ActorSheet {
                         callback: html => {
                             const targetId = html.find('#target-select').val();
                             const facing = html.find('#facing-select').val();
-                            resolve({ targetId, facing });
+                            const hitLocationMode = html.find('#hit-location-mode').val() || "random";
+                            const calledShotLocation = html.find('#called-shot-location').val() || "body";
+                            resolve({ targetId, facing, hitLocationMode, calledShotLocation });
                         }
                     },
                     cancel: {
@@ -3099,6 +3180,15 @@ export class TheFadeCharacterSheet extends ActorSheet {
 
                     applyAutoFacing(targetSelect.val() || "");
                     targetSelect.on('change', ev => applyAutoFacing(ev.currentTarget.value));
+
+                    const modeSelect = html.find('#hit-location-mode');
+                    const calledRow = html.find('#called-shot-row');
+                    const toggleCalledRow = () => {
+                        if (modeSelect.val() === "called") calledRow.show();
+                        else calledRow.hide();
+                    };
+                    toggleCalledRow();
+                    modeSelect.on('change', toggleCalledRow);
                 }
             });
             dialog.render(true);

--- a/src/chat.js
+++ b/src/chat.js
@@ -188,7 +188,11 @@ function bindApplyDamage(html) {
             return;
         }
 
-        const location = html.find('.damage-location').val() || "body";
+        // Location is resolved at attack-roll time (random/default/called shot)
+        // and baked into the card. Fallback to body only if the card predates
+        // this change.
+        const location = card.dataset.hitLocation || "body";
+        const calledShot = card.dataset.calledShot === "1";
         // Read current damage including any rolled crit bonus
         const displayed = parseInt(card.querySelector('.base-damage-value')?.textContent || "0") || 0;
         const damageType = card.dataset.damageType || "Ut";
@@ -201,6 +205,7 @@ function bindApplyDamage(html) {
             amount: displayed,
             type: damageType,
             location,
+            calledShot,
             sourceName: `${sourceName} (${weaponName})`
         });
 

--- a/src/damage.js
+++ b/src/damage.js
@@ -119,6 +119,9 @@ function computeHpStateConditions(newHp, maxHp) {
  * @param {string} [opts.location] - Body location hit (default "body")
  * @param {string} [opts.sourceName] - For chat log; e.g. attacker name
  * @param {boolean} [opts.applyBleed=true] - Whether S/P damage auto-applies Bleed
+ * @param {boolean} [opts.calledShot=false] - True when the attack was declared
+ *   as a called shot. Only called shots apply location-tied status effects
+ *   (e.g. Bleed on S/P). Random and Default hits deal damage only.
  * @returns {Promise<{absorbed, hpBefore, hpAfter, hpDamage, bleedApplied,
  *                   knockedOut, summary}>}
  */
@@ -130,6 +133,7 @@ export async function applyDamage(actor, opts) {
     const location = DAMAGE_LOCATIONS.includes(opts?.location) ? opts.location : "body";
     const sourceName = opts?.sourceName || "damage";
     const applyBleed = opts?.applyBleed !== false;
+    const calledShot = !!opts?.calledShot;
 
     const hpBefore = Number(actor.system.hp?.value ?? 0);
     const hpMax = Number(actor.system.hp?.max ?? 1);
@@ -150,9 +154,10 @@ export async function applyDamage(actor, opts) {
     const hpUpdates = {};
     if (toHp !== 0) hpUpdates["system.hp.value"] = hpAfter;
 
-    // 5) Bleed on slashing/piercing if damage reached HP.
+    // 5) Bleed on slashing/piercing if damage reached HP — ONLY on called shots.
+    // Random and Default hits deal damage without location-tied status effects.
     let bleedApplied = false;
-    if (applyBleed && toHp > 0 && BLEED_TYPES.has(type)) {
+    if (applyBleed && calledShot && toHp > 0 && BLEED_TYPES.has(type)) {
         // Existing Bleed doesn't stack (higher wins) — we set trivial if off,
         // otherwise leave alone so GM can escalate manually on crits.
         const existing = actor.system.conditions?.bleed;

--- a/src/hit-location.js
+++ b/src/hit-location.js
@@ -1,0 +1,52 @@
+// Hit-location rolls per the Core Rulebook "Attack Location" chart.
+//
+// Two simplified facing classes (per system design decision — left/right
+// sides of the target are treated as symmetric):
+//   - front / back    → Front/Back column
+//   - flank / backflank → Flank column (limb side rolled on a d2)
+//
+// d12 distribution:
+//   Front/Back: 1 Head, 2-8 Body, 9 LArm, 10 RArm, 11 LLeg, 12 RLeg
+//   Flank:      1 Head, 2-8 Body, 9-10 Arm (L/R d2), 11-12 Leg (L/R d2)
+
+const LOCATION_LABEL = {
+    head: "Head",
+    body: "Body",
+    leftarm: "Left Arm",
+    rightarm: "Right Arm",
+    leftleg: "Left Leg",
+    rightleg: "Right Leg"
+};
+
+export function locationLabel(key) {
+    return LOCATION_LABEL[key] || key;
+}
+
+/**
+ * Roll a random hit location given the attacker's facing category on the target.
+ * @param {"front"|"back"|"flank"|"backflank"} facing
+ * @returns {Promise<{location: string, roll: number, sideRoll?: number, column: string}>}
+ */
+export async function rollHitLocation(facing) {
+    const roll = await new Roll("1d12").evaluate();
+    const d12 = roll.total;
+    const isFlank = facing === "flank" || facing === "backflank";
+    const column = isFlank ? "Flank" : "Front/Back";
+
+    if (d12 === 1) return { location: "head", roll: d12, column };
+    if (d12 >= 2 && d12 <= 8) return { location: "body", roll: d12, column };
+
+    if (!isFlank) {
+        if (d12 === 9) return { location: "leftarm", roll: d12, column };
+        if (d12 === 10) return { location: "rightarm", roll: d12, column };
+        if (d12 === 11) return { location: "leftleg", roll: d12, column };
+        return { location: "rightleg", roll: d12, column }; // 12
+    }
+
+    const sideRoll = await new Roll("1d2").evaluate();
+    const leftSide = sideRoll.total === 1;
+    if (d12 === 9 || d12 === 10) {
+        return { location: leftSide ? "leftarm" : "rightarm", roll: d12, sideRoll: sideRoll.total, column };
+    }
+    return { location: leftSide ? "leftleg" : "rightleg", roll: d12, sideRoll: sideRoll.total, column };
+}

--- a/src/item.js
+++ b/src/item.js
@@ -72,8 +72,16 @@ export class TheFadeItem extends Item {
             overwrite: false
         });
 
-        if (data.currentAP === 0) data.currentAP = data.ap;
-        if ((data.location === "Arms" || data.location === "Legs" || data.location == "Arms+" || data.location == "Legs+") && data.otherLimbAP === 0) {
+        // Initialize only when the field has never been set (null/undefined).
+        // Once damage drops currentAP to 0 it MUST stay at 0 until repaired —
+        // re-seeding from max here would silently refill broken armor on every
+        // prepareData cycle. New armor gets its starting AP via the
+        // preCreateItem hook in thefade.js.
+        if (data.currentAP === null || data.currentAP === undefined) {
+            data.currentAP = data.ap;
+        }
+        if ((data.location === "Arms" || data.location === "Legs" || data.location == "Arms+" || data.location == "Legs+")
+            && (data.otherLimbAP === null || data.otherLimbAP === undefined)) {
             data.otherLimbAP = data.ap;
         }
     }

--- a/templates/chat/attack-roll.html
+++ b/templates/chat/attack-roll.html
@@ -4,7 +4,9 @@
      data-base-damage="{{totalDamage}}"
      data-damage-type="{{damageType}}"
      data-weapon-name="{{weaponName}}"
-     data-critical-threshold="{{criticalThreshold}}">
+     data-critical-threshold="{{criticalThreshold}}"
+     data-hit-location="{{hitLocation}}"
+     data-called-shot="{{#if calledShot}}1{{else}}0{{/if}}">
     <header class="card-header">
         <h3>Attack with {{weaponName}}</h3>
     </header>
@@ -94,18 +96,16 @@
             <p>Damage: <span class="base-damage-value">{{totalDamage}}</span> {{damageType}}</p>
             {{/if}}
 
+            {{#if hitLocation}}
+            <p class="hit-location-line">
+                <strong>Hit Location:</strong> {{hitLocationLabel}}
+                {{#if calledShot}} <em>(Called Shot)</em>{{/if}}
+                {{#if hitLocationRollDetail}} <span class="hint">[{{hitLocationRollDetail}}]</span>{{/if}}
+            </p>
+            {{/if}}
+
             {{#if targetUuid}}
             <div class="damage-apply-row">
-                <label>Hit location:
-                    <select class="damage-location">
-                        <option value="head">Head</option>
-                        <option value="body" selected>Body</option>
-                        <option value="leftarm">Left Arm</option>
-                        <option value="rightarm">Right Arm</option>
-                        <option value="leftleg">Left Leg</option>
-                        <option value="rightleg">Right Leg</option>
-                    </select>
-                </label>
                 <button class="apply-damage-btn" type="button">
                     <i class="fas fa-burst"></i> Apply Damage
                 </button>

--- a/thefade.js
+++ b/thefade.js
@@ -335,6 +335,27 @@ Hooks.once('init', async function () {
 });
 
 /**
+ * Seed new armor with its starting AP on creation. prepareData no longer
+ * refills currentAP when it hits 0 (that was the "broken armor refills
+ * itself" bug), so freshly created armor needs currentAP populated once
+ * here to avoid starting at 0.
+ */
+Hooks.on("preCreateItem", (item, data, options, userId) => {
+    if (item.type !== "armor") return;
+    const system = data.system || {};
+    const ap = Number(system.ap) || 0;
+    const updates = {};
+    if (system.currentAP === undefined || system.currentAP === null || system.currentAP === 0) {
+        updates["system.currentAP"] = ap;
+    }
+    const isLimb = ["Arms", "Legs", "Arms+", "Legs+"].includes(system.location);
+    if (isLimb && (system.otherLimbAP === undefined || system.otherLimbAP === null || system.otherLimbAP === 0)) {
+        updates["system.otherLimbAP"] = ap;
+    }
+    if (Object.keys(updates).length) item.updateSource(updates);
+});
+
+/**
 * Item creation hook - handle path and species application
 */
 Hooks.on("createItem", async (item, options, userId) => {


### PR DESCRIPTION
## Summary
- **Armor/ND persistence:** `currentAP` and species ND.`current` were refilling to max on every `prepareData` cycle. Damage now sticks: armor at 0 stays at 0 until repaired; ND stays damaged until the existing "Reset ND" button is used. New armor seeds its starting AP via a `preCreateItem` hook.
- **Hit location:** new target-dialog selector — **Random** (1d12 per attacker facing), **Default (Body)**, or **Called Shot [location]**. Called Shot costs −2D on the attack pool and is the only mode that applies location-tied status effects (currently Bleed on S/P). The chat-card hit-location `<select>` is replaced with a read-only line; location is baked in at attack-roll time.
- Front/Back uses the rulebook's Front/Back column; Flank/Back Flank uses the Flank column with a 1d2 side roll for limb location.

## Test plan
- [ ] Create a new armor item — starts at full AP.
- [ ] Apply damage to armor that drops `currentAP` to 0 — refresh sheet, AP stays at 0.
- [ ] Give a species "Natural Armor N" — reduce ND via the sheet button, refresh, ND stays reduced until "Reset ND" is clicked.
- [ ] Attack with Random mode — chat card shows rolled 1d12 + column; no Bleed on S/P hit.
- [ ] Attack with Default mode — location shown as Body; no Bleed.
- [ ] Attack with Called Shot (S/P weapon) — −2D applied to dice pool, chosen location shown, Bleed applied on HP damage.
- [ ] Flank attack random — occasional 1d2 side roll shown in the detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)