### PR TITLE
Redesign item attribute layouts and add Item of Power bonus system

### DIFF
--- a/src/actor.js
+++ b/src/actor.js
@@ -224,6 +224,9 @@ export class TheFadeActor extends Actor {
             // Calculate defenses based on attributes and include bonuses
             this._calculateBaseDefenses(data, actorData);
 
+            // Apply bonuses from equipped Items of Power
+            this._applyEquippedItemBonuses(data, actorData);
+
             // Apply facing modifiers
             this._applyFacingModifiers(data);
 
@@ -402,6 +405,65 @@ export class TheFadeActor extends Actor {
         const roll = new Roll(formula);
 
         return roll;
+    }
+
+    /**
+     * Collect bonuses from all equipped Items of Power and apply them.
+     * Defense/HP bonuses are applied immediately; skill/attack/damage/spell
+     * bonuses are stored in data.equippedBonuses for roll handlers to use.
+     */
+    _applyEquippedItemBonuses(data, actorData) {
+        // Initialize the lookup table roll handlers read from
+        data.equippedBonuses = { skills: {}, attack: 0, damage: 0, spell: 0 };
+
+        const equippedItems = actorData.items
+            ? [...actorData.items].filter(i => i.type === 'magicitem' && i.system?.equipped)
+            : [];
+
+        for (const item of equippedItems) {
+            const bonuses = item.system?.bonuses;
+            if (!Array.isArray(bonuses)) continue;
+
+            for (const bonus of bonuses) {
+                const val = Number(bonus.value) || 0;
+                const target = (bonus.target || "").trim().toLowerCase();
+
+                switch (bonus.type) {
+                    case "avoid":
+                        data.totalAvoid = (data.totalAvoid || 0) + val;
+                        break;
+                    case "resilience":
+                        data.totalResilience = (data.totalResilience || 0) + val;
+                        break;
+                    case "grit":
+                        data.totalGrit = (data.totalGrit || 0) + val;
+                        break;
+                    case "hp":
+                        data.hpMiscBonus = (data.hpMiscBonus || 0) + val;
+                        break;
+                    case "skill": {
+                        const key = target || "all";
+                        data.equippedBonuses.skills[key] = (data.equippedBonuses.skills[key] || 0) + val;
+                        break;
+                    }
+                    case "attack":
+                        if (!target || target === "all") {
+                            data.equippedBonuses.attack += val;
+                        } else {
+                            // Store per-skill-name attack bonus
+                            const aKey = `attack_${target}`;
+                            data.equippedBonuses[aKey] = (data.equippedBonuses[aKey] || 0) + val;
+                        }
+                        break;
+                    case "damage":
+                        data.equippedBonuses.damage += val;
+                        break;
+                    case "spell":
+                        data.equippedBonuses.spell += val;
+                        break;
+                }
+            }
+        }
     }
 
     /**

--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -549,6 +549,12 @@ export class TheFadeCharacterSheet extends ActorSheet {
                 }
 
                 dicePool += (skill.system.miscBonus || 0);
+                // Apply bonuses from equipped Items of Power
+                const eb = actorData.system?.equippedBonuses;
+                if (eb) {
+                    dicePool += (eb.skills?.[skill.name] || 0) + (eb.skills?.all || 0);
+                    if (skill.system.category === "Magical") dicePool += (eb.spell || 0);
+                }
                 skill.calculatedDice = Math.max(1, dicePool);
             } catch (error) {
                 console.warn(`Error calculating dice pool for skill ${skill.name}:`, error);
@@ -584,18 +590,24 @@ export class TheFadeCharacterSheet extends ActorSheet {
                 };
                 weapon.attributeAbbr = attrAbbreviations[weapon.system.attribute] || "N/A";
 
+                const weaponSkillNameLower = (weapon.system.skill || "").toLowerCase();
+                const eb2 = actorData?.system?.equippedBonuses;
+                const itemAttackBonus = eb2
+                    ? (eb2.attack || 0) + (eb2[`attack_${weaponSkillNameLower}`] || 0)
+                    : 0;
+
                 if (skill && skill.calculatedDice !== undefined) {
-                    weapon.calculatedDice = skill.calculatedDice + (weapon.system.miscBonus || 0);
+                    weapon.calculatedDice = skill.calculatedDice + (weapon.system.miscBonus || 0) + itemAttackBonus;
                 } else {
                     // Untrained calculation
                     const attributeName = weapon.system.attribute || "physique";
                     if (attributeName !== "none" && actorData?.system?.attributes) {
                         let attrValue = actorData.system.attributes[attributeName]?.value || 0;
                         let dicePool = Math.floor(attrValue / 2);
-                        dicePool += (weapon.system.miscBonus || 0);
+                        dicePool += (weapon.system.miscBonus || 0) + itemAttackBonus;
                         weapon.calculatedDice = Math.max(1, dicePool);
                     } else {
-                        weapon.calculatedDice = Math.max(1, weapon.system.miscBonus || 0);
+                        weapon.calculatedDice = Math.max(1, (weapon.system.miscBonus || 0) + itemAttackBonus);
                     }
                 }
             } catch (error) {
@@ -2033,6 +2045,13 @@ export class TheFadeCharacterSheet extends ActorSheet {
         // Add misc bonus dice
         dicePool += (skillData.miscBonus || 0);
 
+        // Add bonuses from equipped Items of Power
+        const rollEb = this.actor.system?.equippedBonuses;
+        if (rollEb) {
+            dicePool += (rollEb.skills?.[skill.name] || 0) + (rollEb.skills?.all || 0);
+            if (skillData.category === "Magical") dicePool += (rollEb.spell || 0);
+        }
+
         // Apply active-condition modifiers before min-1 clamp
         const condMods = this.actor.getConditionRollModifiers({
             kind: "skill",
@@ -2269,6 +2288,13 @@ export class TheFadeCharacterSheet extends ActorSheet {
             // Add weapon's misc bonus
             dicePool += (weaponData.miscBonus || 0);
 
+            // Add bonuses from equipped Items of Power
+            const untrEb = this.actor.system?.equippedBonuses;
+            if (untrEb) {
+                dicePool += (untrEb.attack || 0)
+                    + (untrEb[`attack_${(skillName || "").toLowerCase()}`] || 0);
+            }
+
             // Apply active-condition modifiers
             const condModsUntrained = this.actor.getConditionRollModifiers({
                 kind: "attack",
@@ -2421,6 +2447,15 @@ export class TheFadeCharacterSheet extends ActorSheet {
 
         // Add weapon misc bonus
         dicePool += (weaponData.miscBonus || 0);
+
+        // Add bonuses from equipped Items of Power
+        const atkEb = this.actor.system?.equippedBonuses;
+        if (atkEb) {
+            dicePool += (atkEb.attack || 0)
+                + (atkEb[`attack_${(skill.name || "").toLowerCase()}`] || 0)
+                + (atkEb.skills?.[skill.name] || 0)
+                + (atkEb.skills?.all || 0);
+        }
 
         // Apply active-condition modifiers
         const condMods = this.actor.getConditionRollModifiers({

--- a/src/item-sheet.js
+++ b/src/item-sheet.js
@@ -876,6 +876,63 @@ export class TheFadeItemSheet extends ItemSheet {
                     ui.notifications.info(`${this.item.name} is no longer attuned to anyone.`);
                 }
             });
+
+            // Hide target input for bonus types that don't need one
+            const NO_TARGET_TYPES = new Set(["avoid", "resilience", "grit", "hp"]);
+            const updateTargetVisibility = (row) => {
+                const type = row.find('.bonus-type').val();
+                const targetInput = row.find('.bonus-target');
+                if (NO_TARGET_TYPES.has(type)) {
+                    targetInput.val("").prop('disabled', true).css('visibility', 'hidden');
+                } else {
+                    targetInput.prop('disabled', false).css('visibility', 'visible');
+                }
+            };
+
+            // Initialize visibility for existing bonus rows
+            html.find('.bonus-row').each((i, el) => updateTargetVisibility($(el)));
+
+            // Collect all bonus rows from the DOM and save
+            const saveBonuses = () => {
+                const bonuses = [];
+                html.find('.bonus-row').each((i, el) => {
+                    const $row = $(el);
+                    const type = $row.find('.bonus-type').val();
+                    bonuses.push({
+                        id: $row.data('bonus-id'),
+                        type,
+                        target: NO_TARGET_TYPES.has(type) ? "" : ($row.find('.bonus-target').val() || ""),
+                        value: parseInt($row.find('.bonus-value').val()) || 0
+                    });
+                });
+                this.item.update({ "system.bonuses": bonuses });
+            };
+
+            // Add bonus
+            html.find('.bonus-add').click(ev => {
+                ev.preventDefault();
+                const bonuses = foundry.utils.deepClone(this.item.system.bonuses || []);
+                bonuses.push({ id: foundry.utils.randomID(16), type: "skill", target: "", value: 1 });
+                this.item.update({ "system.bonuses": bonuses }).then(() => this.render(false));
+            });
+
+            // Delete bonus
+            html.find('.bonus-delete').click(ev => {
+                ev.preventDefault();
+                const id = ev.currentTarget.dataset.bonusId;
+                const bonuses = (this.item.system.bonuses || []).filter(b => b.id !== id);
+                this.item.update({ "system.bonuses": bonuses }).then(() => this.render(false));
+            });
+
+            // Type change — update target visibility then save
+            html.find('.bonus-type').change(ev => {
+                const $row = $(ev.currentTarget).closest('.bonus-row');
+                updateTargetVisibility($row);
+                saveBonuses();
+            });
+
+            // Target / value changes
+            html.find('.bonus-target, .bonus-value').change(() => saveBonuses());
         }
 
         // Add general input change handler for all item sheets

--- a/src/item.js
+++ b/src/item.js
@@ -284,6 +284,7 @@ export class TheFadeItem extends Item {
         if (typeof data.conflictsArmor === "undefined") data.conflictsArmor = false;
         if (!data.radiationEffect) data.radiationEffect = "";
         if (!data.creationRequirements) data.creationRequirements = "";
+        if (!Array.isArray(data.bonuses)) data.bonuses = [];
     }
     /**
     * Prepare fleshcraft-specific data

--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -7568,6 +7568,120 @@ select[name="system.aura.color"] option[value="white"] {
     resize: vertical;
 }
 
+/* ----- Item attribute 2-column grid ----- */
+.thefade.sheet.item .item-attr-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0 14px;
+}
+
+.thefade.sheet.item .item-attr-grid .form-group.full-width {
+    grid-column: 1 / -1;
+}
+
+/* Align checkbox groups to the bottom of their grid cell */
+.thefade.sheet.item .armor-heavy-group {
+    align-self: end;
+    padding-bottom: 2px;
+}
+
+.thefade.sheet.item .armor-heavy-group .form-field {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.88em;
+    color: var(--text-primary);
+    cursor: pointer;
+}
+
+/* ----- Bonus section (Items of Power) ----- */
+.thefade.sheet.item .bonus-section {
+    margin-top: 14px;
+    border-top: 1px solid var(--border-faint);
+    padding-top: 10px;
+}
+
+.thefade.sheet.item .bonus-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 0.78em;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    font-weight: 600;
+    margin-bottom: 8px;
+}
+
+.thefade.sheet.item .bonus-add {
+    background: none;
+    border: 1px solid var(--accent-gold);
+    color: var(--accent-gold);
+    padding: 2px 8px;
+    font-size: 0.75em;
+    cursor: pointer;
+    border-radius: 2px;
+    line-height: 1.6;
+}
+
+.thefade.sheet.item .bonus-add:hover {
+    background: var(--accent-ghost);
+}
+
+.thefade.sheet.item .bonus-row {
+    display: grid;
+    grid-template-columns: 110px 1fr 52px 26px;
+    gap: 4px;
+    align-items: center;
+    margin-bottom: 5px;
+}
+
+.thefade.sheet.item .bonus-row select,
+.thefade.sheet.item .bonus-row input[type="text"],
+.thefade.sheet.item .bonus-row input[type="number"] {
+    height: 26px;
+    padding: 2px 5px;
+    font-size: 0.82em;
+    background: var(--bg-surface-alt);
+    border: 1px solid var(--border-faint);
+    color: var(--text-primary);
+    border-radius: 2px;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.thefade.sheet.item .bonus-value {
+    text-align: center;
+}
+
+.thefade.sheet.item .bonus-delete {
+    background: none;
+    border: 1px solid var(--border-faint);
+    color: var(--text-muted);
+    cursor: pointer;
+    padding: 0;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 2px;
+    font-size: 0.8em;
+}
+
+.thefade.sheet.item .bonus-delete:hover {
+    border-color: var(--accent-crimson);
+    color: var(--accent-crimson);
+}
+
+.thefade.sheet.item .bonus-empty {
+    font-size: 0.82em;
+    color: var(--text-dim);
+    font-style: italic;
+    text-align: center;
+    padding: 8px 0;
+}
+
 /* ----- Checkboxes (generic) ----- */
 .thefade input[type="checkbox"] {
     accent-color: var(--accent-crimson);

--- a/templates/item/armor-sheet.html
+++ b/templates/item/armor-sheet.html
@@ -22,50 +22,55 @@
 
         {{!-- Attributes Tab --}}
         <div class="tab" data-group="primary" data-tab="attributes">
-            <div class="form-group">
-                <label>Armored Protection (AP)</label>
-                <input type="text" name="system.ap" value="{{system.ap}}" data-dtype="Number" />
-            </div>
+            <div class="item-attr-grid">
 
-            <div class="form-group">
-                <label>Current AP</label>
-                <input type="text" name="system.currentAP" value="{{system.currentAP}}" data-dtype="Number" />
-                <p class="hint">Tracks current armor protection after damage</p>
-            </div>
+                <div class="form-group">
+                    <label>Max AP</label>
+                    <input type="text" name="system.ap" value="{{system.ap}}" data-dtype="Number" />
+                </div>
 
-            <div class="form-group">
-                <label>Is Heavy?</label>
-                <input type="checkbox" name="system.isHeavy" {{checked system.isHeavy}} />
-                <p class="hint">Heavy armor increases the DT of all Physical skill checks by 2.</p>
-            </div>
+                <div class="form-group">
+                    <label>Current AP</label>
+                    <input type="text" name="system.currentAP" value="{{system.currentAP}}" data-dtype="Number" />
+                    <p class="hint">Tracks current protection after damage</p>
+                </div>
 
-            <div class="form-group">
-                <label>Location</label>
-                <select name="system.location">
-                    {{selectOptions armorLocationOptions selected=system.location}}
-                </select>
-            </div>
+                <div class="form-group">
+                    <label>Location</label>
+                    <select name="system.location">
+                        {{selectOptions armorLocationOptions selected=system.location}}
+                    </select>
+                </div>
 
-            <div class="form-group">
-                <label>Weight</label>
-                <input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number" />
-                <span>lbs.</span>
+                <div class="form-group">
+                    <label>Weight (lbs.)</label>
+                    <input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number" />
+                </div>
+
+                <div class="form-group">
+                    <label>Material</label>
+                    <select name="system.material">
+                        {{selectOptions materialOptions selected=system.material}}
+                    </select>
+                </div>
+
+                <div class="form-group armor-heavy-group">
+                    <label class="form-field">
+                        <input type="checkbox" name="system.isHeavy" {{checked system.isHeavy}} />
+                        Heavy Armor
+                    </label>
+                    <p class="hint">+2 DT to Physical skill checks</p>
+                </div>
+
             </div>
 
             {{#if (eq system.location "Shield")}}
-            <div class="form-group">
+            <div class="form-group" style="margin-top: 8px;">
                 <label>Auto Block</label>
                 <input type="text" name="system.autoBlock" value="{{system.autoBlock}}" />
                 <p class="hint">Body parts the shield automatically protects (e.g., "Arms, Body")</p>
             </div>
             {{/if}}
-
-            <div class="form-group">
-                <label>Material</label>
-                <select name="system.material">
-                    {{selectOptions materialOptions selected=system.material}}
-                </select>
-            </div>
         </div>
     </section>
 </form>

--- a/templates/item/item-sheet.html
+++ b/templates/item/item-sheet.html
@@ -26,75 +26,110 @@
 
         {{!-- Properties Tab --}}
         <div class="tab" data-group="primary" data-tab="properties">
-            <div class="form-group">
-                <label>Equipment Slot</label>
-                <select name="system.slot">
-                    <option value="head" {{#ifEquals system.slot "head"}} selected{{/ifEquals}}>Head</option>
-                    <option value="neck" {{#ifEquals system.slot "neck"}} selected{{/ifEquals}}>Neck</option>
-                    <option value="body" {{#ifEquals system.slot "body"}} selected{{/ifEquals}}>Body</option>
-                    <option value="hands" {{#ifEquals system.slot "hands"}} selected{{/ifEquals}}>Hands</option>
-                    <option value="ring" {{#ifEquals system.slot "ring"}} selected{{/ifEquals}}>Ring</option>
-                    <option value="belt" {{#ifEquals system.slot "belt"}} selected{{/ifEquals}}>Belt</option>
-                    <option value="boots" {{#ifEquals system.slot "boots"}} selected{{/ifEquals}}>Boots</option>
-                </select>
+            <div class="item-attr-grid">
+                <div class="form-group">
+                    <label>Equipment Slot</label>
+                    <select name="system.slot">
+                        <option value="head" {{#ifEquals system.slot "head"}} selected{{/ifEquals}}>Head</option>
+                        <option value="neck" {{#ifEquals system.slot "neck"}} selected{{/ifEquals}}>Neck</option>
+                        <option value="body" {{#ifEquals system.slot "body"}} selected{{/ifEquals}}>Body</option>
+                        <option value="hands" {{#ifEquals system.slot "hands"}} selected{{/ifEquals}}>Hands</option>
+                        <option value="ring" {{#ifEquals system.slot "ring"}} selected{{/ifEquals}}>Ring</option>
+                        <option value="belt" {{#ifEquals system.slot "belt"}} selected{{/ifEquals}}>Belt</option>
+                        <option value="boots" {{#ifEquals system.slot "boots"}} selected{{/ifEquals}}>Boots</option>
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label>Catalyst Used</label>
+                    <select name="system.catalyst">
+                        <option value="" {{#ifEquals system.catalyst ""}} selected{{/ifEquals}}>Unknown/Unspecified</option>
+                        <option value="planar-essence" {{#ifEquals system.catalyst "planar-essence"}} selected{{/ifEquals}}>Planar Essence</option>
+                        <option value="divine-gift" {{#ifEquals system.catalyst "divine-gift"}} selected{{/ifEquals}}>Divine Gift</option>
+                        <option value="bones-of-glory" {{#ifEquals system.catalyst "bones-of-glory"}} selected{{/ifEquals}}>Bones of Glory</option>
+                    </select>
+                </div>
             </div>
 
             <div class="form-group">
                 <label>Magical Effect</label>
-                <textarea name="system.effect" rows="6" placeholder="Describe the magical effect this item provides...">{{system.effect}}</textarea>
+                <textarea name="system.effect" rows="4" placeholder="Describe the magical effect this item provides...">{{system.effect}}</textarea>
             </div>
 
-            <div class="form-group">
-                <label>Catalyst Used</label>
-                <select name="system.catalyst">
-                    <option value="" {{#ifEquals system.catalyst ""}} selected{{/ifEquals}}>Unknown/Unspecified</option>
-                    <option value="planar-essence" {{#ifEquals system.catalyst "planar-essence"}} selected{{/ifEquals}}>Planar Essence</option>
-                    <option value="divine-gift" {{#ifEquals system.catalyst "divine-gift"}} selected{{/ifEquals}}>Divine Gift</option>
-                    <option value="bones-of-glory" {{#ifEquals system.catalyst "bones-of-glory"}} selected{{/ifEquals}}>Bones of Glory</option>
-                </select>
-            </div>
-
-            <div class="form-group flexrow">
+            <div class="form-group flexrow" style="margin-top: 4px;">
                 <div class="form-field">
                     <label>Currently Attuned</label>
                     <input type="checkbox" name="system.attunement" {{#if system.attunement}} checked{{/if}} />
                 </div>
-
                 <div class="form-field">
                     <label>Equipped</label>
                     <input type="checkbox" name="system.equipped" {{#if system.equipped}} checked{{/if}} />
                 </div>
-
                 <div class="form-field">
                     <label>Has Aura</label>
                     <input type="checkbox" name="system.hasAura" {{#if system.hasAura}} checked{{/if}} />
                 </div>
             </div>
 
+            {{#if system.hasAura}}
             <div class="form-group">
                 <label>Aura Color</label>
-                <input type="text" name="system.auraColor" value="{{system.auraColor}}" placeholder="Dull gray (default), changes to wielder's color" />
+                <input type="text" name="system.auraColor" value="{{system.auraColor}}" placeholder="Dull gray (default)" />
                 <p class="hint">Items with auras shine like torches out to 3 hexes</p>
+            </div>
+            {{/if}}
+
+            {{!-- Bonuses Section --}}
+            <div class="bonus-section">
+                <div class="bonus-section-header">
+                    <span>Bonuses</span>
+                    <button type="button" class="bonus-add"><i class="fas fa-plus"></i> Add</button>
+                </div>
+                {{#if system.bonuses.length}}
+                    {{#each system.bonuses}}
+                    <div class="bonus-row" data-bonus-id="{{this.id}}">
+                        <select class="bonus-type" data-bonus-id="{{this.id}}">
+                            <option value="skill" {{#ifEquals this.type "skill"}}selected{{/ifEquals}}>Skill</option>
+                            <option value="attack" {{#ifEquals this.type "attack"}}selected{{/ifEquals}}>Attack</option>
+                            <option value="damage" {{#ifEquals this.type "damage"}}selected{{/ifEquals}}>Damage</option>
+                            <option value="spell" {{#ifEquals this.type "spell"}}selected{{/ifEquals}}>Spell</option>
+                            <option value="avoid" {{#ifEquals this.type "avoid"}}selected{{/ifEquals}}>Avoid</option>
+                            <option value="resilience" {{#ifEquals this.type "resilience"}}selected{{/ifEquals}}>Resilience</option>
+                            <option value="grit" {{#ifEquals this.type "grit"}}selected{{/ifEquals}}>Grit</option>
+                            <option value="hp" {{#ifEquals this.type "hp"}}selected{{/ifEquals}}>Max HP</option>
+                        </select>
+                        <input type="text" class="bonus-target" value="{{this.target}}" placeholder="Target (or blank = all)" data-bonus-id="{{this.id}}" />
+                        <input type="number" class="bonus-value" value="{{this.value}}" data-bonus-id="{{this.id}}" />
+                        <button type="button" class="bonus-delete" data-bonus-id="{{this.id}}"><i class="fas fa-times"></i></button>
+                    </div>
+                    {{/each}}
+                {{else}}
+                    <div class="bonus-empty">No bonuses — click <strong>+ Add</strong> to create one.</div>
+                {{/if}}
             </div>
         </div>
 
         {{!-- Details Tab --}}
         <div class="tab" data-group="primary" data-tab="details">
-            <div class="form-group">
-                <label>Price (sp)</label>
-                <input type="number" name="system.price" value="{{system.price}}" data-dtype="Number" />
-                <p class="hint">Price in Serpents</p>
-            </div>
+            <div class="item-attr-grid">
+                <div class="form-group">
+                    <label>Price (sp)</label>
+                    <input type="number" name="system.price" value="{{system.price}}" data-dtype="Number" />
+                    <p class="hint">Price in Serpents</p>
+                </div>
 
-            <div class="form-group">
-                <label>Weight (lbs)</label>
-                <input type="number" name="system.weight" value="{{system.weight}}" data-dtype="Number" step="0.1" />
-            </div>
+                <div class="form-group">
+                    <label>Weight (lbs)</label>
+                    <input type="number" name="system.weight" value="{{system.weight}}" data-dtype="Number" step="0.1" />
+                </div>
 
-            <div class="form-group">
-                <label>Conflicts with Armor</label>
-                <input type="checkbox" name="system.conflictsArmor" {{#if system.conflictsArmor}} checked{{/if}} />
-                <p class="hint">Head, Body, and Hands slots typically conflict with armor</p>
+                <div class="form-group full-width">
+                    <label class="form-field">
+                        <input type="checkbox" name="system.conflictsArmor" {{#if system.conflictsArmor}} checked{{/if}} />
+                        Conflicts with Armor
+                    </label>
+                    <p class="hint">Head, Body, and Hands slots typically conflict with armor</p>
+                </div>
             </div>
 
             <div class="form-group">

--- a/templates/item/weapon-sheet.html
+++ b/templates/item/weapon-sheet.html
@@ -6,94 +6,95 @@
           <div class="item-type-badge {{item.type}}">{{item.type}}</div>
       </div>
     </header>
-  
+
     {{!-- Sheet Tab Navigation --}}
     <nav class="sheet-tabs tabs" data-group="primary">
       <a class="item" data-tab="description">Description</a>
       <a class="item" data-tab="attributes">Attributes</a>
     </nav>
-  
+
     {{!-- Sheet Body --}}
     <section class="sheet-body">
       {{!-- Description Tab --}}
       <div class="tab" data-group="primary" data-tab="description">
         <textarea name="system.description">{{system.description}}</textarea>
       </div>
-  
+
       {{!-- Attributes Tab --}}
-    <div class="tab" data-group="primary" data-tab="attributes">
-        <div class="form-group">
+      <div class="tab" data-group="primary" data-tab="attributes">
+        <div class="item-attr-grid">
+
+          <div class="form-group">
             <label>Damage</label>
             <input type="text" name="system.damage" value="{{system.damage}}" data-dtype="Number" />
-        </div>
+          </div>
 
-        <div class="form-group">
+          <div class="form-group">
             <label>Damage Type</label>
             <select name="system.damageType">
-                {{selectOptions weaponDamageTypeOptions selected=system.damageType}}
+              {{selectOptions weaponDamageTypeOptions selected=system.damageType}}
             </select>
-        </div>
+          </div>
 
-        <div class="form-group">
-            <label>Misc Bonus (Bonus Dice)</label>
-            <input type="number" name="system.miscBonus" value="{{system.miscBonus}}" data-dtype="Number" />
-            <p class="hint">Bonus dice added to attack rolls</p>
-        </div>
-
-        <div class="form-group">
-            <label>Critical</label>
-            <input type="text" name="system.critical" value="{{system.critical}}" data-dtype="Number" />
-        </div>
-
-        <div class="form-group">
-            <label>Handedness</label>
-            <select name="system.handedness">
-                {{selectOptions weaponHandednessOptions selected=system.handedness}}
-            </select>
-        </div>
-
-        <div class="form-group">
-            <label>Range</label>
-            <input type="text" name="system.range" value="{{system.range}}" />
-        </div>
-
-        <div class="form-group">
-            <label>Integrity</label>
-            <input type="text" name="system.integrity" value="{{system.integrity}}" data-dtype="Number" />
-        </div>
-
-        <div class="form-group">
-            <label>Weight</label>
-            <input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number" />
-            <span>lbs.</span>
-        </div>
-
-        <div class="form-group">
-            <label>Qualities</label>
-            <input type="text" name="system.qualities" value="{{system.qualities}}" />
-        </div>
-
-        <div class="form-group">
+          <div class="form-group">
             <label>Skill</label>
             <select name="system.skill">
-                {{selectOptions weaponSkillOptions selected=system.skill}}
+              {{selectOptions weaponSkillOptions selected=system.skill}}
             </select>
-        </div>
+          </div>
 
-        <div class="form-group">
+          <div class="form-group">
             <label>Damage Attribute</label>
             <select name="system.attribute">
-                {{selectOptions weaponAttributeOptions selected=system.attribute}}
+              {{selectOptions weaponAttributeOptions selected=system.attribute}}
             </select>
-        </div>
+          </div>
 
-        <div class="form-group">
+          <div class="form-group">
+            <label>Handedness</label>
+            <select name="system.handedness">
+              {{selectOptions weaponHandednessOptions selected=system.handedness}}
+            </select>
+          </div>
+
+          <div class="form-group">
+            <label>Range</label>
+            <input type="text" name="system.range" value="{{system.range}}" />
+          </div>
+
+          <div class="form-group">
+            <label>Bonus Dice</label>
+            <input type="number" name="system.miscBonus" value="{{system.miscBonus}}" data-dtype="Number" />
+          </div>
+
+          <div class="form-group">
+            <label>Critical</label>
+            <input type="text" name="system.critical" value="{{system.critical}}" data-dtype="Number" />
+          </div>
+
+          <div class="form-group">
+            <label>Integrity</label>
+            <input type="text" name="system.integrity" value="{{system.integrity}}" data-dtype="Number" />
+          </div>
+
+          <div class="form-group">
+            <label>Weight (lbs.)</label>
+            <input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number" />
+          </div>
+
+          <div class="form-group full-width">
             <label>Material</label>
             <select name="system.material">
-                {{selectOptions materialOptions selected=system.material}}
+              {{selectOptions materialOptions selected=system.material}}
             </select>
-        </div>
+          </div>
 
-    </div>
+          <div class="form-group full-width">
+            <label>Qualities</label>
+            <input type="text" name="system.qualities" value="{{system.qualities}}" />
+          </div>
+
+        </div>
+      </div>
     </section>
 </form>


### PR DESCRIPTION
## Summary

- **Weapon & armor attribute tabs** are now 2-column grids instead of one long scrollable list, so all the key fields are visible without scrolling
- **Item of Power sheets** gain a Bonuses section in the Properties tab where GMs can attach named bonuses that apply automatically when the item is marked Equipped
- **Actor data prep + roll builders** wire up those bonuses so they actually affect dice pools and defenses at the table

## What changed

### Layout
- `templates/item/weapon-sheet.html` — 2-col grid: Damage/Type, Skill/Attribute, Handedness/Range, Bonus Dice/Critical, Integrity/Weight; Material and Qualities span full width
- `templates/item/armor-sheet.html` — 2-col grid: Max AP/Current AP, Location/Weight, Material/Heavy Armor; Auto Block (Shield) still conditional full-width
- `templates/item/item-sheet.html` — Properties tab gets Slot/Catalyst side-by-side, checkboxes in a horizontal row, and a new **Bonuses** section at the bottom

### Bonus system
- `src/item.js` — initializes `system.bonuses = []` for `magicitem` items
- `src/item-sheet.js` — add/delete/change handlers for bonus rows; target field hidden for types that don't need one (Avoid, Resilience, Grit, Max HP)
- `src/actor.js` — `_applyEquippedItemBonuses()` runs during character data prep; defense/HP bonuses applied to totals immediately, skill/attack/spell bonuses stored in `data.equippedBonuses` for roll handlers
- `src/character-sheet.js` — four roll-building sites (skill pool prep, weapon pool prep, live skill roll, live attack roll) now read from `equippedBonuses`
- `styles/thefade.css` — grid layout class `.item-attr-grid`, `.full-width` modifier, and all bonus-row styles

### Bonus types supported
| Type | Target field | Effect |
|---|---|---|
| Skill | Skill name or blank (= all skills) | +dice to that skill's rolls |
| Attack | Weapon skill name or blank (= all) | +dice to attack rolls |
| Damage | *(stored, not yet applied to damage output)* | reserved |
| Spell | Blank = all Magical skills | +dice to Magical category skill rolls |
| Avoid / Resilience / Grit | *(hidden — no target)* | +flat to that defense total |
| Max HP | *(hidden — no target)* | +to `hpMiscBonus` |

## Reviewer notes
- Damage bonuses are stored in `equippedBonuses.damage` but not yet applied to the damage output in chat messages — that's a separate pass once we decide the display format
- Bonuses only apply when `system.equipped === true` on the Item of Power (attunement alone is not sufficient)

🤖 Generated with [Claude Code](https://claude.com/claude-code)