### PR TITLE
Add Token Action HUD integration

### DIFF
--- a/src/integrations/token-action-hud/action-handler.js
+++ b/src/integrations/token-action-hud/action-handler.js
@@ -1,0 +1,182 @@
+// Builds Token Action HUD actions from a selected The Fade actor.
+import { ACTION_TYPE, ATTRIBUTES, GROUP } from "./constants.js";
+
+export function makeActionHandler(coreApi) {
+    return class TheFadeActionHandler extends coreApi.ActionHandler {
+        async buildSystemActions(_groupIds) {
+            const actor = this.actor;
+            if (!actor) return;
+            const type = actor.type;
+            if (!["character", "npc"].includes(type)) return;
+
+            this._buildAttributes(actor);
+            this._buildWeapons(actor);
+            this._buildUtility(actor);
+
+            if (type === "character") {
+                this._buildSkills(actor);
+                this._buildSpells(actor);
+                this._buildTalents(actor);
+            }
+
+            this._buildInventory(actor);
+        }
+
+        _enc(actionType, id) {
+            return [actionType, id].join(this.delimiter ?? "|");
+        }
+
+        _push(groupId, actions) {
+            if (!actions.length) return;
+            this.addActions(actions, { id: groupId, type: "system" });
+        }
+
+        _buildAttributes(actor) {
+            const attrs = actor.system?.attributes ?? {};
+            const actions = ATTRIBUTES
+                .filter(a => attrs[a])
+                .map(a => {
+                    const v = attrs[a]?.value ?? 0;
+                    return {
+                        id: `attribute-${a}`,
+                        name: `${a[0].toUpperCase()}${a.slice(1)}`,
+                        encodedValue: this._enc(ACTION_TYPE.attribute, a),
+                        info1: { text: `${v}d12` }
+                    };
+                });
+            this._push(GROUP.attributes.id, actions);
+        }
+
+        _buildSkills(actor) {
+            const buckets = {
+                "Combat":   GROUP.skillsCombat.id,
+                "Physical": GROUP.skillsPhys.id,
+                "Mental":   GROUP.skillsMental.id,
+                "Social":   GROUP.skillsSocial.id,
+                "Magical":  GROUP.skillsMagic.id
+            };
+            const grouped = {};
+            for (const skill of actor.items.filter(i => i.type === "skill")) {
+                const bucket = buckets[skill.system?.category] || GROUP.skillsOther.id;
+                (grouped[bucket] ??= []).push({
+                    id: `skill-${skill.id}`,
+                    name: skill.name,
+                    encodedValue: this._enc(ACTION_TYPE.skill, skill.id),
+                    info1: { text: this._rankAbbr(skill.system?.rank) }
+                });
+            }
+            for (const [groupId, actions] of Object.entries(grouped)) {
+                actions.sort((a, b) => a.name.localeCompare(b.name));
+                this._push(groupId, actions);
+            }
+        }
+
+        _rankAbbr(rank) {
+            const map = {
+                untrained: "U", practiced: "P", adept: "A",
+                experienced: "E", expert: "Ex", mastered: "M"
+            };
+            return map[rank] ?? "";
+        }
+
+        _buildWeapons(actor) {
+            const weapons = actor.items.filter(i => i.type === "weapon");
+            const actions = weapons.map(w => ({
+                id: `weapon-${w.id}`,
+                name: w.name,
+                encodedValue: this._enc(ACTION_TYPE.weapon, w.id),
+                img: w.img,
+                info1: { text: w.system?.range || "" },
+                info2: { text: w.system?.damage ? `${w.system.damage} ${w.system.damageType || ""}`.trim() : "" }
+            }));
+            this._push(GROUP.weapons.id, actions);
+        }
+
+        _buildSpells(actor) {
+            const spells = actor.items.filter(i => i.type === "spell");
+            const actions = spells.map(s => ({
+                id: `spell-${s.id}`,
+                name: s.name,
+                encodedValue: this._enc(ACTION_TYPE.spell, s.id),
+                img: s.img,
+                info1: { text: s.system?.school || "" },
+                info2: { text: s.system?.successes ? `DT ${s.system.successes}` : "" }
+            }));
+            actions.sort((a, b) => a.name.localeCompare(b.name));
+            this._push(GROUP.spells.id, actions);
+        }
+
+        _buildTalents(actor) {
+            const talents = actor.items.filter(i => i.type === "talent");
+            const actions = talents.map(t => {
+                const used = Number(t.system?.currentUses ?? 0);
+                const max = Number(t.system?.usesPerDay ?? 0);
+                const uses = max > 0 ? `${Math.max(0, max - used)}/${max}` : "";
+                return {
+                    id: `talent-${t.id}`,
+                    name: t.name,
+                    encodedValue: this._enc(ACTION_TYPE.talent, t.id),
+                    img: t.img,
+                    info1: { text: uses }
+                };
+            });
+            actions.sort((a, b) => a.name.localeCompare(b.name));
+            this._push(GROUP.talents.id, actions);
+        }
+
+        _buildInventory(actor) {
+            const skip = new Set([
+                "weapon", "armor", "skill", "path", "spell", "talent",
+                "trait", "precept", "species"
+            ]);
+            const items = actor.items.filter(i => !skip.has(i.type));
+            const actions = items.map(i => {
+                const qty = Number(i.system?.quantity ?? 0);
+                return {
+                    id: `item-${i.id}`,
+                    name: i.name,
+                    encodedValue: this._enc(ACTION_TYPE.item, i.id),
+                    img: i.img,
+                    info1: { text: qty > 1 ? `×${qty}` : "" }
+                };
+            });
+            actions.sort((a, b) => a.name.localeCompare(b.name));
+            this._push(GROUP.inventory.id, actions);
+        }
+
+        _buildUtility(actor) {
+            const actions = [
+                {
+                    id: "utility-initiative",
+                    name: "Initiative",
+                    encodedValue: this._enc(ACTION_TYPE.utility, "initiative")
+                },
+                {
+                    id: "utility-sheet",
+                    name: "Open Sheet",
+                    encodedValue: this._enc(ACTION_TYPE.utility, "sheet")
+                }
+            ];
+            if (actor.type === "character") {
+                actions.push(
+                    {
+                        id: "utility-opposed",
+                        name: "Opposed Roll",
+                        encodedValue: this._enc(ACTION_TYPE.utility, "opposed")
+                    },
+                    {
+                        id: "utility-aid",
+                        name: "Aid Another",
+                        encodedValue: this._enc(ACTION_TYPE.utility, "aid")
+                    },
+                    {
+                        id: "utility-rest",
+                        name: "Take Rest",
+                        encodedValue: this._enc(ACTION_TYPE.utility, "rest")
+                    }
+                );
+            }
+            this._push(GROUP.utility.id, actions);
+        }
+    };
+}

