### PR TITLE
Item sheet dark theme, automation, and Talents background fix

### DIFF
--- a/src/actor.js
+++ b/src/actor.js
@@ -855,9 +855,22 @@ export class TheFadeActor extends Actor {
      */
     async restDaily() {
         await resetDailySin(this);
+
+        // Reset talent uses-per-day
+        const talentsWithUses = this.items.filter(i => i.type === 'talent' && (i.system.usesPerDay ?? 0) > 0);
+        for (const talent of talentsWithUses) {
+            await talent.update({ "system.currentUses": 0 });
+        }
+
+        // Reset staff uses
+        const staves = this.items.filter(i => i.type === 'staff');
+        for (const staff of staves) {
+            await staff.update({ "system.uses": 0 });
+        }
+
         ChatMessage.create({
             speaker: ChatMessage.getSpeaker({ actor: this }),
-            content: `<p><strong>${this.name}</strong> rests — Sin cleared.</p>`
+            content: `<p><strong>${this.name}</strong> rests — Sin cleared, daily uses reset.</p>`
         });
     }
 

--- a/src/item-sheet.js
+++ b/src/item-sheet.js
@@ -309,6 +309,28 @@ export class TheFadeItemSheet extends ItemSheet {
                     "precept": "Precepts"
                 };
             }
+
+            // Calculated dice pool for weapons owned by an actor
+            if (this.item?.type === 'weapon' && this.item.parent) {
+                const actor = this.item.parent;
+                const sys = this.item.system;
+                const skillItem = actor.items.find(i => i.type === 'skill' && i.name === sys.skill);
+                const rank = skillItem ? getRankValue(skillItem.system.rank) : 0;
+                const miscBonus = sys.miscBonus ?? 0;
+                const total = rank + miscBonus;
+                if (total > 0) data.calculatedDice = total;
+            }
+
+            // Consume label per consumable type
+            const consumeLabels = {
+                potion: "Consume Potion",
+                drug: "Take Drug",
+                medical: "Use Medicine",
+                poison: "Apply Poison"
+            };
+            if (consumeLabels[this.item?.type]) {
+                data.consumeLabel = consumeLabels[this.item.type];
+            }
         } catch (error) {
             console.error("Error in special item type handling:", error);
         }
@@ -760,34 +782,93 @@ export class TheFadeItemSheet extends ItemSheet {
             }
         });
 
