### PR TITLE
Support multi-type weapon damage on item sheet

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -81,9 +81,36 @@ export const SKILL_RANK_OPTIONS = {
 
 export const BODY_PARTS = ["head", "body", "leftarm", "rightarm", "leftleg", "rightleg"];
 
+/**
+ * Pretty-print labels for weapon damage type codes. Used by the item sheet
+ * to render the typed Effective Damage breakdown (e.g. "3 Fire + 3 Bludgeoning").
+ * Keep in sync with weaponDamageTypeOptions in item-sheet.js.
+ */
+export const DAMAGE_TYPE_LABELS = {
+    "B": "Bludgeoning",
+    "S": "Slashing",
+    "P": "Piercing",
+    "BoP": "Bludgeoning or Piercing",
+    "BP": "Bludgeoning & Piercing",
+    "SP": "Slashing & Piercing",
+    "SoP": "Slashing or Piercing",
+    "SoB": "Slashing or Bludgeoning",
+    "F": "Fire",
+    "C": "Cold",
+    "A": "Acid",
+    "E": "Electricity",
+    "So": "Sonic",
+    "Sm": "Smiting",
+    "Ex": "Expel",
+    "Psi": "Psychokinetic",
+    "Co": "Corruption",
+    "Ut": "Untyped"
+};
+
 export const DEFAULT_WEAPON = {
     damage: 0,
     damageType: "S",
+    damageComponents: [],
     critical: 4,
     handedness: "One-Handed",
     range: "Melee",

--- a/src/item-sheet.js
+++ b/src/item-sheet.js
@@ -8,7 +8,8 @@ import {
     WEAPON_STRENGTHENING_OPTIONS,
     ARMOR_STRENGTHENING_OPTIONS,
     WEAPON_MOD_SLOTS,
-    ARMOR_MOD_SLOTS
+    ARMOR_MOD_SLOTS,
+    DAMAGE_TYPE_LABELS
 } from './constants.js';
 import { getRankValue, openCompendiumBrowser } from './helpers.js';
 
@@ -334,9 +335,73 @@ export class TheFadeItemSheet extends ItemSheet {
             // Magic + modification data for weapons
             if (this.item?.type === 'weapon') {
                 const sys = this.item.system;
-                const baseDamage = Number(sys.damage) || 0;
                 const dmgInc = Number(sys.damageIncrease) || 0;
-                data.effectiveDamage = baseDamage + dmgInc;
+
+                // Lazy persistent migration: if a legacy weapon has damage/damageType
+                // but no damageComponents, persist a single component on first sheet
+                // open. prepareData has already hydrated the in-memory array, so we
+                // just check whether the persisted source still lacks it.
+                const sourceComponents = this.item._source?.system?.damageComponents;
+                const sourceDamage = Number(this.item._source?.system?.damage) || 0;
+                if (
+                    !this._migratedDamageComponents &&
+                    Array.isArray(sourceComponents) &&
+                    sourceComponents.length === 0 &&
+                    sourceDamage > 0
+                ) {
+                    this._migratedDamageComponents = true;
+                    const migrated = [{
+                        id: foundry.utils.randomID(16),
+                        amount: sourceDamage,
+                        type: this.item._source.system.damageType || "Ut"
+                    }];
+                    this.item.update({ "system.damageComponents": migrated });
+                }
+
+                const components = Array.isArray(sys.damageComponents) ? sys.damageComponents : [];
+                data.weaponDamageComponents = components.map(c => ({
+                    id: c.id,
+                    amount: c.amount,
+                    type: c.type
+                }));
+
+                // Damage attribute bonus from the parent actor, mirroring the
+                // logic in character-sheet.js attack rolls (Agile/Brutish/attribute).
+                let attrBonus = 0;
+                let attrLabel = "";
+                if (this.item.parent?.system?.attributes) {
+                    const attrs = this.item.parent.system.attributes;
+                    const qualities = sys.qualities || "";
+                    if (qualities.includes("Agile") && attrs.finesse) {
+                        attrBonus = Math.floor((attrs.finesse.value || 0) / 2);
+                        attrLabel = "Finesse";
+                    } else if (qualities.includes("Brutish") && attrs.physique) {
+                        attrBonus = Math.floor((attrs.physique.value || 0) / 2);
+                        attrLabel = "Physique";
+                    } else if (sys.attribute && sys.attribute !== "none" && attrs[sys.attribute]) {
+                        attrBonus = Math.floor((attrs[sys.attribute].value || 0) / 2);
+                        attrLabel = sys.attribute.charAt(0).toUpperCase() + sys.attribute.slice(1);
+                    }
+                }
+
+                // Build the typed breakdown: "3 Fire + 3 Bludgeoning + 2 + 4"
+                const parts = [];
+                let typedTotal = 0;
+                for (const c of components) {
+                    const amt = Number(c.amount) || 0;
+                    if (amt <= 0) continue;
+                    typedTotal += amt;
+                    const label = DAMAGE_TYPE_LABELS[c.type] || c.type || "Untyped";
+                    parts.push(`${amt} ${label}`);
+                }
+                if (dmgInc > 0) parts.push(`${dmgInc}`);
+                if (attrBonus > 0) parts.push(`${attrBonus}`);
+
+                data.effectiveDamage = typedTotal + dmgInc + attrBonus;
+                data.effectiveDamageBreakdown = parts.length > 1 ? parts.join(" + ") : null;
+                data.weaponAttrBonus = attrBonus;
+                data.weaponAttrLabel = attrLabel;
+
                 data.weaponEnchantBasePrice = WEAPON_ENCHANT_BASE_PRICES[sys.skill] ?? WEAPON_ENCHANT_BASE_PRICES.default;
                 data.weaponImmuneToRadiation = sys.skill === "Bow" || sys.skill === "Firearm" || sys.skill === "Heavy Weaponry";
                 data.weaponStrengtheningOptions = WEAPON_STRENGTHENING_OPTIONS;
@@ -1111,6 +1176,38 @@ export class TheFadeItemSheet extends ItemSheet {
 
             // Target / value changes
             html.find('.bonus-target, .bonus-value').change(() => saveBonuses());
+        }
+
+        // Damage components (weapons only)
+        if (this.item.type === 'weapon') {
+            const saveDamageComponents = () => {
+                const comps = [];
+                html.find('.dmg-comp-row').each((i, el) => {
+                    const $row = $(el);
+                    comps.push({
+                        id: $row.data('dmg-id'),
+                        amount: Number($row.find('.dmg-comp-amount').val()) || 0,
+                        type: $row.find('.dmg-comp-type').val() || "Ut"
+                    });
+                });
+                this.item.update({ "system.damageComponents": comps });
+            };
+
+            html.find('.dmg-comp-add').on('click', ev => {
+                ev.preventDefault();
+                const comps = foundry.utils.deepClone(this.item.system.damageComponents || []);
+                comps.push({ id: foundry.utils.randomID(16), amount: 0, type: "B" });
+                this.item.update({ "system.damageComponents": comps });
+            });
+
+            html.find('.dmg-comp-delete').on('click', ev => {
+                ev.preventDefault();
+                const id = ev.currentTarget.dataset.dmgId;
+                const comps = (this.item.system.damageComponents || []).filter(c => c.id !== id);
+                this.item.update({ "system.damageComponents": comps });
+            });
+
+            html.find('.dmg-comp-amount, .dmg-comp-type').on('change', () => saveDamageComponents());
         }
 
         // Enchantment powers + modifications (weapons and armor)

--- a/src/item.js
+++ b/src/item.js
@@ -60,6 +60,27 @@ export class TheFadeItem extends Item {
 
         if (!Array.isArray(data.enchantmentPowers)) data.enchantmentPowers = [];
         if (!Array.isArray(data.modifications)) data.modifications = [];
+        if (!Array.isArray(data.damageComponents)) data.damageComponents = [];
+
+        // In-memory hydration from legacy single damage/damageType. The persisted
+        // migration (so user edits write components) happens lazily in the item
+        // sheet getData; here we just make sure prepareData/templates always see
+        // a usable components array.
+        if (data.damageComponents.length === 0 && (Number(data.damage) || 0) > 0) {
+            data.damageComponents = [{
+                id: "_legacy",
+                amount: Number(data.damage) || 0,
+                type: data.damageType || "Ut"
+            }];
+        }
+
+        // Sync legacy damage/damageType from components so existing roll, chat,
+        // and TAH paths (which read sys.damage / sys.damageType) keep working
+        // unchanged. Total = sum of component amounts; primary type = first.
+        if (data.damageComponents.length > 0) {
+            data.damage = data.damageComponents.reduce((sum, c) => sum + (Number(c.amount) || 0), 0);
+            data.damageType = data.damageComponents[0].type || "Ut";
+        }
 
         // Derived: total damage including magical strengthening
         data.effectiveDamage = (Number(data.damage) || 0) + (Number(data.damageIncrease) || 0);

--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -8054,6 +8054,90 @@ select[name="system.aura.color"] option[value="white"] {
     margin: 0;
 }
 
+/* Damage component rows (weapon sheet) */
+.thefade.sheet.item .dmg-comp-section {
+    margin-bottom: 8px;
+}
+
+.thefade.sheet.item .dmg-comp-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 4px 0;
+    margin-bottom: 4px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    font-size: 0.85em;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border-faint);
+}
+
+.thefade.sheet.item .dmg-comp-row {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    padding: 4px 6px;
+    margin-bottom: 4px;
+    background: var(--bg-surface-alt, rgba(0,0,0,0.12));
+    border: 1px solid var(--border-faint);
+    border-radius: 2px;
+}
+
+.thefade.sheet.item .dmg-comp-amount {
+    width: 70px;
+    height: 26px;
+    padding: 2px 6px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-faint);
+    color: var(--text-primary);
+    border-radius: 2px;
+    text-align: right;
+    box-sizing: border-box;
+}
+
+.thefade.sheet.item .dmg-comp-type {
+    flex: 1;
+    height: 26px;
+    padding: 2px 6px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-faint);
+    color: var(--text-primary);
+    border-radius: 2px;
+    box-sizing: border-box;
+}
+
+.thefade.sheet.item .dmg-comp-delete,
+.thefade.sheet.item .dmg-comp-add {
+    background: none;
+    border: 1px solid var(--border-faint);
+    color: var(--text-muted);
+    cursor: pointer;
+    padding: 0;
+    width: 24px;
+    height: 24px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 2px;
+    font-size: 0.8em;
+    flex-shrink: 0;
+}
+
+.thefade.sheet.item .dmg-comp-add {
+    width: auto;
+    padding: 0 8px;
+    gap: 4px;
+}
+
+.thefade.sheet.item .dmg-comp-empty {
+    padding: 8px;
+    color: var(--text-muted);
+    font-style: italic;
+    text-align: center;
+    font-size: 0.85em;
+}
+
 /* Enchantment power rows */
 .thefade.sheet.item .ench-power-row,
 .thefade.sheet.item .mod-row {

--- a/template.json
+++ b/template.json
@@ -262,6 +262,7 @@
       "templates": [ "base", "physical" ],
       "damage": 0,
       "damageType": "B",
+      "damageComponents": [],
       "critical": 4,
       "handedness": "One-Handed",
       "range": "Melee",

--- a/templates/item/weapon-sheet.html
+++ b/templates/item/weapon-sheet.html
@@ -34,22 +34,31 @@
         {{#if effectiveDamage}}
         <div class="item-calc-bar">
           <span class="calc-label">Effective Damage:</span>
-          <span class="calc-value">{{effectiveDamage}}{{#if system.damageIncrease}} ({{system.damage}} + {{system.damageIncrease}}){{/if}}</span>
+          <span class="calc-value">{{effectiveDamage}}{{#if effectiveDamageBreakdown}} ({{effectiveDamageBreakdown}}){{/if}}</span>
         </div>
         {{/if}}
+
+        <div class="dmg-comp-section">
+          <div class="dmg-comp-header">
+            <span>Damage</span>
+            <button type="button" class="dmg-comp-add"><i class="fas fa-plus"></i> Add</button>
+          </div>
+          {{#if weaponDamageComponents.length}}
+            {{#each weaponDamageComponents}}
+            <div class="dmg-comp-row" data-dmg-id="{{this.id}}">
+              <input type="number" class="dmg-comp-amount" value="{{this.amount}}" data-dmg-id="{{this.id}}" data-dtype="Number" />
+              <select class="dmg-comp-type" data-dmg-id="{{this.id}}">
+                {{selectOptions ../weaponDamageTypeOptions selected=this.type}}
+              </select>
+              <button type="button" class="dmg-comp-delete" data-dmg-id="{{this.id}}"><i class="fas fa-times"></i></button>
+            </div>
+            {{/each}}
+          {{else}}
+            <div class="dmg-comp-empty">No damage components — click <strong>+ Add</strong> to create one.</div>
+          {{/if}}
+        </div>
+
         <div class="item-attr-grid">
-
-          <div class="form-group">
-            <label>Damage</label>
-            <input type="text" name="system.damage" value="{{system.damage}}" data-dtype="Number" />
-          </div>
-
-          <div class="form-group">
-            <label>Damage Type</label>
-            <select name="system.damageType">
-              {{selectOptions weaponDamageTypeOptions selected=system.damageType}}
-            </select>
-          </div>
 
           <div class="form-group">
             <label>Skill</label>


### PR DESCRIPTION
## Summary
- Weapons can now have multiple typed damage components (e.g. `3 Fire + 3 Bludgeoning`) edited via a repeatable list on the item sheet, replacing the old single Damage / Damage Type pair.
- Effective Damage preview now includes the parent actor's damage-attribute mod (Agile → Finesse/2, Brutish → Physique/2, otherwise weapon `attribute`/2) plus `damageIncrease`, so the sheet matches what the attack roll actually deals.
- Existing weapons auto-migrate: the first time a legacy weapon's sheet is opened, its single `damage`/`damageType` is persisted as one component. Legacy fields stay populated (synced from components) so existing roll, chat, and Token Action HUD paths work unchanged.

## Implementation notes
- `system.damageComponents: [{ id, amount, type }]` added to the weapon schema (`template.json`, `DEFAULT_WEAPON`).
- `_prepareWeaponData` ([src/item.js](../blob/claude/brave-pare-907c09/src/item.js)) hydrates the components array in memory and re-derives `system.damage` (sum) / `system.damageType` (first component) on every prepare cycle.
- Lazy persistent migration runs from `getData` in [src/item-sheet.js](../blob/claude/brave-pare-907c09/src/item-sheet.js), guarded by a sheet-instance flag so it can't loop.
- New `.dmg-comp-*` UI mirrors the existing enchantment-powers / modifications list pattern (template + listeners + styles).
- Attribute-mod logic mirrors the rules in `character-sheet.js` attack rolls so the preview never disagrees with the actual roll.

## Test plan
- [ ] Open an existing (pre-migration) weapon — confirm a single damage component appears matching the old values, and that it persists after closing/reopening.
- [ ] Add a second component (e.g. 3 Fire) on a weapon with 3 Bludgeoning base — confirm Effective Damage shows `6 (3 Bludgeoning + 3 Fire)` on a sheet with no parent actor.
- [ ] Equip the same weapon to a character with Physique 4 and confirm Effective Damage becomes `8 (3 Bludgeoning + 3 Fire + 2)`; verify the rolled attack damage in chat matches.
- [ ] Strengthen the weapon (set `damageIncrease` to 2) and confirm the breakdown adds an untyped `+ 2`.
- [ ] Test Agile and Brutish quality variants to confirm Finesse/Physique override the configured `attribute`.
- [ ] Delete all damage components → confirm Effective Damage hides and the form behaves cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)