--- a/src/integrations/token-action-hud/constants.js
+++ b/src/integrations/token-action-hud/constants.js
@@ -1,0 +1,34 @@
+// Constants for The Fade Token Action HUD integration.
+export const MODULE = {
+    ID: "thefade-token-action-hud",
+    NAME: "The Fade — Token Action HUD"
+};
+
+export const REQUIRED_CORE_MODULE_VERSION = "2.1";
+
+export const ACTION_TYPE = {
+    attribute: "attribute",
+    skill: "skill",
+    weapon: "weapon",
+    spell: "spell",
+    talent: "talent",
+    item: "item",
+    utility: "utility"
+};
+
+export const GROUP = {
+    attributes:  { id: "attributes",  name: "Attributes",  type: "system" },
+    skillsCombat:{ id: "skills-combat", name: "Skills · Combat", type: "system" },
+    skillsPhys:  { id: "skills-physical", name: "Skills · Physical", type: "system" },
+    skillsMental:{ id: "skills-mental", name: "Skills · Mental", type: "system" },
+    skillsSocial:{ id: "skills-social", name: "Skills · Social", type: "system" },
+    skillsMagic: { id: "skills-magical", name: "Skills · Magical", type: "system" },
+    skillsOther: { id: "skills-other", name: "Skills · Other", type: "system" },
+    weapons:     { id: "weapons",     name: "Weapons",     type: "system" },
+    spells:      { id: "spells",      name: "Spells",      type: "system" },
+    talents:     { id: "talents",     name: "Talents",     type: "system" },
+    inventory:   { id: "inventory",   name: "Inventory",   type: "system" },
+    utility:     { id: "utility",     name: "Utility",     type: "system" }
+};
+
+export const ATTRIBUTES = ["physique", "finesse", "mind", "presence", "soul"];

