### PR TITLE
Magic weapons/armor, equipment modifications, and item sheet UI fixes

### DIFF
--- a/src/item-sheet.js
+++ b/src/item-sheet.js
@@ -24,8 +24,8 @@ export class TheFadeItemSheet extends ItemSheet {
     static get defaultOptions() {
         return foundry.utils.mergeObject(super.defaultOptions, {
             classes: ["thefade", "sheet", "item", "species"],
-            width: 520,
-            height: 480,
+            width: 600,
+            height: 540,
             tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description" }],
             scrollY: [".sheet-body", ".tab"]
         });

--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -7842,11 +7842,24 @@ select[name="system.aura.color"] option[value="white"] {
 .thefade.sheet.item .item-attr-grid {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 0 14px;
+    gap: 8px 14px;
+}
+
+/* Grid items default to min-width: auto which lets long hints/inputs push the
+   column wider than 1fr and overlap neighboring cells. Clamp to the track. */
+.thefade.sheet.item .item-attr-grid > .form-group {
+    min-width: 0;
 }
 
 .thefade.sheet.item .item-attr-grid .form-group.full-width {
     grid-column: 1 / -1;
+}
+
+/* Hints should wrap inside their cell no matter how narrow the sheet is. */
+.thefade.sheet.item .hint {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    max-width: 100%;
 }
 
 /* Align checkbox groups to the bottom of their grid cell */


### PR DESCRIPTION
## Summary

- Add magic-item support to weapons and armor: Enchantment (with auto-suggested base price per weapon skill / armor type), Strengthening (damage or AP increase with tiered prices), and Enchantment Powers (including a Dark Magic toggle).
- Add Equipment Modifications tab with handedness-/location-based slot budgets and an over-capacity warning.
- Propagate strengthening through every system that reads AP: damage absorption, `currentAP` seeding in `preCreateItem`, armor-reset handlers on all three sheets, derived-AP initialization, and the "reduce AP" dialogs on the character sheet.
- Attack chat card now shows strengthened damage as `effective (base + bonus)` and flags enchanted weapons.
- Fix item sheet UI overflow at narrow widths:
  - Bump default item sheet dimensions to 600×540 so the 4 weapon/armor tabs fit on one line and 2-column grids have breathing room.
  - Clamp grid form-groups with `min-width: 0` so long hint text wraps inside its track instead of pushing into the neighboring cell.
  - Force hints to `overflow-wrap: anywhere` so the layout degrades gracefully.

## Test plan

- [ ] Create a new weapon, toggle Enchanted — confirm price auto-suggests based on skill (Bow/Firearm/Heavy = base 4000/6000/6000, else 2500) and shows the radiation-immunity note for ranged.
- [ ] Set Strengthening on a weapon — confirm damage display updates to `effective (base + bonus)` on the attack chat card.
- [ ] Set Strengthening on an armor piece — confirm max AP includes the increase on the character sheet, NPC sheet, reset handlers, and derived-AP fallback.
- [ ] Add / remove Enchantment Powers and Modifications; confirm the mod slots bar turns red when over capacity (based on handedness for weapons, location for armor).
- [ ] Open weapon and armor sheets at default width — confirm all 4 tabs fit on one line and hints don't overlap adjacent grid columns.

https://claude.ai/code/session_01XrN4XT4s7mpUnqx98h2gZA