### PR TITLE
Lower TAH Core required version to 2.0

### DIFF
--- a/src/integrations/token-action-hud/constants.js
+++ b/src/integrations/token-action-hud/constants.js
@@ -4,7 +4,7 @@ export const MODULE = {
     NAME: "The Fade — Token Action HUD"
 };
 
-export const REQUIRED_CORE_MODULE_VERSION = "2.1";
+export const REQUIRED_CORE_MODULE_VERSION = "2.0";
 
 export const ACTION_TYPE = {
     attribute: "attribute",


### PR DESCRIPTION
## Summary
- Token Action HUD integration was declaring `requiredCoreModuleVersion: \"2.1\"`, which caused Foundry to refuse to load it against the currently-installed TAH Core 2.0.16.
- Lowered the requirement to `2.0` since the API surface used by this integration (`SystemManager`, `ActionHandler`, `addActions`, `registerDefaults`) is the same in 2.0.x.

## Test plan
- [ ] Reload Foundry with TAH Core 2.0.16 installed and confirm the compatibility error no longer appears.
- [ ] Open a character/NPC and verify the HUD populates attributes, skills, weapons, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)