--- a/src/integrations/token-action-hud/defaults.js
+++ b/src/integrations/token-action-hud/defaults.js
@@ -1,0 +1,33 @@
+// Default category/group layout for The Fade in Token Action HUD.
+import { GROUP } from "./constants.js";
+
+export function buildDefaults() {
+    const groups = Object.values(GROUP).map(g => ({ ...g, listName: g.name }));
+    const groupsById = Object.fromEntries(groups.map(g => [g.id, g]));
+
+    const cat = (id, name, groupIds) => ({
+        nestId: id,
+        id,
+        name,
+        groups: groupIds.map(gid => ({
+            ...groupsById[gid],
+            nestId: `${id}_${gid}`
+        }))
+    });
+
+    return {
+        layout: [
+            cat("attributes", "Attributes", ["attributes"]),
+            cat("skills",     "Skills",     [
+                "skills-combat", "skills-physical", "skills-mental",
+                "skills-social", "skills-magical", "skills-other"
+            ]),
+            cat("combat",     "Combat",     ["weapons"]),
+            cat("magic",      "Magic",      ["spells"]),
+            cat("talents",    "Talents",    ["talents"]),
+            cat("inventory",  "Inventory",  ["inventory"]),
+            cat("utility",    "Utility",    ["utility"])
+        ],
+        groups
+    };
+}

--- a/src/integrations/token-action-hud/index.js
+++ b/src/integrations/token-action-hud/index.js
@@ -1,0 +1,40 @@
+// Entry point for The Fade's Token Action HUD integration.
+// Listens for TAH Core's API hook and registers a SystemManager so Core treats
+// The Fade as if it had a companion module, even though the integration lives
+// inside the system itself.
+import { MODULE, REQUIRED_CORE_MODULE_VERSION } from "./constants.js";
+import { buildDefaults } from "./defaults.js";
+import { makeActionHandler } from "./action-handler.js";
+import { makeRollHandler } from "./roll-handler.js";
+
+export function registerTokenActionHud() {
+    Hooks.on("tokenActionHudCoreApiReady", (coreModule) => {
+        const coreApi = coreModule?.api;
+        if (!coreApi?.SystemManager) return;
+
+        const ActionHandler = makeActionHandler(coreApi);
+        const RollHandler = makeRollHandler(coreApi);
+
+        class TheFadeSystemManager extends coreApi.SystemManager {
+            getActionHandler() { return new ActionHandler(); }
+
+            getAvailableRollHandlers() {
+                return { core: "The Fade" };
+            }
+
+            getRollHandler(_id) { return new RollHandler(); }
+
+            async registerDefaults() { return buildDefaults(); }
+        }
+
+        // Hand the SystemManager to TAH Core. Core listens on this hook and
+        // calls `new api.SystemManager(coreModuleId)` once it sees us.
+        Hooks.callAll("tokenActionHudSystemReady", {
+            id: MODULE.ID,
+            api: {
+                SystemManager: TheFadeSystemManager,
+                requiredCoreModuleVersion: REQUIRED_CORE_MODULE_VERSION
+            }
+        });
+    });
+}

