### PR TITLE
Add NPC/Monster sheet and Party sheet

### DIFF
--- a/src/actor.js
+++ b/src/actor.js
@@ -40,6 +40,8 @@ export class TheFadeActor extends Actor {
         // Make separate methods for each Actor type (character, npc, etc.)
         if (actorData.type === 'character') {
             this._prepareCharacterData(actorData);
+        } else if (actorData.type === 'npc') {
+            this._prepareNPCData(actorData);
         }
     }
 
@@ -669,6 +671,80 @@ export class TheFadeActor extends Actor {
         data['overland-movement'].swimOverland = swim * 6;
         data['overland-movement'].climbOverland = climb * 6;
         data['overland-movement'].burrowOverland = burrow * 6;
+    }
+
+    /**
+     * Prepare NPC-specific data: auto-calculate defenses from attributes,
+     * apply stances, facing, and condition state. HP max is stored directly.
+     */
+    _prepareNPCData(actorData) {
+        const data = actorData.system;
+
+        // Ensure attributes exist
+        if (!data.attributes) {
+            data.attributes = {
+                physique: { value: 1 }, finesse: { value: 1 }, mind: { value: 1 },
+                presence: { value: 1 }, soul: { value: 1 }
+            };
+        }
+
+        // Ensure defenses exist
+        if (!data.defenses) {
+            data.defenses = {
+                resilience: 0, avoid: 0, grit: 0,
+                resilienceBonus: 0, avoidBonus: 0, gritBonus: 0,
+                passiveDodge: 0, passiveParry: 0, facing: "front", avoidPenalty: 0
+            };
+        }
+        if (data.defenses.avoidPenalty === undefined) data.defenses.avoidPenalty = 0;
+
+        // Ensure conditions are initialized
+        const SEVERITY_CONDITIONS = ["bleed", "dazed", "fatigue", "fear", "illness", "pain", "paralysis", "staggered", "stunned"];
+        const BINARY_CONDITIONS = ["blindness", "confusion", "deafness", "flatFooted", "sleep"];
+        if (!data.conditions) data.conditions = {};
+        for (const key of SEVERITY_CONDITIONS) {
+            if (!data.conditions[key]) data.conditions[key] = { active: false, intensity: "trivial" };
+        }
+        for (const key of BINARY_CONDITIONS) {
+            if (!data.conditions[key]) data.conditions[key] = { active: false };
+        }
+
+        if (!["none","dodgeStance","parryingStance","brace","toughItOut","resoluteWill"].includes(data.activeStance)) {
+            data.activeStance = "none";
+        }
+
+        // Calculate defenses from attributes
+        const phy = data.attributes.physique?.value || 1;
+        const fin = data.attributes.finesse?.value || 1;
+        const mnd = data.attributes.mind?.value || 1;
+        data.defenses.resilience = Math.max(1, Math.floor(phy / 2));
+        data.defenses.avoid = Math.max(1, Math.floor(fin / 2));
+        data.defenses.grit = Math.max(1, Math.floor(mnd / 2));
+        data.totalResilience = Math.max(1, data.defenses.resilience + (Number(data.defenses.resilienceBonus) || 0));
+        data.totalAvoid = Math.max(1, data.defenses.avoid + (Number(data.defenses.avoidBonus) || 0));
+        data.totalGrit = Math.max(1, data.defenses.grit + (Number(data.defenses.gritBonus) || 0));
+
+        // No Acrobatics/weapon skill lookup for NPCs
+        data.defenses.basePassiveDodge = 0;
+        data.defenses.passiveDodge = 0;
+        data.defenses.basePassiveParry = 0;
+        data.defenses.passiveParry = 0;
+        data.defenses.acrobaticsDodgeDice = 0;
+
+        applyBaseDefenseStances(data);
+        this._applyFacingModifiers(data);
+        this._applyConditionState(data);
+
+        // HP state label (max is stored directly, not calculated)
+        if (!data.hp) data.hp = { value: 10, max: 10 };
+        const hp = data.hp.value ?? 0;
+        const max = Math.max(1, data.hp.max ?? 10);
+        if (hp >= max)          { data.hp.state = "healthy";     data.hp.stateLabel = "Healthy"; }
+        else if (hp > max / 2)  { data.hp.state = "bloodied";    data.hp.stateLabel = "Bloodied"; }
+        else if (hp > 0)        { data.hp.state = "wounded";     data.hp.stateLabel = "Wounded"; }
+        else if (hp === 0)      { data.hp.state = "unconscious"; data.hp.stateLabel = "Unconscious"; }
+        else if (hp > -max * 2) { data.hp.state = "dying";       data.hp.stateLabel = "Dying"; }
+        else                    { data.hp.state = "dead";        data.hp.stateLabel = "Dead"; }
     }
 
     /**

--- a/src/npc-sheet.js
+++ b/src/npc-sheet.js
@@ -1,0 +1,120 @@
+// TheFadeNPCSheet — simplified actor sheet for monsters and named NPCs.
+import { SIZE_OPTIONS } from './constants.js';
+
+export class TheFadeNPCSheet extends ActorSheet {
+    static get defaultOptions() {
+        return foundry.utils.mergeObject(super.defaultOptions, {
+            classes: ["thefade", "sheet", "actor", "npc"],
+            template: "systems/thefade/templates/actor/npc-sheet.html",
+            width: 680,
+            height: 680,
+            tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "main" }],
+            scrollY: [".sheet-body"]
+        });
+    }
+
+    getData() {
+        const data = super.getData();
+        data.system = data.actor.system;
+        data.sizeOptions = SIZE_OPTIONS;
+
+        // Categorize embedded items
+        const items = data.items || [];
+        data.weapons = items.filter(i => i.type === "weapon");
+        data.armor   = items.filter(i => i.type === "armor");
+        data.gear    = items.filter(i => !["weapon","armor","skill","path","spell","talent","species","trait","precept"].includes(i.type));
+
+        // Calculate attack dice for each weapon (attribute / 2, untrained)
+        const attrs = data.system.attributes || {};
+        for (const w of data.weapons) {
+            const attr = w.system?.attribute || "physique";
+            const attrVal = attrs[attr]?.value || 1;
+            w.calculatedDice = Math.max(1, Math.floor(attrVal / 2) + (w.system?.miscBonus || 0));
+            const abbr = { physique:"PHY", finesse:"FIN", mind:"MND", presence:"PRS", soul:"SOL" };
+            w.attributeAbbr = abbr[attr] || "PHY";
+        }
+
+        return data;
+    }
+
+    activateListeners(html) {
+        super.activateListeners(html);
+        if (!this.options.editable) return;
+
+        // Initiative roll
+        html.find(".initiative-roll").click(async () => {
+            const fin = this.actor.system.attributes?.finesse?.value || 0;
+            const mnd = this.actor.system.attributes?.mind?.value || 0;
+            const bonus = Math.floor((fin + mnd) / 2) + (this.actor.system.initiativeBonus || 0);
+            const roll = await new Roll(`1d12 + ${bonus}`).evaluate();
+            roll.toMessage({
+                speaker: ChatMessage.getSpeaker({ actor: this.actor }),
+                flavor: `${this.actor.name} rolls Initiative!`
+            });
+        });
+
+        // Attack roll from weapon row
+        html.find(".attack-roll").click(async ev => {
+            const li = $(ev.currentTarget).closest("[data-item-id]");
+            const item = this.actor.items.get(li.data("item-id"));
+            if (!item) return;
+            const dice = item.calculatedDice ?? 1;
+            const roll = await new Roll(`${dice}d12`).evaluate();
+            roll.toMessage({
+                speaker: ChatMessage.getSpeaker({ actor: this.actor }),
+                flavor: `${this.actor.name} attacks with ${item.name} (${dice}d12)`
+            });
+        });
+
+        // Clear all conditions + stance
+        html.find(".combat-state-clear").click(async () => {
+            const conditions = this.actor.system?.conditions || {};
+            const update = { "system.activeStance": "none" };
+            for (const key of Object.keys(conditions)) {
+                update[`system.conditions.${key}.active`] = false;
+            }
+            await this.actor.update(update);
+        });
+
+        // Item create
+        html.find(".item-create").click(ev => {
+            ev.preventDefault();
+            const type = ev.currentTarget.dataset.type || "item";
+            this.actor.createEmbeddedDocuments("Item", [{
+                name: `New ${type.charAt(0).toUpperCase() + type.slice(1)}`,
+                type
+            }]);
+        });
+
+        // Item edit
+        html.find(".item-edit").click(ev => {
+            const li = $(ev.currentTarget).closest("[data-item-id]");
+            const item = this.actor.items.get(li.data("item-id"));
+            item?.sheet.render(true);
+        });
+
+        // Item delete
+        html.find(".item-delete").click(ev => {
+            const li = $(ev.currentTarget).closest("[data-item-id]");
+            const item = this.actor.items.get(li.data("item-id"));
+            if (!item) return;
+            new Dialog({
+                title: `Delete ${item.name}`,
+                content: `<p>Delete <strong>${item.name}</strong>?</p>`,
+                buttons: {
+                    yes: { label: "Delete", icon: '<i class="fas fa-trash"></i>', callback: () => item.delete() },
+                    no:  { label: "Cancel" }
+                },
+                default: "no"
+            }).render(true);
+        });
+
+        // Armor reset (current AP back to max)
+        html.find(".armor-reset").click(async ev => {
+            const li = $(ev.currentTarget).closest("[data-item-id]");
+            const item = this.actor.items.get(li.data("item-id"));
+            if (!item) return;
+            await item.update({ "system.currentAP": item.system.ap });
+        });
+    }
+}

--- a/src/party-sheet.js
+++ b/src/party-sheet.js
@@ -1,0 +1,243 @@
+// TheFadePartySheet — party management sheet for XP, currency, and shared items.
+
+export class TheFadePartySheet extends ActorSheet {
+    static get defaultOptions() {
+        return foundry.utils.mergeObject(super.defaultOptions, {
+            classes: ["thefade", "sheet", "actor", "party"],
+            template: "systems/thefade/templates/actor/party-sheet.html",
+            width: 620,
+            height: 600,
+            tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "members" }],
+            scrollY: [".sheet-body"]
+        });
+    }
+
+    getData() {
+        const data = super.getData();
+        data.system = data.actor.system;
+
+        // Resolve member actor references from stored IDs
+        const memberIds = Array.isArray(data.system.members) ? data.system.members : [];
+        data.resolvedMembers = memberIds
+            .map(id => game.actors?.get(id))
+            .filter(a => a != null)
+            .map(a => ({
+                id: a.id,
+                name: a.name,
+                img: a.img,
+                hpValue: a.system.hp?.value ?? 0,
+                hpMax: a.system.hp?.max ?? 0,
+                level: a.system.level ?? 1,
+                xp: a.system.experience ?? 0
+            }));
+
+        // Shared items on the party actor
+        data.sharedItems = (data.items || []).filter(i =>
+            !["skill","path","talent","species","trait","precept"].includes(i.type)
+        );
+
+        return data;
+    }
+
+    activateListeners(html) {
+        super.activateListeners(html);
+        if (!this.options.editable) return;
+
+        // Add member
+        html.find(".add-member").click(() => this._onAddMember());
+
+        // Remove member
+        html.find(".member-remove").click(async ev => {
+            const actorId = ev.currentTarget.dataset.actorId;
+            const current = Array.isArray(this.actor.system.members) ? [...this.actor.system.members] : [];
+            await this.actor.update({ "system.members": current.filter(id => id !== actorId) });
+        });
+
+        // Give XP to all members
+        html.find(".give-xp").click(() => this._onGiveXP());
+
+        // Give serpents to each member
+        html.find(".give-currency").click(() => this._onGiveCurrency());
+
+        // Divide party pool evenly among members
+        html.find(".divide-pool").click(() => this._onDividePool());
+
+        // Shared item create
+        html.find(".item-create").click(ev => {
+            ev.preventDefault();
+            const type = ev.currentTarget.dataset.type || "item";
+            this.actor.createEmbeddedDocuments("Item", [{
+                name: `New ${type.charAt(0).toUpperCase() + type.slice(1)}`,
+                type
+            }]);
+        });
+
+        // Shared item edit
+        html.find(".item-edit").click(ev => {
+            const li = $(ev.currentTarget).closest("[data-item-id]");
+            this.actor.items.get(li.data("item-id"))?.sheet.render(true);
+        });
+
+        // Shared item delete
+        html.find(".item-delete").click(ev => {
+            const li = $(ev.currentTarget).closest("[data-item-id]");
+            const item = this.actor.items.get(li.data("item-id"));
+            if (!item) return;
+            new Dialog({
+                title: `Delete ${item.name}`,
+                content: `<p>Delete <strong>${item.name}</strong> from the party stash?</p>`,
+                buttons: {
+                    yes: { label: "Delete", icon: '<i class="fas fa-trash"></i>', callback: () => item.delete() },
+                    no:  { label: "Cancel" }
+                },
+                default: "no"
+            }).render(true);
+        });
+    }
+
+    async _onAddMember() {
+        const characters = (game.actors?.contents || []).filter(a => a.type === "character");
+        if (!characters.length) {
+            ui.notifications.warn("No character actors found in the world.");
+            return;
+        }
+
+        const current = Array.isArray(this.actor.system.members) ? this.actor.system.members : [];
+        const options = characters
+            .map(a => `<option value="${a.id}" ${current.includes(a.id) ? "disabled" : ""}>${a.name}${current.includes(a.id) ? " (already added)" : ""}</option>`)
+            .join("");
+
+        new Dialog({
+            title: "Add Party Member",
+            content: `<div style="padding:8px 0"><label>Choose a character:</label><select id="member-select" style="width:100%;margin-top:4px">${options}</select></div>`,
+            buttons: {
+                add: {
+                    label: "Add",
+                    icon: '<i class="fas fa-user-plus"></i>',
+                    callback: async html => {
+                        const id = html.find("#member-select").val();
+                        if (!id || current.includes(id)) return;
+                        await this.actor.update({ "system.members": [...current, id] });
+                    }
+                },
+                cancel: { label: "Cancel" }
+            },
+            default: "add"
+        }).render(true);
+    }
+
+    async _onGiveXP() {
+        const memberIds = Array.isArray(this.actor.system.members) ? this.actor.system.members : [];
+        const members = memberIds.map(id => game.actors?.get(id)).filter(a => a?.type === "character");
+        if (!members.length) {
+            ui.notifications.warn("No party members to give XP to.");
+            return;
+        }
+
+        new Dialog({
+            title: "Give XP to Party",
+            content: `
+                <div style="padding:8px 0">
+                    <p>Give XP to all <strong>${members.length}</strong> party member(s).</p>
+                    <label>XP amount:</label>
+                    <input id="xp-amount" type="number" value="100" min="0" style="width:100%;margin-top:4px" />
+                </div>`,
+            buttons: {
+                give: {
+                    label: "Give XP",
+                    icon: '<i class="fas fa-star"></i>',
+                    callback: async html => {
+                        const amount = Number(html.find("#xp-amount").val()) || 0;
+                        if (amount <= 0) return;
+                        for (const actor of members) {
+                            const currentXP = actor.system.experience ?? 0;
+                            await actor.update({ "system.experience": currentXP + amount });
+                        }
+                        ui.notifications.info(`Gave ${amount} XP to ${members.length} party member(s).`);
+                    }
+                },
+                cancel: { label: "Cancel" }
+            },
+            default: "give"
+        }).render(true);
+    }
+
+    async _onGiveCurrency() {
+        const memberIds = Array.isArray(this.actor.system.members) ? this.actor.system.members : [];
+        const members = memberIds.map(id => game.actors?.get(id)).filter(a => a?.type === "character");
+        if (!members.length) {
+            ui.notifications.warn("No party members to give currency to.");
+            return;
+        }
+
+        new Dialog({
+            title: "Give Serpents to Each Member",
+            content: `
+                <div style="padding:8px 0">
+                    <p>Give <em>each</em> of the <strong>${members.length}</strong> party member(s) this many serpents.</p>
+                    <label>Serpents per member:</label>
+                    <input id="currency-amount" type="number" value="0" min="0" style="width:100%;margin-top:4px" />
+                </div>`,
+            buttons: {
+                give: {
+                    label: "Give",
+                    icon: '<i class="fas fa-coins"></i>',
+                    callback: async html => {
+                        const amount = Number(html.find("#currency-amount").val()) || 0;
+                        if (amount <= 0) return;
+                        for (const actor of members) {
+                            const current = actor.system.currency?.serpents ?? 0;
+                            await actor.update({ "system.currency.serpents": current + amount });
+                        }
+                        ui.notifications.info(`Gave ${amount} serpents to each of ${members.length} member(s).`);
+                    }
+                },
+                cancel: { label: "Cancel" }
+            },
+            default: "give"
+        }).render(true);
+    }
+
+    async _onDividePool() {
+        const memberIds = Array.isArray(this.actor.system.members) ? this.actor.system.members : [];
+        const members = memberIds.map(id => game.actors?.get(id)).filter(a => a?.type === "character");
+        if (!members.length) {
+            ui.notifications.warn("No party members to distribute currency to.");
+            return;
+        }
+
+        const partyPool = this.actor.system.currency?.serpents ?? 0;
+        const share = Math.floor(partyPool / members.length);
+        const remainder = partyPool % members.length;
+
+        new Dialog({
+            title: "Divide Party Pool",
+            content: `
+                <div style="padding:8px 0">
+                    <p>Divide <strong>${partyPool} serpents</strong> among <strong>${members.length}</strong> members.</p>
+                    <p>Each member gets <strong>${share}</strong> serpents. Remainder: ${remainder}.</p>
+                    <p><em>The remainder stays in the party pool.</em></p>
+                </div>`,
+            buttons: {
+                divide: {
+                    label: "Distribute",
+                    icon: '<i class="fas fa-divide"></i>',
+                    callback: async () => {
+                        if (share <= 0) {
+                            ui.notifications.warn("Not enough serpents to distribute.");
+                            return;
+                        }
+                        for (const actor of members) {
+                            const current = actor.system.currency?.serpents ?? 0;
+                            await actor.update({ "system.currency.serpents": current + share });
+                        }
+                        await this.actor.update({ "system.currency.serpents": remainder });
+                        ui.notifications.info(`Distributed ${share} serpents to each of ${members.length} member(s). ${remainder} remain in the party pool.`);
+                    }
+                },
+                cancel: { label: "Cancel" }
+            },
+            default: "divide"
+        }).render(true);
+    }
+}

--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -8336,3 +8336,268 @@ select[name="system.aura.color"] option[value="white"] {
     font-size: 0.85em;
     font-style: italic;
 }
+
+
+/* ===== NPC SHEET ===== */
+.thefade.npc .npc-meta input,
+.thefade.npc .npc-meta select {
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--border-faint);
+  color: var(--text-muted);
+  font-size: 0.85em;
+  padding: 1px 4px;
+}
+.thefade.npc .npc-meta input:focus,
+.thefade.npc .npc-meta select:focus {
+  border-bottom-color: var(--accent-crimson);
+  outline: none;
+  color: var(--text-primary);
+}
+
+.thefade.npc .npc-defenses-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+.thefade.npc .npc-defense {
+  flex: 1;
+  min-width: 100px;
+  text-align: center;
+  padding: 8px;
+}
+.thefade.npc .npc-defense label {
+  font-size: 0.75em;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  display: block;
+  margin-bottom: 2px;
+}
+.thefade.npc .npc-defense-total {
+  font-size: 1.6em;
+  font-weight: bold;
+  color: var(--accent-gold);
+  line-height: 1;
+}
+.thefade.npc .npc-defense-detail {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  margin-top: 4px;
+  font-size: 0.75em;
+  color: var(--text-muted);
+}
+.thefade.npc .npc-defense-detail .small-input {
+  width: 36px;
+  text-align: center;
+  font-size: 1em;
+  padding: 1px 2px;
+}
+.thefade.npc .npc-defense select {
+  width: 100%;
+  font-size: 0.8em;
+  margin-top: 4px;
+}
+
+.thefade.npc .npc-movement {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+.thefade.npc .move-entry {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+.thefade.npc .move-entry label {
+  font-size: 0.72em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.thefade.npc .move-entry input {
+  width: 44px;
+  text-align: center;
+}
+
+.thefade.npc .npc-item-section {
+  margin-bottom: 16px;
+}
+.thefade.npc .npc-item-header,
+.thefade.party .npc-item-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--border-faint);
+  margin-bottom: 6px;
+  padding-bottom: 4px;
+}
+.thefade.npc .npc-item-header h2,
+.thefade.party .npc-item-header h2 {
+  margin: 0;
+  font-size: 1em;
+}
+.thefade.npc .npc-weapon-table,
+.thefade.npc .npc-armor-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85em;
+}
+.thefade.npc .npc-weapon-table th,
+.thefade.npc .npc-armor-table th {
+  text-align: left;
+  font-size: 0.72em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  padding: 2px 4px;
+  border-bottom: 1px solid var(--border-faint);
+}
+.thefade.npc .npc-weapon-table td,
+.thefade.npc .npc-armor-table td {
+  padding: 3px 4px;
+  border-bottom: 1px solid var(--border-faint);
+  vertical-align: middle;
+}
+.thefade.npc .npc-weapon-table .item-controls,
+.thefade.npc .npc-armor-table .item-controls {
+  white-space: nowrap;
+  text-align: right;
+}
+.thefade.npc .npc-weapon-table .item-icon,
+.thefade.npc .npc-armor-table .item-icon {
+  width: 20px;
+  height: 20px;
+  border: none;
+}
+
+/* ===== PARTY SHEET ===== */
+.thefade.party .party-members-section {
+  padding: 4px 0;
+}
+.thefade.party .party-member-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.thefade.party .party-member {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+}
+.thefade.party .member-portrait {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 2px solid var(--border-faint);
+  object-fit: cover;
+  flex-shrink: 0;
+}
+.thefade.party .member-info {
+  flex: 1;
+}
+.thefade.party .member-name {
+  font-weight: bold;
+  font-size: 1em;
+  display: block;
+  margin-bottom: 2px;
+}
+.thefade.party .member-stats {
+  display: flex;
+  gap: 12px;
+  font-size: 0.8em;
+  color: var(--text-muted);
+}
+.thefade.party .member-stat i {
+  margin-right: 3px;
+  color: var(--accent-gold);
+}
+.thefade.party .member-remove {
+  background: transparent;
+  border: 1px solid var(--border-faint);
+  color: var(--text-muted);
+  border-radius: 50%;
+  width: 22px;
+  height: 22px;
+  cursor: pointer;
+  font-size: 0.8em;
+  line-height: 1;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.thefade.party .member-remove:hover {
+  border-color: var(--accent-crimson);
+  color: var(--accent-hot);
+}
+.thefade.party .add-member {
+  margin-top: 10px;
+  width: 100%;
+}
+.thefade.party .party-resource-section {
+  padding: 12px;
+  margin-bottom: 12px;
+}
+.thefade.party .party-resource-section h2 {
+  font-size: 1em;
+  margin: 0 0 8px 0;
+  border-bottom: 1px solid var(--border-faint);
+  padding-bottom: 4px;
+}
+.thefade.party .party-currency-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  font-size: 0.9em;
+}
+.thefade.party .party-currency-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.thefade.party .party-currency-actions button,
+.thefade.party .give-xp {
+  flex: 1;
+  min-width: 140px;
+  font-size: 0.85em;
+}
+.thefade.party .resource-hint {
+  font-size: 0.8em;
+  color: var(--text-muted);
+  margin: 0 0 8px 0;
+  font-style: italic;
+}
+
+/* Shared empty-list style */
+.thefade .empty-list {
+  font-size: 0.82em;
+  color: var(--text-dim);
+  font-style: italic;
+  padding: 6px 4px;
+}
+.thefade .notes-section textarea {
+  width: 100%;
+  background: var(--bg-surface-alt);
+  color: var(--text-primary);
+  border: 1px solid var(--border-faint);
+  border-radius: 4px;
+  padding: 8px;
+  font-family: inherit;
+  font-size: 0.88em;
+  resize: vertical;
+  box-sizing: border-box;
+}
+.thefade .muted {
+  color: var(--text-muted);
+  font-size: 0.82em;
+}