-        // Handle item charges and uses
-        if (this.item.type === 'wand') {
-            html.find('.charge-use').click(ev => {
+        // Weapon: roll attack from item sheet
+        if (this.item.type === 'weapon') {
+            html.find('.roll-weapon-attack').click(async ev => {
                 ev.preventDefault();
-                const charges = this.item.system.charges || 0;
-                if (charges > 0) {
-                    this.item.update({ "system.charges": charges - 1 });
-                } else {
-                    ui.notifications.warn("This wand has no charges remaining.");
-                }
+                const actor = this.item.parent;
+                if (!actor) return ui.notifications.warn("Equip this weapon to a character to roll.");
+                const sys = this.item.system;
+                const skillItem = actor.items.find(i => i.type === 'skill' && i.name === sys.skill);
+                const rank = skillItem ? getRankValue(skillItem.system.rank) : 0;
+                const miscBonus = sys.miscBonus ?? 0;
+                const dice = rank + miscBonus;
+                if (dice <= 0) return ui.notifications.warn("No dice to roll — assign a skill rank first.");
+                const roll = await new Roll(`${dice}d10`).evaluate();
+                ChatMessage.create({
+                    speaker: ChatMessage.getSpeaker({ actor }),
+                    flavor: `${this.item.name} — Attack (${sys.skill})`,
+                    content: `<div class="thefade chat-card">
+                        <h3>${this.item.name}</h3>
+                        <p><strong>Damage:</strong> ${sys.damage || "—"} (${sys.damageType || "—"})</p>
+                        ${sys.critical ? `<p><strong>Critical:</strong> ${sys.critical}</p>` : ""}
+                        ${await roll.render()}
+                    </div>`
+                });
             });
         }
 
+        // Armor: AP reduce/reset buttons
+        if (this.item.type === 'armor') {
+            html.find('.reduce-ap').click(async ev => {
+                ev.preventDefault();
+                const cur = this.item.system.currentAP ?? this.item.system.ap ?? 0;
+                if (cur <= 0) return ui.notifications.warn("AP is already depleted.");
+                await this.item.update({ "system.currentAP": cur - 1 });
+            });
+            html.find('.reset-ap').click(async ev => {
+                ev.preventDefault();
+                await this.item.update({ "system.currentAP": this.item.system.ap ?? 0 });
+            });
+        }
+
+        // Handle wand charges — with chat card
+        if (this.item.type === 'wand') {
+            html.find('.charge-use').click(async ev => {
+                ev.preventDefault();
+                const charges = this.item.system.charges || 0;
+                if (charges <= 0) return ui.notifications.warn("This wand has no charges remaining.");
+                const newCharges = charges - 1;
+                await this.item.update({ "system.charges": newCharges });
+                const actor = this.item.parent;
+                ChatMessage.create({
+                    speaker: actor ? ChatMessage.getSpeaker({ actor }) : undefined,
+                    content: `<div class="thefade chat-card">
+                        <h3>${this.item.name}</h3>
+                        <p class="item-type-label">Wand</p>
+                        ${this.item.system.spellName ? `<p><strong>Spell:</strong> ${this.item.system.spellName}</p>` : ""}
+                        ${this.item.system.spellDescription || this.item.system.spellEffect ? `<p>${this.item.system.spellDescription || this.item.system.spellEffect}</p>` : ""}
+                        <p class="qty-remaining">Charges remaining: ${newCharges}${this.item.system.maxCharges ? ` / ${this.item.system.maxCharges}` : ""}</p>
+                    </div>`
+                });
+            });
+        }
+
+        // Handle staff uses — with chat card
         if (this.item.type === 'staff') {
-            html.find('.use-per-day').click(ev => {
+            html.find('.use-per-day').click(async ev => {
                 ev.preventDefault();
                 const uses = this.item.system.uses || 0;
                 const maxUses = this.item.system.usesPerDay || 3;
-                if (uses < maxUses) {
-                    this.item.update({ "system.uses": uses + 1 });
-                } else {
-                    ui.notifications.warn("This staff has been used the maximum number of times today.");
-                }
+                if (uses >= maxUses) return ui.notifications.warn("This staff has been used the maximum number of times today.");
+                const newUses = uses + 1;
+                await this.item.update({ "system.uses": newUses });
+                const actor = this.item.parent;
+                ChatMessage.create({
+                    speaker: actor ? ChatMessage.getSpeaker({ actor }) : undefined,
+                    content: `<div class="thefade chat-card">
+                        <h3>${this.item.name}</h3>
+                        <p class="item-type-label">Staff</p>
+                        ${this.item.system.spellName ? `<p><strong>Spell:</strong> ${this.item.system.spellName}</p>` : ""}
+                        ${this.item.system.spellDescription || this.item.system.spellEffect ? `<p>${this.item.system.spellDescription || this.item.system.spellEffect}</p>` : ""}
+                        <p class="qty-remaining">Uses today: ${newUses} / ${maxUses}</p>
+                    </div>`
+                });
             });
 
-            html.find('.reset-uses').click(ev => {
+            html.find('.reset-uses').click(async ev => {
                 ev.preventDefault();
-                this.item.update({ "system.uses": 0 });
+                await this.item.update({ "system.uses": 0 });
                 ui.notifications.info("Staff uses have been reset for a new day.");
             });
         }
@@ -842,25 +923,70 @@ export class TheFadeItemSheet extends ItemSheet {
             });
         }
 
-        // Handle potion consumption
-        if (this.item.type === 'potion') {
-            html.find('.consume-potion').click(ev => {
+        // Generic consume/use handler for potions, drugs, medical supplies, poisons
+        if (['potion', 'drug', 'medical', 'poison'].includes(this.item.type)) {
+            html.find('.consume-item').click(async ev => {
                 ev.preventDefault();
-                // If this item is owned by an actor, we can apply its effects
-                if (this.item.parent) {
-                    ui.notifications.info(`${this.item.name} consumed by ${this.item.parent.name}!`);
-                    // Here we would apply the potion's effects to the actor
+                const item = this.item;
+                const actor = item.parent;
+                const qty = item.system.quantity ?? 1;
+                if (qty <= 0) return ui.notifications.warn(`No ${item.name} remaining.`);
+                await item.update({ "system.quantity": qty - 1 });
+                const effect = item.system.effect || item.system.healingAmount || "";
+                const duration = item.system.duration || "";
+                ChatMessage.create({
+                    speaker: actor ? ChatMessage.getSpeaker({ actor }) : undefined,
+                    content: `<div class="thefade chat-card">
+                        <h3>${item.name}</h3>
+                        <p class="item-type-label">${item.type.charAt(0).toUpperCase() + item.type.slice(1)}</p>
+                        ${effect ? `<p><strong>Effect:</strong> ${effect}</p>` : ""}
+                        ${duration ? `<p><strong>Duration:</strong> ${duration}</p>` : ""}
+                        <p class="qty-remaining">Remaining: ${qty - 1}</p>
+                    </div>`
+                });
+            });
+        }
 
-                    // Remove the potion after use (or reduce quantity)
-                    const quantity = this.item.system.quantity || 1;
-                    if (quantity > 1) {
-                        this.item.update({ "system.quantity": quantity - 1 });
-                    } else {
-                        this.item.parent.deleteEmbeddedDocuments("Item", [this.item.id]);
-                    }
-                } else {
-                    ui.notifications.warn("This potion is not owned by a character and cannot be consumed.");
-                }
+        // Talent: Use button with uses-per-day tracking
+        if (this.item.type === 'talent') {
+            html.find('.use-talent').click(async ev => {
+                ev.preventDefault();
+                const item = this.item;
+                const cur = item.system.currentUses ?? 0;
+                const max = item.system.usesPerDay ?? 0;
+                if (max > 0 && cur >= max) return ui.notifications.warn(`${item.name}: No uses remaining today.`);
+                if (max > 0) await item.update({ "system.currentUses": cur + 1 });
+                ChatMessage.create({
+                    speaker: item.parent ? ChatMessage.getSpeaker({ actor: item.parent }) : undefined,
+                    content: `<div class="thefade chat-card">
+                        <h3>${item.name}</h3>
+                        <p class="item-type-label">Talent</p>
+                        ${item.system.description ? `<p>${item.system.description}</p>` : ""}
+                        ${max > 0 ? `<p class="qty-remaining">Uses: ${cur + 1} / ${max}</p>` : ""}
+                    </div>`
+                });
+            });
+        }
+
+        // Spell: Cast button — posts a chat card with spell details
+        if (this.item.type === 'spell') {
+            html.find('.cast-spell').click(async ev => {
+                ev.preventDefault();
+                const sys = this.item.system;
+                ChatMessage.create({
+                    speaker: this.item.parent ? ChatMessage.getSpeaker({ actor: this.item.parent }) : undefined,
+                    content: `<div class="thefade chat-card">
+                        <h3>${this.item.name}</h3>
+                        <p class="item-type-label">${sys.school || "Spell"}${sys.isDarkMagic ? " — Dark Magic" : ""}</p>
+                        ${sys.damage ? `<p><strong>Damage:</strong> ${sys.damage}${sys.damageType ? ` (${sys.damageType})` : ""}</p>` : ""}
+                        ${sys.attack ? `<p><strong>Attack:</strong> ${sys.attack}</p>` : ""}
+                        ${sys.range ? `<p><strong>Range:</strong> ${sys.range}</p>` : ""}
+                        ${sys.time ? `<p><strong>Casting Time:</strong> ${sys.time}</p>` : ""}
+                        ${sys.successes ? `<p><strong>Successes Needed:</strong> ${sys.successes}</p>` : ""}
+                        ${sys.bonusEffect ? `<p><strong>Bonus Effect:</strong> ${sys.bonusEffect}</p>` : ""}
+                        ${this.item.system.description ? `<p>${this.item.system.description}</p>` : ""}
+                    </div>`
+                });
             });
         }
 

--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -2526,9 +2526,9 @@ input[readonly] {
 .spells-learned-counter {
   margin: 16px 0;
   padding: 12px;
-  border: 1px solid var(--gray-200);
+  border: 1px solid var(--border-faint);
   border-radius: 6px;
-  background: #fafafa;
+  background: var(--bg-surface);
 }
 
 .paths-info h3,
@@ -2537,7 +2537,7 @@ input[readonly] {
   margin: 0 0 12px 0;
   font-size: 0.875rem;
   font-weight: bold;
-  color: var(--gray-800);
+  color: var(--text-primary);
 }
 
 .paths-progression,
@@ -3202,8 +3202,16 @@ select[name="system.aura.color"] option[value="white"] {
 }
 
 /* ===== ITEM SHEETS ===== */
+
+/* Dark base */
+.thefade.sheet.item {
+  background: var(--bg-ink);
+  color: var(--text-primary);
+}
+
 .thefade.sheet.item .sheet-header {
-  border-bottom: 2px solid var(--primary-color);
+  background: var(--bg-surface);
+  border-bottom: 2px solid var(--accent-crimson);
 }
 
 .sheet.item .sheet-header {
@@ -3231,9 +3239,14 @@ select[name="system.aura.color"] option[value="white"] {
   min-width: auto;
   font-size: 1.2em;
   font-weight: bold;
-  border: 1px solid var(--gray-300);
   padding: 4px 8px;
   border-radius: 3px;
+}
+
+.thefade.sheet.item .item-name-dynamic input {
+  background: transparent;
+  color: var(--text-primary);
+  border: 1px solid var(--border-faint);
 }
 
 .sheet.item .item-type-badge {
@@ -3246,6 +3259,147 @@ select[name="system.aura.color"] option[value="white"] {
   color: white;
   text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
   width: 100%;
+  text-align: center;
+}
+
+/* Tab nav */
+.thefade.sheet.item .sheet-tabs {
+  background: var(--bg-surface-deep);
+  border-bottom: 1px solid var(--border-strong);
+}
+
+.thefade.sheet.item .sheet-tabs .item {
+  color: var(--text-muted);
+}
+
+.thefade.sheet.item .sheet-tabs .item.active {
+  color: var(--accent-hot);
+  border-bottom: 2px solid var(--accent-crimson);
+}
+
+/* Sheet body */
+.thefade.sheet.item .sheet-body {
+  background: var(--bg-ink);
+  padding: 10px;
+}
+
+/* Form inputs */
+.thefade.sheet.item input[type="text"],
+.thefade.sheet.item input[type="number"],
+.thefade.sheet.item select,
+.thefade.sheet.item textarea {
+  background: var(--bg-surface-alt);
+  color: var(--text-primary);
+  border: 1px solid var(--border-faint);
+  border-radius: 3px;
+}
+
+.thefade.sheet.item label {
+  color: var(--text-muted);
+}
+
+/* Action buttons */
+.thefade.sheet.item .item-action-btn {
+  display: block;
+  background: var(--accent-crimson);
+  color: var(--text-primary);
+  border: 1px solid var(--accent-hot);
+  border-radius: 4px;
+  padding: 6px 12px;
+  cursor: pointer;
+  width: 100%;
+  margin-top: 8px;
+  text-align: center;
+  font-size: 0.9em;
+  transition: background var(--transition-speed);
+}
+
+.thefade.sheet.item .item-action-btn:hover {
+  background: var(--accent-hot);
+  color: var(--text-primary);
+}
+
+/* Calculated dice bar */
+.thefade.sheet.item .item-calc-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-faint);
+  border-radius: 4px;
+  padding: 6px 10px;
+  margin-bottom: 10px;
+}
+
+.thefade.sheet.item .item-calc-bar .calc-label {
+  color: var(--text-muted);
+  font-size: 0.85em;
+}
+
+.thefade.sheet.item .item-calc-bar .calc-value {
+  color: var(--accent-gold);
+  font-weight: bold;
+  font-size: 1em;
+}
+
+.thefade.sheet.item .item-calc-bar .roll-weapon-attack {
+  margin-left: auto;
+  margin-top: 0;
+  width: auto;
+  padding: 3px 10px;
+}
+
+/* AP controls */
+.thefade.sheet.item .item-ap-controls {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-faint);
+  border-radius: 4px;
+  padding: 8px 10px;
+  margin-bottom: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.thefade.sheet.item .item-ap-controls span {
+  color: var(--text-primary);
+  font-size: 0.95em;
+}
+
+.thefade.sheet.item .item-ap-controls input.ap-current {
+  width: 48px;
+  display: inline;
+  text-align: center;
+  padding: 2px 4px;
+}
+
+/* Consume/use section */
+.thefade.sheet.item .item-use-section {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-faint);
+  border-radius: 4px;
+  padding: 8px 10px;
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.thefade.sheet.item .item-use-section .qty-display {
+  color: var(--text-muted);
+  font-size: 0.85em;
+}
+
+/* Uses tracker */
+.thefade.sheet.item .uses-tracker .uses-pip-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-primary);
+}
+
+.thefade.sheet.item .uses-tracker .uses-pip-row input {
+  width: 48px;
   text-align: center;
 }
 
@@ -3267,7 +3421,7 @@ select[name="system.aura.color"] option[value="white"] {
 
 .thefade.sheet.item .hint {
   font-size: 0.8em;
-  color: var(--secondary-color);
+  color: var(--text-dim);
   margin-top: 2px;
 }
 

--- a/template.json
+++ b/template.json
@@ -310,6 +310,7 @@
       "templates": [ "base" ],
       "prerequisites": "",
       "usesPerDay": 0,
+      "currentUses": 0,
       "associatedPath": ""
     },
     "species": {

--- a/templates/item/armor-sheet.html
+++ b/templates/item/armor-sheet.html
@@ -71,6 +71,12 @@
                 <p class="hint">Body parts the shield automatically protects (e.g., "Arms, Body")</p>
             </div>
             {{/if}}
+
+            <div class="item-ap-controls">
+                <span>AP: <input type="number" name="system.currentAP" value="{{system.currentAP}}" class="ap-current" data-dtype="Number" /> / {{system.ap}}</span>
+                <a class="item-action-btn reduce-ap"><i class="fas fa-shield-alt"></i> Take Hit (−1 AP)</a>
+                <a class="item-action-btn reset-ap"><i class="fas fa-redo"></i> Repair (Reset AP)</a>
+            </div>
         </div>
     </section>
 </form>

--- a/templates/item/drug-sheet.html
+++ b/templates/item/drug-sheet.html
@@ -38,6 +38,10 @@
                 <label>Side Effects:</label>
                 <textarea name="system.sideEffects" rows="3">{{system.sideEffects}}</textarea>
             </div>
+            <div class="item-use-section">
+                {{#if system.quantity}}<span class="qty-display">Qty: {{system.quantity}}</span>{{/if}}
+                <a class="item-action-btn consume-item"><i class="fas fa-flask"></i> Take Drug</a>
+            </div>
         </div>
 
         <div class="tab" data-group="primary" data-tab="attributes">

--- a/templates/item/medical-sheet.html
+++ b/templates/item/medical-sheet.html
@@ -38,6 +38,10 @@
                 <label>Uses:</label>
                 <input type="number" name="system.uses" value="{{system.uses}}" />
             </div>
+            <div class="item-use-section">
+                {{#if system.quantity}}<span class="qty-display">Qty: {{system.quantity}}</span>{{/if}}
+                <a class="item-action-btn consume-item"><i class="fas fa-medkit"></i> Use Medicine</a>
+            </div>
         </div>
 
         <div class="tab" data-group="primary" data-tab="attributes">

--- a/templates/item/poison-sheet.html
+++ b/templates/item/poison-sheet.html
@@ -42,6 +42,10 @@
                 <label>Effect:</label>
                 <textarea name="system.effect" rows="3">{{system.effect}}</textarea>
             </div>
+            <div class="item-use-section">
+                {{#if system.quantity}}<span class="qty-display">Qty: {{system.quantity}}</span>{{/if}}
+                <a class="item-action-btn consume-item"><i class="fas fa-skull-crossbones"></i> Apply Poison</a>
+            </div>
         </div>
 
         <div class="tab" data-group="primary" data-tab="attributes">

--- a/templates/item/potion-sheet.html
+++ b/templates/item/potion-sheet.html
@@ -16,6 +16,10 @@
     <section class="sheet-body">
         <div class="tab" data-group="primary" data-tab="description">
             <textarea name="system.description">{{system.description}}</textarea>
+            <div class="item-use-section">
+                {{#if system.quantity}}<span class="qty-display">Qty: {{system.quantity}}</span>{{/if}}
+                <a class="item-action-btn consume-item"><i class="fas fa-flask"></i> Consume Potion</a>
+            </div>
         </div>
 
         <div class="tab" data-group="primary" data-tab="details">

--- a/templates/item/skill-sheet.html
+++ b/templates/item/skill-sheet.html
@@ -1,45 +1,53 @@
 <form class="{{cssClass}}" autocomplete="off">
     <header class="sheet-header">
-      <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
-      <div class="header-fields">
-        <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h1>
-      </div>
+        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
+        <div class="header-fields">
+            <h1 class="item-name-dynamic"><input name="name" type="text" value="{{item.name}}" placeholder="Name" /></h1>
+            <div class="item-type-badge {{item.type}}">{{item.type}}</div>
+        </div>
     </header>
-  
-    <div class="form-group">
-      <label>Rank</label>
-      <select name="system.rank">
-          {{selectOptions skillRankOptions selected=system.rank}}
-      </select>
-    </div>
-    
-    <div class="form-group">
-      <label>Category</label>
-      <select name="system.category">
-          {{selectOptions skillCategoryOptions selected=system.category}}
-      </select>
-    </div>
-    
-    <div class="form-group">
-      <label>Associated Attribute</label>
-      <select name="system.attribute">
-          {{selectOptions skillAttributeOptions selected=system.attribute}}
-      </select>
-    </div>
 
-    <div class="form-group">
-      <label>Misc Bonus (Extra Dice)</label>
-      <input type="number" name="system.miscBonus" value="{{system.miscBonus}}" data-dtype="Number"/>
-      <p class="hint">Additional dice added to skill rolls</p>
-    </div>
-    
-    <div class="form-group">
-      <label>Description</label>
-      <textarea name="system.description">{{system.description}}</textarea>
-    </div>
-  
-    <div class="form-group">
-      <label>Usage Examples</label>
-      <textarea name="system.usage">{{system.usage}}</textarea>
-    </div>
-  </form>
+    <nav class="sheet-tabs tabs" data-group="primary">
+        <a class="item" data-tab="description">Description</a>
+        <a class="item" data-tab="attributes">Attributes</a>
+    </nav>
+
+    <section class="sheet-body">
+        <div class="tab" data-group="primary" data-tab="description">
+            <div class="form-group">
+                <label>Description</label>
+                <textarea name="system.description">{{system.description}}</textarea>
+            </div>
+            <div class="form-group">
+                <label>Usage Examples</label>
+                <textarea name="system.usage">{{system.usage}}</textarea>
+            </div>
+        </div>
+
+        <div class="tab" data-group="primary" data-tab="attributes">
+            <div class="form-group">
+                <label>Rank</label>
+                <select name="system.rank">
+                    {{selectOptions skillRankOptions selected=system.rank}}
+                </select>
+            </div>
+            <div class="form-group">
+                <label>Category</label>
+                <select name="system.category">
+                    {{selectOptions skillCategoryOptions selected=system.category}}
+                </select>
+            </div>
+            <div class="form-group">
+                <label>Associated Attribute</label>
+                <select name="system.attribute">
+                    {{selectOptions skillAttributeOptions selected=system.attribute}}
+                </select>
+            </div>
+            <div class="form-group">
+                <label>Misc Bonus (Extra Dice)</label>
+                <input type="number" name="system.miscBonus" value="{{system.miscBonus}}" data-dtype="Number" />
+                <p class="hint">Additional dice added to skill rolls</p>
+            </div>
+        </div>
+    </section>
+</form>

--- a/templates/item/spell-sheet.html
+++ b/templates/item/spell-sheet.html
@@ -17,6 +17,7 @@
       {{!-- Description Tab --}}
       <div class="tab" data-group="primary" data-tab="description">
         <textarea name="system.description">{{system.description}}</textarea>
+        <a class="item-action-btn cast-spell"><i class="fas fa-magic"></i> Cast Spell</a>
       </div>
   
       {{!-- Attributes Tab --}}

--- a/templates/item/staff-sheet.html
+++ b/templates/item/staff-sheet.html
@@ -27,6 +27,10 @@
                 <input type="number" name="system.usesPerDay" value="{{system.usesPerDay}}" />
             </div>
             <div class="form-group">
+                <label>Uses Today:</label>
+                <input type="number" name="system.uses" value="{{system.uses}}" min="0" />
+            </div>
+            <div class="form-group">
                 <label>Spell Level:</label>
                 <input type="number" name="system.spellLevel" value="{{system.spellLevel}}" />
             </div>
@@ -37,6 +41,11 @@
             <div class="form-group">
                 <label>Activation:</label>
                 <input type="text" name="system.activation" value="{{system.activation}}" />
+            </div>
+            <div class="item-use-section">
+                <span class="qty-display">Uses: {{system.uses}} / {{system.usesPerDay}}</span>
+                <a class="item-action-btn use-per-day"><i class="fas fa-staff"></i> Use Staff</a>
+                <a class="item-action-btn reset-uses"><i class="fas fa-redo"></i> Reset Uses (New Day)</a>
             </div>
         </div>
 

--- a/templates/item/talent-sheet.html
+++ b/templates/item/talent-sheet.html
@@ -32,4 +32,16 @@
         <input type="number" name="system.usesPerDay" value="{{system.usesPerDay}}" data-dtype="Number" />
         <p class="hint">Leave at 0 for unlimited uses</p>
     </div>
+
+    {{#if system.usesPerDay}}
+    <div class="form-group uses-tracker">
+        <label>Uses Today</label>
+        <div class="uses-pip-row">
+            <input type="number" name="system.currentUses" value="{{system.currentUses}}" min="0" max="{{system.usesPerDay}}" data-dtype="Number" />
+            <span>/ {{system.usesPerDay}}</span>
+        </div>
+    </div>
+    {{/if}}
+
+    <a class="item-action-btn use-talent"><i class="fas fa-star"></i> Use Talent</a>
 </form>

--- a/templates/item/wand-sheet.html
+++ b/templates/item/wand-sheet.html
@@ -42,6 +42,10 @@
                 <label>Activation:</label>
                 <input type="text" name="system.activation" value="{{system.activation}}" />
             </div>
+            <div class="item-use-section">
+                <span class="qty-display">Charges: {{system.charges}}{{#if system.maxCharges}} / {{system.maxCharges}}{{/if}}</span>
+                <a class="item-action-btn charge-use"><i class="fas fa-magic"></i> Use Wand</a>
+            </div>
         </div>
 
         <div class="tab" data-group="primary" data-tab="attributes">

--- a/templates/item/weapon-sheet.html
+++ b/templates/item/weapon-sheet.html
@@ -22,6 +22,13 @@
 
       {{!-- Attributes Tab --}}
       <div class="tab" data-group="primary" data-tab="attributes">
+        {{#if calculatedDice}}
+        <div class="item-calc-bar">
+          <span class="calc-label">Dice Pool:</span>
+          <span class="calc-value">{{calculatedDice}}d10</span>
+          <a class="item-action-btn roll-weapon-attack"><i class="fas fa-dice-d10"></i> Roll Attack</a>
+        </div>
+        {{/if}}
         <div class="item-attr-grid">
 
           <div class="form-group">


### PR DESCRIPTION
## Summary

- **Talents tab background**: The `.talents-counter`, `.paths-info`, and `.spells-learned-counter` sections had a hardcoded `#fafafa` (white) background — replaced with `var(--bg-surface)` to match the system's dark crimson theme
- **Item sheet dark theme**: All item sheets now use the system's dark color variables (`--bg-ink`, `--bg-surface`, `--accent-crimson`, etc.) with a new `.item-action-btn` CSS class for themed action buttons
- **Automation added to item sheets**:
  - **Weapon** — Roll Attack button (visible only when owned by an actor with a matching skill); posts a chat card with damage info and the rolled result
  - **Armor** — Take Hit (−1 AP) and Repair (Reset AP) buttons directly on the item sheet
  - **Consumables** (potion, drug, medical, poison) — type-labelled use/consume/apply buttons; decrements quantity and posts a chat card with effect and duration
  - **Staff** — Use Staff button (tracks uses-per-day, posts chat card) + Reset Uses for new day
  - **Wand** — Use Wand button (decrements charges, posts chat card)
  - **Talent** — Uses-today tracker input + Use Talent button (enforces usesPerDay cap, posts chat card); `currentUses` resets on Daily Rest
  - **Spell** — Cast Spell button posting a formatted chat card with school, damage, range, casting time, and successes needed
- **Skill sheet** — converted from flat fieldset to Description/Attributes tabs matching the rest of the system
- **Data model** — `currentUses: 0` added to the talent template in `template.json`
- **Daily rest** (`actor.js`) — `restDaily()` now resets talent `currentUses` and staff `uses` to 0 alongside sin clearing

## Test plan

- [ ] Open a character sheet — Talents/Paths/Spells counter sections should have a dark background
- [ ] Open any item sheet — verify dark background, crimson header, styled inputs
- [ ] Open a weapon owned by a character — verify dice pool bar and Roll Attack button appear; clicking posts a chat card
- [ ] Open an armor item — Take Hit decrements AP, Repair resets to max
- [ ] Open a potion owned by a character — Consume Potion decrements quantity and posts chat card
- [ ] Repeat for drug (Take Drug), medical (Use Medicine), poison (Apply Poison)
- [ ] Open a staff — Use Staff tracks uses vs. usesPerDay and posts chat card; Reset Uses resets to 0
- [ ] Open a wand — Use Wand decrements charges and posts chat card
- [ ] Open a talent with usesPerDay > 0 — Use Talent increments counter; clicking past max warns; Daily Rest resets to 0
- [ ] Open a spell — Cast Spell posts a chat card with all relevant fields
- [ ] Open a skill item sheet — verify tabbed Description/Attributes layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)