--- a/src/integrations/token-action-hud/roll-handler.js
+++ b/src/integrations/token-action-hud/roll-handler.js
@@ -1,0 +1,142 @@
+// Dispatches Token Action HUD action clicks for The Fade.
+import { ACTION_TYPE } from "./constants.js";
+import { openOpposedRollDialog, openAidAnotherDialog } from "../../opposed.js";
+
+export function makeRollHandler(coreApi) {
+    return class TheFadeRollHandler extends coreApi.RollHandler {
+        async handleActionClick(event, encodedValue) {
+            const [actionType, id] = encodedValue.split(this.delimiter ?? "|");
+            const actor = this.actor;
+            if (!actor) return;
+
+            switch (actionType) {
+                case ACTION_TYPE.attribute: return this._rollAttribute(actor, id);
+                case ACTION_TYPE.skill:     return this._rollSkill(actor, id, event);
+                case ACTION_TYPE.weapon:    return this._rollWeapon(actor, id, event);
+                case ACTION_TYPE.spell:     return this._openItem(actor, id);
+                case ACTION_TYPE.talent:    return this._useTalent(actor, id, event);
+                case ACTION_TYPE.item:      return this._openItem(actor, id);
+                case ACTION_TYPE.utility:   return this._utility(actor, id);
+            }
+        }
+
+        // Mirrors npc-sheet/character-sheet attribute roll logic without sheet UI.
+        async _rollAttribute(actor, attribute) {
+            const value = actor.system?.attributes?.[attribute]?.value || 0;
+            const dice = Math.max(1, value);
+            const roll = await new Roll(`${dice}d12`).evaluate();
+            let successes = 0;
+            for (const die of roll.terms[0].results) {
+                if (die.result >= 12) successes += 2;
+                else if (die.result >= 8) successes += 1;
+            }
+            const name = attribute.charAt(0).toUpperCase() + attribute.slice(1);
+            return roll.toMessage({
+                speaker: ChatMessage.getSpeaker({ actor }),
+                flavor: `${name} Check`,
+                content: `<p>${actor.name} rolled ${dice}d12.</p><p>Successes: ${successes}</p>`
+            });
+        }
+
+        async _rollSkill(actor, skillId, event) {
+            // Defer to the character sheet's existing handler so DT prompt &
+            // condition modifiers stay consistent.
+            const sheet = actor.sheet;
+            if (sheet?._onSkillRoll) {
+                const fakeEvent = this._fakeItemEvent(event, skillId);
+                return sheet._onSkillRoll(fakeEvent);
+            }
+            // NPC fallback: roll skill's attribute pool directly.
+            const skill = actor.items.get(skillId);
+            if (!skill) return;
+            return this._rollAttribute(actor, skill.system?.attribute || "physique");
+        }
+
+        async _rollWeapon(actor, weaponId, event) {
+            const sheet = actor.sheet;
+            if (sheet?._onAttackRoll) {
+                const fakeEvent = this._fakeItemEvent(event, weaponId);
+                return sheet._onAttackRoll(fakeEvent);
+            }
+            // NPC: simple attribute/2 d12 roll, mirrors npc-sheet inline.
+            const weapon = actor.items.get(weaponId);
+            if (!weapon) return;
+            const attr = weapon.system?.attribute || "physique";
+            const attrVal = actor.system?.attributes?.[attr]?.value || 1;
+            const dice = Math.max(1, Math.floor(attrVal / 2) + (weapon.system?.miscBonus || 0));
+            const roll = await new Roll(`${dice}d12`).evaluate();
+            return roll.toMessage({
+                speaker: ChatMessage.getSpeaker({ actor }),
+                flavor: `${actor.name} attacks with ${weapon.name} (${dice}d12)`
+            });
+        }
+
+        async _useTalent(actor, talentId, event) {
+            const talent = actor.items.get(talentId);
+            if (!talent) return;
+            const max = Number(talent.system?.usesPerDay ?? 0);
+            // Right-click opens sheet; left-click decrements uses if it's a daily.
+            if (this.isRightClick(event) || max <= 0) return talent.sheet.render(true);
+
+            const used = Number(talent.system?.currentUses ?? 0);
+            if (used >= max) {
+                ui.notifications.warn(`${talent.name}: no uses remaining today.`);
+                return;
+            }
+            await talent.update({ "system.currentUses": used + 1 });
+            return ChatMessage.create({
+                speaker: ChatMessage.getSpeaker({ actor }),
+                content: `<p><strong>${actor.name}</strong> uses <strong>${talent.name}</strong>.</p>` +
+                    `<p>Uses remaining: ${Math.max(0, max - (used + 1))}/${max}</p>` +
+                    (talent.system?.description ? `<hr>${talent.system.description}` : "")
+            });
+        }
+
+        async _openItem(actor, itemId) {
+            const item = actor.items.get(itemId);
+            return item?.sheet.render(true);
+        }
+
+        async _utility(actor, id) {
+            switch (id) {
+                case "sheet":      return actor.sheet.render(true);
+                case "opposed":    return openOpposedRollDialog(actor);
+                case "aid":        return openAidAnotherDialog(actor);
+                case "rest":       return actor.takeRest?.();
+                case "initiative": return this._rollInitiative(actor);
+            }
+        }
+
+        async _rollInitiative(actor) {
+            const fin = actor.system?.attributes?.finesse?.value || 0;
+            const mnd = actor.system?.attributes?.mind?.value || 0;
+            const bonus = Math.floor((fin + mnd) / 2) + (actor.system?.initiativeBonus || 0);
+            const roll = await new Roll(`1d12 + ${bonus}`).evaluate();
+            if (game.combat) {
+                const combatant = game.combat.combatants.find(c => c.actorId === actor.id);
+                if (combatant) await game.combat.setInitiative(combatant.id, roll.total);
+            }
+            return roll.toMessage({
+                speaker: ChatMessage.getSpeaker({ actor }),
+                flavor: `${actor.name} rolls Initiative!`
+            });
+        }
+
+        isRightClick(event) {
+            return event?.type === "contextmenu" || event?.button === 2;
+        }
+
+        _fakeItemEvent(event, itemId) {
+            return {
+                preventDefault: () => {},
+                stopPropagation: () => {},
+                type: event?.type ?? "click",
+                button: event?.button ?? 0,
+                currentTarget: {
+                    dataset: {},
+                    closest: (sel) => sel === ".item" ? { dataset: { itemId } } : null
+                }
+            };
+        }
+    };
+}

