### PR TITLE
Fix character sheet: skill dice, species ability edit, initiative cutoff

### DIFF
--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -3774,6 +3774,49 @@ export class TheFadeCharacterSheet extends ActorSheet {
             this._onSpeciesAbilityEdit(abilityId);
         });
 
+        // Inline define edit handler so we don't need a separate method binding
+        this._onSpeciesAbilityEdit = async (abilityId) => {
+            const abilities = foundry.utils.deepClone(this.actor.system.species?.speciesAbilities || {});
+            const ability = abilities[abilityId];
+            if (!ability) return;
+
+            const escapeHtml = (s) => String(s ?? "")
+                .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+                .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+
+            const content = `
+                <form>
+                    <div class="form-group">
+                        <label>Name</label>
+                        <input type="text" name="name" value="${escapeHtml(ability.name)}" />
+                    </div>
+                    <div class="form-group">
+                        <label>Description</label>
+                        <textarea name="description" rows="6">${escapeHtml(ability.description)}</textarea>
+                    </div>
+                </form>
+            `;
+
+            new Dialog({
+                title: "Edit Species Ability",
+                content,
+                buttons: {
+                    save: {
+                        label: "Save",
+                        callback: async (html) => {
+                            const name = html.find('[name="name"]').val()?.trim() || "Unnamed";
+                            const description = html.find('[name="description"]').val() || "";
+                            await this.actor.update({
+                                [`system.species.speciesAbilities.${abilityId}`]: { name, description }
+                            });
+                        }
+                    },
+                    cancel: { label: "Cancel" }
+                },
+                default: "save"
+            }).render(true);
+        };
+
         html.find('.species-ability-delete').click(async (event) => {
             event.preventDefault();
 

--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -6099,7 +6099,7 @@ select[name="system.aura.color"] option[value="white"] {
 /* ----- Vitals strip (HP / Sanity / Initiative) ----- */
 .thefade .vitals-strip {
     display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
     gap: 10px;
 }
 
@@ -6108,6 +6108,8 @@ select[name="system.aura.color"] option[value="white"] {
     align-items: center;
     gap: 8px;
     padding: 8px 12px;
+    min-width: 0;
+    overflow: hidden;
     background: var(--bg-surface-deep);
     border: 1px solid var(--border-faint);
     border-left: 3px solid var(--accent-crimson);
@@ -6164,7 +6166,8 @@ select[name="system.aura.color"] option[value="white"] {
 }
 
 .thefade .vital-pill .vital-values input {
-    width: 42px;
+    width: 38px;
+    min-width: 0;
     text-align: center;
     padding: 3px;
     font-size: 1.05em;

--- a/templates/actor/parts/skills.html
+++ b/templates/actor/parts/skills.html
@@ -45,7 +45,7 @@
             <div class="skill-bonus">
                 <input type="number" name="system.miscBonus" value="{{skill.system.miscBonus}}" data-dtype="Number" data-item-id="{{skill._id}}" class="small-input" />
             </div>
-            <div class="skill-total">{{skill._calculatedDice}}d12</div>
+            <div class="skill-total">{{skill.calculatedDice}}d12</div>
             <div class="skill-controls">
                 <a class="skill-roll" title="Roll Skill"><i class="fas fa-dice-d12"></i></a>
                 <a class="item-edit" title="Edit Skill"><i class="fas fa-edit"></i></a>
@@ -79,7 +79,7 @@
             <div class="skill-bonus">
                 <input type="number" name="system.miscBonus" value="{{skill.system.miscBonus}}" data-dtype="Number" data-item-id="{{skill._id}}" class="small-input" />
             </div>
-            <div class="skill-total">{{skill._calculatedDice}}d12</div>
+            <div class="skill-total">{{skill.calculatedDice}}d12</div>
             <div class="skill-controls">
                 <a class="skill-roll" title="Roll Skill"><i class="fas fa-dice-d12"></i></a>
                 <a class="item-edit" title="Edit Skill"><i class="fas fa-edit"></i></a>
@@ -113,7 +113,7 @@
             <div class="skill-bonus">
                 <input type="number" name="system.miscBonus" value="{{skill.system.miscBonus}}" data-dtype="Number" data-item-id="{{skill._id}}" class="small-input" />
             </div>
-            <div class="skill-total">{{skill._calculatedDice}}d12</div>
+            <div class="skill-total">{{skill.calculatedDice}}d12</div>
             <div class="skill-controls">
                 <a class="skill-roll" title="Roll Skill"><i class="fas fa-dice-d12"></i></a>
                 <a class="item-edit" title="Edit Skill"><i class="fas fa-edit"></i></a>
@@ -147,7 +147,7 @@
             <div class="skill-bonus">
                 <input type="number" name="system.miscBonus" value="{{skill.system.miscBonus}}" data-dtype="Number" data-item-id="{{skill._id}}" class="small-input" />
             </div>
-            <div class="skill-total">{{skill._calculatedDice}}d12</div>
+            <div class="skill-total">{{skill.calculatedDice}}d12</div>
             <div class="skill-controls">
                 <a class="skill-roll" title="Roll Skill"><i class="fas fa-dice-d12"></i></a>
                 <a class="item-edit" title="Edit Skill"><i class="fas fa-edit"></i></a>
@@ -181,7 +181,7 @@
             <div class="skill-bonus">
                 <input type="number" name="system.miscBonus" value="{{skill.system.miscBonus}}" data-dtype="Number" data-item-id="{{skill._id}}" class="small-input" />
             </div>
-            <div class="skill-total">{{skill._calculatedDice}}d12</div>
+            <div class="skill-total">{{skill.calculatedDice}}d12</div>
             <div class="skill-controls">
                 <a class="skill-roll" title="Roll Skill"><i class="fas fa-dice-d12"></i></a>
                 <a class="item-edit" title="Edit Skill"><i class="fas fa-edit"></i></a>
@@ -215,7 +215,7 @@
             <div class="skill-bonus">
                 <input type="number" name="system.miscBonus" value="{{skill.system.miscBonus}}" data-dtype="Number" data-item-id="{{skill._id}}" class="small-input" />
             </div>
-            <div class="skill-total">{{skill._calculatedDice}}d12</div>
+            <div class="skill-total">{{skill.calculatedDice}}d12</div>
             <div class="skill-controls">
                 <a class="skill-roll" title="Roll Skill"><i class="fas fa-dice-d12"></i></a>
                 <a class="item-edit" title="Edit Skill"><i class="fas fa-edit"></i></a>
@@ -249,7 +249,7 @@
             <div class="skill-bonus">
                 <input type="number" name="system.miscBonus" value="{{skill.system.miscBonus}}" data-dtype="Number" data-item-id="{{skill._id}}" class="small-input" />
             </div>
-            <div class="skill-total">{{skill._calculatedDice}}d12</div>
+            <div class="skill-total">{{skill.calculatedDice}}d12</div>
             <div class="skill-controls">
                 <a class="skill-roll" title="Roll Skill"><i class="fas fa-dice-d12"></i></a>
                 <a class="item-edit" title="Edit Skill"><i class="fas fa-edit"></i></a>


### PR DESCRIPTION
## Summary
- Restore `skill.calculatedDice` in the skills template — commit 043287e renamed it to `_calculatedDice`, which left the dice total blank (shown as just "d12") for every skill row.
- Implement the missing `_onSpeciesAbilityEdit` handler. Clicking the edit pencil on a species ability under Stats & Info was throwing `TypeError: this._onSpeciesAbilityEdit is not a function`. Now opens a Dialog with name + description fields and writes back to `system.species.speciesAbilities.<id>`.
- Fix the Initiative vital pill being clipped off the right edge of the header. The `.vitals-strip` grid used `1fr 1fr 1fr` without `min-width: 0`, so the HP pill (badge + take-rest button) pushed the third column off-screen at the default 800px sheet width. Switched to `minmax(0, 1fr)`, added `min-width: 0; overflow: hidden` to `.vital-pill`, and shrank vital input width from 42px → 38px.

## Not addressed
The user also reported a header flicker on every change. No definitive cause found from static analysis — there are no `actor.update()` calls inside `prepareData`/`_prepareCharacterData` that would loop. Most likely Foundry's normal full-sheet re-render is just visually heavy because of the gradient header + image. Needs runtime debugging (count `_render` calls per change, check Active Effect reapplication).

## Test plan
- [ ] Skills tab — confirm each skill row shows e.g. "5d12" instead of "d12"
- [ ] Stats & Info → Abilities — click edit pencil, dialog opens, save persists name + description
- [ ] Open a character sheet at default 800px width — Initiative pill is fully visible
- [ ] Verify HP/Sanity/Initiative pills still readable and inputs editable

🤖 Generated with [Claude Code](https://claude.com/claude-code)