--- a/template.json
+++ b/template.json
@@ -1,6 +1,6 @@
 {
   "Actor": {
-    "types": [ "character" ],
+    "types": [ "character", "npc", "party" ],
     "templates": {
       "base": {
         "hp": {
@@ -163,6 +163,43 @@
         "reputation": "",
         "fightingStyle": ""
       }
+    },
+    "npc": {
+      "templates": ["base"],
+      "hp": { "value": 10, "max": 10 },
+      "defenses": {
+        "resilience": 0, "avoid": 0, "grit": 0,
+        "resilienceBonus": 0, "avoidBonus": 0, "gritBonus": 0,
+        "passiveDodge": 0, "passiveParry": 0, "facing": "front"
+      },
+      "movement": { "land": 4, "fly": 0, "swim": 0, "climb": 0, "burrow": 0 },
+      "conditions": {
+        "bleed":      { "active": false, "intensity": "trivial" },
+        "blindness":  { "active": false },
+        "confusion":  { "active": false },
+        "dazed":      { "active": false, "intensity": "trivial" },
+        "deafness":   { "active": false },
+        "fatigue":    { "active": false, "intensity": "trivial" },
+        "fear":       { "active": false, "intensity": "trivial" },
+        "flatFooted": { "active": false },
+        "illness":    { "active": false, "intensity": "trivial" },
+        "pain":       { "active": false, "intensity": "trivial" },
+        "paralysis":  { "active": false, "intensity": "trivial" },
+        "sleep":      { "active": false },
+        "staggered":  { "active": false, "intensity": "trivial" },
+        "stunned":    { "active": false, "intensity": "trivial" }
+      },
+      "activeStance": "none",
+      "creatureType": "humanoid",
+      "creatureSubtype": "",
+      "size": "medium",
+      "initiativeBonus": 0,
+      "notes": ""
+    },
+    "party": {
+      "currency": { "serpents": 0 },
+      "members": [],
+      "notes": ""
     }
   },
   "Item": {

--- a/templates/actor/npc-sheet.html
+++ b/templates/actor/npc-sheet.html
@@ -1,0 +1,268 @@
+<form class="{{cssClass}} flexcol" autocomplete="off">
+    <!-- ===================== HEADER ===================== -->
+    <header class="sheet-header redesigned-header">
+        <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" />
+
+        <div class="header-fields">
+            <div class="char-identity">
+                <h1 class="charname">
+                    <input name="name" type="text" value="{{actor.name}}" placeholder="NPC Name" />
+                </h1>
+                <div class="char-subtitle npc-meta">
+                    <input type="text" name="system.creatureType" value="{{system.creatureType}}" placeholder="Creature Type" style="width:110px" />
+                    <span class="sep">·</span>
+                    <input type="text" name="system.creatureSubtype" value="{{system.creatureSubtype}}" placeholder="Subtype" style="width:90px" />
+                    <span class="sep">·</span>
+                    <select name="system.size">
+                        {{#each sizeOptions as |label key|}}
+                        <option value="{{key}}" {{#if (eq ../system.size key)}}selected{{/if}}>{{label}}</option>
+                        {{/each}}
+                    </select>
+                </div>
+            </div>
+
+            <div class="vitals-strip">
+                <div class="vital-pill vital-hp">
+                    <label>HP</label>
+                    <div class="vital-values">
+                        <input type="text" name="system.hp.value" value="{{system.hp.value}}" data-dtype="Number" />
+                        <span class="sep">/</span>
+                        <input type="text" name="system.hp.max" value="{{system.hp.max}}" data-dtype="Number" />
+                    </div>
+                    {{#if system.hp.stateLabel}}
+                    <span class="hp-state hp-{{system.hp.state}}" title="{{system.hp.stateLabel}}">{{system.hp.stateLabel}}</span>
+                    {{/if}}
+                </div>
+
+                <div class="vital-pill vital-init">
+                    <label>Initiative</label>
+                    <button type="button" class="initiative-roll"><i class="fas fa-dice-d20"></i> Roll</button>
+                    <input type="text" name="system.initiativeBonus" value="{{system.initiativeBonus}}" data-dtype="Number" title="Misc Initiative Bonus" class="vital-bonus" placeholder="+0" />
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <!-- ===================== TABS ===================== -->
+    <nav class="sheet-tabs tabs" data-group="primary">
+        <a class="item" data-tab="main">Stats</a>
+        <a class="item" data-tab="items">Items</a>
+        <a class="item" data-tab="notes">Notes</a>
+    </nav>
+
+    <!-- ===================== BODY ===================== -->
+    <section class="sheet-body">
+
+        <!-- ===== STATS TAB ===== -->
+        <div class="tab" data-group="primary" data-tab="main">
+
+            <!-- Attributes -->
+            <h2>Attributes</h2>
+            <div class="grid grid-5col">
+                <div class="attribute panel">
+                    <label>Physique</label>
+                    <div class="attribute-value">
+                        <input type="text" name="system.attributes.physique.value" value="{{system.attributes.physique.value}}" data-dtype="Number" />
+                    </div>
+                </div>
+                <div class="attribute panel">
+                    <label>Finesse</label>
+                    <div class="attribute-value">
+                        <input type="text" name="system.attributes.finesse.value" value="{{system.attributes.finesse.value}}" data-dtype="Number" />
+                    </div>
+                </div>
+                <div class="attribute panel">
+                    <label>Mind</label>
+                    <div class="attribute-value">
+                        <input type="text" name="system.attributes.mind.value" value="{{system.attributes.mind.value}}" data-dtype="Number" />
+                    </div>
+                </div>
+                <div class="attribute panel">
+                    <label>Presence</label>
+                    <div class="attribute-value">
+                        <input type="text" name="system.attributes.presence.value" value="{{system.attributes.presence.value}}" data-dtype="Number" />
+                    </div>
+                </div>
+                <div class="attribute panel">
+                    <label>Soul</label>
+                    <div class="attribute-value">
+                        <input type="text" name="system.attributes.soul.value" value="{{system.attributes.soul.value}}" data-dtype="Number" />
+                    </div>
+                </div>
+            </div>
+
+            <!-- Defenses -->
+            <h2>Defenses</h2>
+            <div class="npc-defenses-row">
+                <div class="npc-defense panel">
+                    <label>Resilience</label>
+                    <div class="npc-defense-total">{{system.totalResilience}}</div>
+                    <div class="npc-defense-detail">
+                        <span>Base {{system.defenses.resilience}}</span>
+                        <input type="text" name="system.defenses.resilienceBonus" value="{{system.defenses.resilienceBonus}}" data-dtype="Number" placeholder="+0" title="Bonus" class="small-input" />
+                    </div>
+                </div>
+                <div class="npc-defense panel">
+                    <label>Avoid</label>
+                    <div class="npc-defense-total">{{system.totalAvoid}}</div>
+                    <div class="npc-defense-detail">
+                        <span>Base {{system.defenses.avoid}}</span>
+                        <input type="text" name="system.defenses.avoidBonus" value="{{system.defenses.avoidBonus}}" data-dtype="Number" placeholder="+0" title="Bonus" class="small-input" />
+                    </div>
+                </div>
+                <div class="npc-defense panel">
+                    <label>Grit</label>
+                    <div class="npc-defense-total">{{system.totalGrit}}</div>
+                    <div class="npc-defense-detail">
+                        <span>Base {{system.defenses.grit}}</span>
+                        <input type="text" name="system.defenses.gritBonus" value="{{system.defenses.gritBonus}}" data-dtype="Number" placeholder="+0" title="Bonus" class="small-input" />
+                    </div>
+                </div>
+                <div class="npc-defense panel">
+                    <label>Facing</label>
+                    <select name="system.defenses.facing" class="facing-select">
+                        <option value="front"     {{#if (eq system.defenses.facing "front")}}selected{{/if}}>Front</option>
+                        <option value="flank"     {{#if (eq system.defenses.facing "flank")}}selected{{/if}}>Flank (−1 Avoid)</option>
+                        <option value="backflank" {{#if (eq system.defenses.facing "backflank")}}selected{{/if}}>Back Flank (−2 Avoid)</option>
+                        <option value="back"      {{#if (eq system.defenses.facing "back")}}selected{{/if}}>Back (−2 Avoid)</option>
+                    </select>
+                </div>
+            </div>
+
+            <!-- Movement -->
+            <h2>Movement</h2>
+            <div class="movement-grid npc-movement">
+                <div class="move-entry"><label>Land</label><input type="text" name="system.movement.land" value="{{system.movement.land}}" data-dtype="Number" /></div>
+                <div class="move-entry"><label>Fly</label><input type="text" name="system.movement.fly" value="{{system.movement.fly}}" data-dtype="Number" /></div>
+                <div class="move-entry"><label>Swim</label><input type="text" name="system.movement.swim" value="{{system.movement.swim}}" data-dtype="Number" /></div>
+                <div class="move-entry"><label>Climb</label><input type="text" name="system.movement.climb" value="{{system.movement.climb}}" data-dtype="Number" /></div>
+                <div class="move-entry"><label>Burrow</label><input type="text" name="system.movement.burrow" value="{{system.movement.burrow}}" data-dtype="Number" /></div>
+            </div>
+
+            <!-- Combat State (conditions + stance) -->
+            {{> "systems/thefade/templates/actor/parts/combat-state.html"}}
+
+        </div><!-- /main tab -->
+
+        <!-- ===== ITEMS TAB ===== -->
+        <div class="tab" data-group="primary" data-tab="items">
+
+            <!-- Weapons -->
+            <div class="npc-item-section">
+                <header class="npc-item-header">
+                    <h2>Weapons</h2>
+                    <a class="item-create" data-type="weapon" title="Add Weapon"><i class="fas fa-plus"></i></a>
+                </header>
+                {{#if weapons.length}}
+                <table class="npc-weapon-table">
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>Name</th>
+                            <th>Skill</th>
+                            <th>Dice</th>
+                            <th>Dmg</th>
+                            <th>Crit</th>
+                            <th>Range</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {{#each weapons as |w|}}
+                        <tr class="item" data-item-id="{{w._id}}">
+                            <td><img src="{{w.img}}" class="item-icon" alt="{{w.name}}" /></td>
+                            <td>{{w.name}}</td>
+                            <td>{{w.system.skill}}</td>
+                            <td>{{w.calculatedDice}}d12</td>
+                            <td>{{w.system.damage}} {{w.system.damageType}}</td>
+                            <td>{{w.system.critical}}</td>
+                            <td>{{w.system.range}}</td>
+                            <td class="item-controls">
+                                <a class="attack-roll" title="Roll Attack"><i class="fas fa-dice-d12"></i></a>
+                                <a class="item-edit" title="Edit"><i class="fas fa-edit"></i></a>
+                                <a class="item-delete" title="Delete"><i class="fas fa-trash"></i></a>
+                            </td>
+                        </tr>
+                        {{/each}}
+                    </tbody>
+                </table>
+                {{else}}
+                <p class="empty-list">No weapons.</p>
+                {{/if}}
+            </div>
+
+            <!-- Armor -->
+            <div class="npc-item-section">
+                <header class="npc-item-header">
+                    <h2>Armor</h2>
+                    <a class="item-create" data-type="armor" title="Add Armor"><i class="fas fa-plus"></i></a>
+                </header>
+                {{#if armor.length}}
+                <table class="npc-armor-table">
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>Name</th>
+                            <th>Location</th>
+                            <th>AP</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {{#each armor as |a|}}
+                        <tr class="item" data-item-id="{{a._id}}">
+                            <td><img src="{{a.img}}" class="item-icon" alt="{{a.name}}" /></td>
+                            <td>{{a.name}}</td>
+                            <td>{{a.system.location}}</td>
+                            <td>{{numberOr a.system.currentAP 0}}/{{a.system.ap}}</td>
+                            <td class="item-controls">
+                                <a class="armor-reset" title="Reset AP"><i class="fas fa-sync-alt"></i></a>
+                                <a class="item-edit" title="Edit"><i class="fas fa-edit"></i></a>
+                                <a class="item-delete" title="Delete"><i class="fas fa-trash"></i></a>
+                            </td>
+                        </tr>
+                        {{/each}}
+                    </tbody>
+                </table>
+                {{else}}
+                <p class="empty-list">No armor.</p>
+                {{/if}}
+            </div>
+
+            <!-- Other gear -->
+            <div class="npc-item-section">
+                <header class="npc-item-header">
+                    <h2>Other Items</h2>
+                    <a class="item-create" data-type="item" title="Add Item"><i class="fas fa-plus"></i></a>
+                </header>
+                {{#if gear.length}}
+                <ol class="items-list">
+                    {{#each gear as |g|}}
+                    <li class="item flexrow" data-item-id="{{g._id}}">
+                        <img src="{{g.img}}" class="item-icon" alt="{{g.name}}" />
+                        <span class="item-name">{{g.name}}</span>
+                        <span class="item-type muted">{{g.type}}</span>
+                        <div class="item-controls">
+                            <a class="item-edit" title="Edit"><i class="fas fa-edit"></i></a>
+                            <a class="item-delete" title="Delete"><i class="fas fa-trash"></i></a>
+                        </div>
+                    </li>
+                    {{/each}}
+                </ol>
+                {{else}}
+                <p class="empty-list">No other items.</p>
+                {{/if}}
+            </div>
+
+        </div><!-- /items tab -->
+
+        <!-- ===== NOTES TAB ===== -->
+        <div class="tab" data-group="primary" data-tab="notes">
+            <div class="notes-section">
+                <h2>Notes</h2>
+                <textarea name="system.notes" rows="20" placeholder="NPC description, tactics, special abilities…">{{system.notes}}</textarea>
+            </div>
+        </div>
+
+    </section><!-- /sheet-body -->
+</form>

--- a/templates/actor/party-sheet.html
+++ b/templates/actor/party-sheet.html
@@ -1,0 +1,143 @@
+<form class="{{cssClass}} flexcol" autocomplete="off">
+    <!-- ===================== HEADER ===================== -->
+    <header class="sheet-header redesigned-header">
+        <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" />
+        <div class="header-fields">
+            <div class="char-identity">
+                <h1 class="charname">
+                    <input name="name" type="text" value="{{actor.name}}" placeholder="Party Name" />
+                </h1>
+                <div class="char-subtitle">
+                    <span>{{resolvedMembers.length}} member(s)</span>
+                    <span class="sep">·</span>
+                    <span>{{system.currency.serpents}} serpents in pool</span>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <!-- ===================== TABS ===================== -->
+    <nav class="sheet-tabs tabs" data-group="primary">
+        <a class="item" data-tab="members">Members</a>
+        <a class="item" data-tab="resources">Resources</a>
+        <a class="item" data-tab="inventory">Stash</a>
+        <a class="item" data-tab="notes">Notes</a>
+    </nav>
+
+    <!-- ===================== BODY ===================== -->
+    <section class="sheet-body">
+
+        <!-- ===== MEMBERS TAB ===== -->
+        <div class="tab" data-group="primary" data-tab="members">
+            <div class="party-members-section">
+                <header class="npc-item-header">
+                    <h2>Party Members</h2>
+                    <button type="button" class="add-member" title="Add a character to the party">
+                        <i class="fas fa-user-plus"></i> Add Member
+                    </button>
+                </header>
+
+                {{#if resolvedMembers.length}}
+                <ol class="party-member-list">
+                    {{#each resolvedMembers as |m|}}
+                    <li class="party-member panel">
+                        <img src="{{m.img}}" class="member-portrait" alt="{{m.name}}" />
+                        <div class="member-info">
+                            <span class="member-name">{{m.name}}</span>
+                            <div class="member-stats">
+                                <span class="member-stat" title="Hit Points">
+                                    <i class="fas fa-heart"></i> {{m.hpValue}}/{{m.hpMax}}
+                                </span>
+                                <span class="member-stat" title="Level">
+                                    <i class="fas fa-shield-alt"></i> Lv {{m.level}}
+                                </span>
+                                <span class="member-stat" title="Experience">
+                                    <i class="fas fa-star"></i> {{m.xp}} XP
+                                </span>
+                            </div>
+                        </div>
+                        <button type="button" class="member-remove" data-actor-id="{{m.id}}" title="Remove from party">
+                            <i class="fas fa-times"></i>
+                        </button>
+                    </li>
+                    {{/each}}
+                </ol>
+                {{else}}
+                <p class="empty-list">No party members yet. Click <em>Add Member</em> to link characters.</p>
+                {{/if}}
+            </div>
+        </div><!-- /members tab -->
+
+        <!-- ===== RESOURCES TAB ===== -->
+        <div class="tab" data-group="primary" data-tab="resources">
+
+            <!-- Party Treasury -->
+            <div class="party-resource-section panel">
+                <h2><i class="fas fa-coins"></i> Party Treasury</h2>
+                <div class="party-currency-row">
+                    <label>Serpents (sp)</label>
+                    <input type="text" name="system.currency.serpents" value="{{system.currency.serpents}}" data-dtype="Number" style="width:100px" />
+                </div>
+                <div class="party-currency-actions">
+                    <button type="button" class="divide-pool" title="Divide this pool evenly among all members">
+                        <i class="fas fa-divide"></i> Divide Pool Among Members
+                    </button>
+                    <button type="button" class="give-currency" title="Give each member a set amount from their own wealth">
+                        <i class="fas fa-coins"></i> Give Serpents to Each Member
+                    </button>
+                </div>
+            </div>
+
+            <!-- XP Distribution -->
+            <div class="party-resource-section panel">
+                <h2><i class="fas fa-star"></i> Experience</h2>
+                <p class="resource-hint">Award XP to all linked party members at once.</p>
+                <button type="button" class="give-xp">
+                    <i class="fas fa-star"></i> Give XP to All Members
+                </button>
+            </div>
+
+        </div><!-- /resources tab -->
+
+        <!-- ===== INVENTORY / STASH TAB ===== -->
+        <div class="tab" data-group="primary" data-tab="inventory">
+            <div class="npc-item-section">
+                <header class="npc-item-header">
+                    <h2>Party Stash</h2>
+                    <a class="item-create" data-type="item" title="Add Item"><i class="fas fa-plus"></i></a>
+                </header>
+                <p class="resource-hint">Drag items here to track shared loot, quest items, and group equipment.</p>
+
+                {{#if sharedItems.length}}
+                <ol class="items-list">
+                    {{#each sharedItems as |item|}}
+                    <li class="item flexrow" data-item-id="{{item._id}}">
+                        <img src="{{item.img}}" class="item-icon" alt="{{item.name}}" />
+                        <span class="item-name">{{item.name}}</span>
+                        <span class="item-type muted">{{item.type}}</span>
+                        {{#if item.system.quantity}}
+                        <span class="item-qty muted">×{{item.system.quantity}}</span>
+                        {{/if}}
+                        <div class="item-controls">
+                            <a class="item-edit" title="Edit"><i class="fas fa-edit"></i></a>
+                            <a class="item-delete" title="Remove from stash"><i class="fas fa-trash"></i></a>
+                        </div>
+                    </li>
+                    {{/each}}
+                </ol>
+                {{else}}
+                <p class="empty-list">The stash is empty.</p>
+                {{/if}}
+            </div>
+        </div><!-- /inventory tab -->
+
+        <!-- ===== NOTES TAB ===== -->
+        <div class="tab" data-group="primary" data-tab="notes">
+            <div class="notes-section">
+                <h2>Party Notes</h2>
+                <textarea name="system.notes" rows="20" placeholder="Campaign notes, quest log, shared objectives…">{{system.notes}}</textarea>
+            </div>
+        </div>
+
+    </section><!-- /sheet-body -->
+</form>

--- a/thefade.js
+++ b/thefade.js
@@ -10,6 +10,8 @@ import { TheFadeActor } from './src/actor.js';
 import { TheFadeItem } from './src/item.js';
 import { TheFadeItemSheet } from './src/item-sheet.js';
 import { TheFadeCharacterSheet } from './src/character-sheet.js';
+import { TheFadeNPCSheet } from './src/npc-sheet.js';
+import { TheFadePartySheet } from './src/party-sheet.js';
 import { computePerRoundDamage, CONDITION_EFFECTS } from './src/conditions.js';
 import './src/token-facing.js';
 
@@ -66,7 +68,7 @@ Hooks.on("combatTurn", async (combat, updateData, updateOptions) => {
         const nextTurnIndex = updateData?.turn ?? combat?.turn;
         const combatant = combat?.turns?.[nextTurnIndex];
         const actor = combatant?.actor;
-        if (!actor || actor.type !== "character") return;
+        if (!actor || !["character","npc"].includes(actor.type)) return;
 
         const ticks = computePerRoundDamage(actor.system?.conditions);
         if (!ticks.length) return;
@@ -183,6 +185,18 @@ Hooks.once('init', async function () {
         makeDefault: true
     });
 
+    // Register NPC sheet
+    Actors.registerSheet("thefade", TheFadeNPCSheet, {
+        types: ["npc"],
+        makeDefault: true
+    });
+
+    // Register Party sheet
+    Actors.registerSheet("thefade", TheFadePartySheet, {
+        types: ["party"],
+        makeDefault: true
+    });
+
     // Register The Fade item sheet
     Items.registerSheet("thefade", TheFadeItemSheet, {
         types: [
@@ -200,6 +214,8 @@ Hooks.once('init', async function () {
 
     await loadTemplates([
         "systems/thefade/templates/actor/character-sheet.html",
+        "systems/thefade/templates/actor/npc-sheet.html",
+        "systems/thefade/templates/actor/party-sheet.html",
         "systems/thefade/templates/actor/parts/attributes.html",
         "systems/thefade/templates/actor/parts/skills.html",
         "systems/thefade/templates/actor/parts/inventory.html",
@@ -247,10 +263,11 @@ Hooks.once('init', async function () {
         const actor = combatant.actor;
         if (!actor) return "1d12";
 
-        if (actor.type === "character") {
-            const finesse = actor.system.attributes.finesse?.value || 0;
-            const mind = actor.system.attributes.mind?.value || 0;
-            const modifier = Math.floor((finesse + mind) / 2);
+        if (["character", "npc"].includes(actor.type)) {
+            const finesse = actor.system.attributes?.finesse?.value || 0;
+            const mind = actor.system.attributes?.mind?.value || 0;
+            const bonus = (actor.system.initiativeBonus || 0);
+            const modifier = Math.floor((finesse + mind) / 2) + bonus;
             return `1d12 + ${modifier}`;
         }
 


### PR DESCRIPTION
## Summary

- **NPC/Monster sheet** (`npc` actor type): A stripped-down sheet for monsters and named NPCs — no paths, talents, background, or dark magic. Includes editable HP (max set directly by GM), 5 attributes that auto-calculate Resilience/Avoid/Grit defenses, movement, the full conditions + stance panel, and a weapons/armor/gear inventory with attack roll buttons.
- **Party sheet** (`party` actor type): Links to existing character actors by ID. Lets the GM add/remove party members, view their HP/Level/XP at a glance, award XP to all members at once, give serpents to each member individually, or divide the party treasury pool evenly. Also has a shared item stash and notes tab.
- Both new actor types participate in the initiative system (Fin+Mind/2 formula) and per-round condition damage.

## Test plan

- [ ] Create a new Actor of type `npc` — sheet opens with attributes, defenses, HP fields
- [ ] Edit NPC attributes and confirm Resilience/Avoid/Grit auto-update
- [ ] Add a weapon to NPC and click the dice button to roll an attack
- [ ] Toggle conditions on NPC and confirm stance + condition summary shows
- [ ] Add NPC to combat tracker and roll initiative
- [ ] Create a new Actor of type `party`
- [ ] Add existing characters as members via the Add Member button
- [ ] Use Give XP — confirm each member's experience increases
- [ ] Use Give Serpents to Each — confirm each member's currency increases
- [ ] Use Divide Pool — confirm party pool is zeroed out (minus remainder) and members receive shares
- [ ] Drop items onto the party sheet and confirm they appear in the Stash tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)