--- a/thefade.js
+++ b/thefade.js
@@ -15,6 +15,9 @@ import { TheFadePartySheet } from './src/party-sheet.js';
 import { TheFadeShopSheet } from './src/shop-sheet.js';
 import { computePerRoundDamage, CONDITION_EFFECTS } from './src/conditions.js';
 import './src/token-facing.js';
+import { registerTokenActionHud } from './src/integrations/token-action-hud/index.js';
+
+registerTokenActionHud();
 
 
 /**


### PR DESCRIPTION
## Summary
- Bundles a Token Action HUD Core companion inside the system at `src/integrations/token-action-hud/`, so the HUD works against The Fade actors with no separate Foundry module needed.
- Registers a `SystemManager` via the `tokenActionHudSystemReady` hook once Core's API hook fires; exposes attributes, skills (bucketed by category), weapons, spells, talents (with daily-uses tracking), inventory, and utility actions (initiative, opposed roll, aid another, take rest, open sheet).
- Skill and weapon clicks delegate to the existing character-sheet handlers via a synthesized event, so DT prompts, target selection, and condition modifiers stay consistent. NPCs use simpler inline rolls matching `npc-sheet.js`.

## Why
Players asked for one-click rolls from a selected token. Rather than maintain a separate `token-action-hud-thefade` module, the integration lives inside the system and self-registers via TAH's public hooks.

## Files
- `src/integrations/token-action-hud/index.js` — entry; listens for `tokenActionHudCoreApiReady`, hands Core a `SystemManager`.
- `src/integrations/token-action-hud/action-handler.js` — discovers actions on the selected actor.
- `src/integrations/token-action-hud/roll-handler.js` — dispatches clicks; reuses sheet handlers where possible.
- `src/integrations/token-action-hud/defaults.js` — default category/group layout.
- `src/integrations/token-action-hud/constants.js` — group definitions and required Core version (`2.1`).
- `thefade.js` — wires `registerTokenActionHud()` at module load.

## Notes for reviewers
- Requires TAH Core ≥ 2.1 and the `socketlib` module that TAH already requires. If neither is installed, the hook never fires and the system behaves unchanged.
- I haven't been able to launch Foundry from this environment to smoke-test. Worth a manual pass: select a character token, confirm attribute / skill / weapon / talent buttons appear and trigger the right rolls; repeat for an NPC.
- Talent left-click decrements `currentUses` and posts to chat; right-click opens the talent sheet. Spells/items currently open their sheets — dedicated cast/use logic can be layered on later.

## Test plan
- [ ] Load a world with TAH Core + socketlib enabled; confirm no console errors at startup.
- [ ] Select a character token and verify Attributes, Skills (each category), Weapons, Spells, Talents, Inventory, Utility groups populate.
- [ ] Click an attribute → roll posts to chat with success count.
- [ ] Click a skill → DT dialog appears, roll posts with condition-modifier banner if applicable.
- [ ] Click a weapon → target/DT dialog appears, attack roll posts.
- [ ] Click a daily-use talent → `currentUses` increments and a chat message posts; second click when at max warns and does nothing.
- [ ] Right-click a talent → talent sheet opens.
- [ ] Select an NPC token and verify Attributes, Weapons, Utility populate; weapon click rolls attack.
- [ ] Confirm Initiative utility sets initiative on the active combatant when a combat is running.