### PR TITLE
Add Disease item type and rebuild Poison sheet to match rulebook

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -248,6 +248,7 @@
   "TYPES.Item.species": "Species",
   "TYPES.Item.drug": "Drug",
   "TYPES.Item.poison": "Poison",
+  "TYPES.Item.disease": "Disease",
   "TYPES.Item.biological": "Biological",
   "TYPES.Item.medical": "Medical",
   "TYPES.Item.travel": "Travel & Survival",

--- a/src/item-sheet.js
+++ b/src/item-sheet.js
@@ -90,6 +90,7 @@ export class TheFadeItemSheet extends ItemSheet {
                 "magicitem": "Item of Power",
                 "drug": "Drug",
                 "poison": "Poison",
+                "disease": "Disease",
                 "biological": "Biological",
                 "medical": "Medical",
                 "travel": "Travel & Survival",
@@ -134,6 +135,46 @@ export class TheFadeItemSheet extends ItemSheet {
             data.communicationComplexityOptions = {
                 "audio": "Audio Only",
                 "audiovisual": "Audio & Visual"
+            };
+
+            data.poisonAdminOptions = {
+                "injury": "Injury",
+                "ingested": "Ingested",
+                "inhaled": "Inhaled",
+                "contact": "Contact"
+            };
+
+            data.poisonOnsetOptions = {
+                "immediate": "Immediate (on hit)",
+                "fast": "Fast (1 round)",
+                "moderate": "Moderate (10 minutes)",
+                "slow": "Slow (3 hours)",
+                "insidious": "Insidious (5 days)"
+            };
+
+            data.poisonCategoryOptions = {
+                "neurotoxin": "Neurotoxin",
+                "hemotoxin": "Hemotoxin",
+                "cytotoxin": "Cytotoxin",
+                "psychotoxin": "Psychotoxin",
+                "thaumatoxin": "Thaumatoxin",
+                "aetherotoxin": "Aetherotoxin",
+                "pathotoxin": "Pathotoxin",
+                "aisthetoxin": "Aisthetoxin"
+            };
+
+            data.diseaseTransmissionOptions = {
+                "airborne": "Airborne",
+                "contact": "Contact",
+                "fluid": "Fluid",
+                "ingested": "Ingested",
+                "injury": "Injury"
+            };
+
+            data.diseaseDurationTypeOptions = {
+                "temporary": "Temporary (T)",
+                "chronic": "Chronic",
+                "permanent": "Permanent"
             };
 
             data.materialOptions = {
@@ -1037,6 +1078,70 @@ export class TheFadeItemSheet extends ItemSheet {
                 } else {
                     ui.notifications.warn("Please enter a target relay code.");
                 }
+            });
+        }
+
+        // Poison: Roll Toxicity (NdT vs target Resilience).
+        if (this.item.type === 'poison') {
+            html.find('.roll-toxicity').click(async ev => {
+                ev.preventDefault();
+                const sys = this.item.system;
+                const dice = Number(sys.toxicity) || 0;
+                if (dice <= 0) return ui.notifications.warn("Set a Toxicity dice value first.");
+                const roll = await new Roll(`${dice}d12`).evaluate();
+                let successes = 0;
+                roll.terms[0].results.forEach(d => {
+                    if (d.result >= 12) successes += 2;
+                    else if (d.result >= 8) successes += 1;
+                });
+                const adminLabel = html.find(`select[name="system.poisonType"] option[value="${sys.poisonType}"]`).text() || sys.poisonType;
+                const onsetLabel = html.find(`select[name="system.onset"] option[value="${sys.onset}"]`).text() || sys.onset;
+                const categoryLabel = html.find(`select[name="system.category"] option[value="${sys.category}"]`).text() || sys.category;
+                ChatMessage.create({
+                    speaker: this.item.parent ? ChatMessage.getSpeaker({ actor: this.item.parent }) : undefined,
+                    flavor: `${this.item.name} — Toxicity vs Resilience`,
+                    content: `<div class="thefade chat-card">
+                        <h3>${this.item.name}</h3>
+                        <p class="item-type-label">Poison · ${categoryLabel}</p>
+                        <p><strong>Administering:</strong> ${adminLabel}</p>
+                        <p><strong>Onset:</strong> ${onsetLabel}</p>
+                        <p><strong>Successes:</strong> ${successes}</p>
+                        ${sys.effect ? `<p><strong>Effect:</strong> ${sys.effect}</p>` : ""}
+                        ${await roll.render()}
+                    </div>`
+                });
+            });
+        }
+
+        // Disease: Roll Virality (NdT exposure check).
+        if (this.item.type === 'disease') {
+            html.find('.roll-virality').click(async ev => {
+                ev.preventDefault();
+                const sys = this.item.system;
+                const dice = Number(sys.virality) || 0;
+                if (dice <= 0) return ui.notifications.warn("Set a Virality dice value first.");
+                const roll = await new Roll(`${dice}d12`).evaluate();
+                let successes = 0;
+                roll.terms[0].results.forEach(d => {
+                    if (d.result >= 12) successes += 2;
+                    else if (d.result >= 8) successes += 1;
+                });
+                const transmissionLabel = html.find(`select[name="system.transmission"] option[value="${sys.transmission}"]`).text() || sys.transmission;
+                const durationTypeLabel = html.find(`select[name="system.durationType"] option[value="${sys.durationType}"]`).text() || sys.durationType;
+                ChatMessage.create({
+                    speaker: this.item.parent ? ChatMessage.getSpeaker({ actor: this.item.parent }) : undefined,
+                    flavor: `${this.item.name} — Virality (${sys.viralityBand || ""})`,
+                    content: `<div class="thefade chat-card">
+                        <h3>${this.item.name}</h3>
+                        <p class="item-type-label">Disease · ${transmissionLabel}</p>
+                        <p><strong>Successes:</strong> ${successes}</p>
+                        ${sys.incubation ? `<p><strong>Incubation:</strong> ${sys.incubation}</p>` : ""}
+                        ${sys.duration ? `<p><strong>Duration:</strong> ${sys.duration} (${durationTypeLabel})</p>` : ""}
+                        ${sys.treatmentDT ? `<p><strong>Treatment DT:</strong> ${sys.treatmentDT}</p>` : ""}
+                        ${sys.effect ? `<p><strong>Effect:</strong> ${sys.effect}</p>` : ""}
+                        ${await roll.render()}
+                    </div>`
+                });
             });
         }
 

--- a/src/item.js
+++ b/src/item.js
@@ -25,6 +25,7 @@ export class TheFadeItem extends Item {
             species: this._prepareSpeciesData,
             drug: this._prepareDrugData,
             poison: this._preparePoisonData,
+            disease: this._prepareDiseaseData,
             biological: this._prepareBiologicalData,
             mount: this._prepareMountData,
             vehicle: this._prepareVehicleData,
@@ -214,10 +215,38 @@ export class TheFadeItem extends Item {
         const data = itemData.system;
 
         // Initialize poison properties if undefined
-        if (!data.toxicity) data.toxicity = "";
+        if (data.toxicity === undefined || data.toxicity === null) data.toxicity = 0;
         if (!data.poisonType) data.poisonType = "injury";
+        if (!data.onset) data.onset = "immediate";
+        if (!data.category) data.category = "neurotoxin";
         if (!data.effect) data.effect = "";
         if (!data.weight) data.weight = 0;
+    }
+
+    /**
+    * Prepare disease-specific data
+    * @param {Object} itemData - Item data object
+    */
+    _prepareDiseaseData(itemData) {
+        const data = itemData.system;
+
+        if (!data.transmission) data.transmission = "airborne";
+        if (!data.incubation) data.incubation = "";
+        if (!data.duration) data.duration = "";
+        if (!data.durationType) data.durationType = "temporary";
+        if (data.virality === undefined || data.virality === null) data.virality = 0;
+        if (data.treatmentDT === undefined || data.treatmentDT === null) data.treatmentDT = 0;
+        if (data.requiresVector === undefined) data.requiresVector = false;
+        if (data.requiresCure === undefined) data.requiresCure = false;
+        if (!data.effect) data.effect = "";
+        if (!data.weight) data.weight = 0;
+
+        // Derived: Virality band (Low 4-7D, Moderate 8-11D, High 12D+).
+        const v = Number(data.virality) || 0;
+        if (v >= 12) data.viralityBand = "High";
+        else if (v >= 8) data.viralityBand = "Moderate";
+        else if (v >= 4) data.viralityBand = "Low";
+        else data.viralityBand = null;
     }
 
     /**

--- a/template.json
+++ b/template.json
@@ -245,7 +245,8 @@
       "fleshcraft",
       "magicitem",
       "trait",
-      "precept"
+      "precept",
+      "disease"
     ],
     "templates": {
       "base": {
@@ -412,8 +413,22 @@
     },
     "poison": {
       "templates": [ "base", "physical" ],
-      "toxicity": "",
+      "toxicity": 0,
       "poisonType": "injury",
+      "onset": "immediate",
+      "category": "neurotoxin",
+      "effect": ""
+    },
+    "disease": {
+      "templates": [ "base", "physical" ],
+      "transmission": "airborne",
+      "incubation": "",
+      "duration": "",
+      "durationType": "temporary",
+      "virality": 0,
+      "treatmentDT": 0,
+      "requiresVector": false,
+      "requiresCure": false,
       "effect": ""
     },
     "biological": {

--- a/templates/item/disease-sheet.html
+++ b/templates/item/disease-sheet.html
@@ -1,0 +1,100 @@
+<form class="{{cssClass}}" autocomplete="off">
+    <header class="sheet-header">
+        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
+        <div class="header-fields">
+            <h1 class="item-name-dynamic"><input name="name" type="text" value="{{item.name}}" placeholder="Name" /></h1>
+            <div class="item-type-badge {{item.type}}">{{item.type}}</div>
+        </div>
+    </header>
+
+    <nav class="sheet-tabs tabs" data-group="primary">
+        <a class="item" data-tab="description">Description</a>
+        <a class="item" data-tab="attributes">Attributes</a>
+    </nav>
+
+    <section class="sheet-body">
+        <div class="tab" data-group="primary" data-tab="description">
+            <textarea name="system.description">{{system.description}}</textarea>
+        </div>
+
+        <div class="tab" data-group="primary" data-tab="attributes">
+            {{#if system.virality}}
+            <div class="item-calc-bar">
+                <span class="calc-label">Virality:</span>
+                <span class="calc-value">{{system.virality}}D{{#if system.viralityBand}} ({{system.viralityBand}}){{/if}}</span>
+                <a class="item-action-btn roll-virality"><i class="fas fa-dice-d10"></i> Roll Virality</a>
+            </div>
+            {{/if}}
+
+            <div class="item-attr-grid">
+
+                <div class="form-group">
+                    <label>Virality (Dice)</label>
+                    <input type="number" name="system.virality" value="{{system.virality}}" data-dtype="Number" />
+                </div>
+
+                <div class="form-group">
+                    <label>Treatment DT</label>
+                    <input type="number" name="system.treatmentDT" value="{{system.treatmentDT}}" data-dtype="Number" />
+                </div>
+
+                <div class="form-group">
+                    <label>Transmission</label>
+                    <select name="system.transmission">
+                        {{selectOptions diseaseTransmissionOptions selected=system.transmission}}
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label>Duration Type</label>
+                    <select name="system.durationType">
+                        {{selectOptions diseaseDurationTypeOptions selected=system.durationType}}
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label>Incubation</label>
+                    <input type="text" name="system.incubation" value="{{system.incubation}}" placeholder="e.g. 2-5 days" />
+                </div>
+
+                <div class="form-group">
+                    <label>Duration</label>
+                    <input type="text" name="system.duration" value="{{system.duration}}" placeholder="e.g. 10 days" />
+                </div>
+
+                <div class="form-group">
+                    <label class="form-field">
+                        <input type="checkbox" name="system.requiresVector" {{checked system.requiresVector}} />
+                        <span>Requires a certain vector</span>
+                    </label>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-field">
+                        <input type="checkbox" name="system.requiresCure" {{checked system.requiresCure}} />
+                        <span>Requires a certain cure</span>
+                    </label>
+                </div>
+
+                <div class="form-group">
+                    <label>Cost (sp.)</label>
+                    <input type="text" name="system.price" value="{{system.price}}" data-dtype="Number" />
+                </div>
+
+                <div class="form-group">
+                    <label>Weight (lbs.)</label>
+                    <input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number" />
+                </div>
+
+                <div class="form-group full-width">
+                    <label>Effect</label>
+                    <textarea name="system.effect" rows="3">{{system.effect}}</textarea>
+                </div>
+
+            </div>
+
+            <p class="hint">Virality bands: Low (4D-7D), Moderate (8D-11D), High (12D+). +1D per repeat exposure. Treatment DT is the Medicine check to suppress symptoms.</p>
+        </div>
+
+    </section>
+</form>

--- a/templates/item/poison-sheet.html
+++ b/templates/item/poison-sheet.html
@@ -1,7 +1,7 @@
-<form class="{{classes}} flexcol" autocomplete="off">
-    <header class="sheet-header flexrow">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" height="64" width="64" />
-        <div class="header-fields flexcol">
+<form class="{{cssClass}}" autocomplete="off">
+    <header class="sheet-header">
+        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
+        <div class="header-fields">
             <h1 class="item-name-dynamic"><input name="name" type="text" value="{{item.name}}" placeholder="Name" /></h1>
             <div class="item-type-badge {{item.type}}">{{item.type}}</div>
         </div>
@@ -9,58 +9,78 @@
 
     <nav class="sheet-tabs tabs" data-group="primary">
         <a class="item" data-tab="description">Description</a>
-        <a class="item" data-tab="details">Details</a>
         <a class="item" data-tab="attributes">Attributes</a>
     </nav>
 
     <section class="sheet-body">
         <div class="tab" data-group="primary" data-tab="description">
-            <div class="form-group">
-                <label>Description:</label>
-                <textarea name="system.description" rows="10">{{system.description}}</textarea>
-            </div>
-        </div>
-
-        <div class="tab" data-group="primary" data-tab="details">
-            <div class="form-group">
-                <label>Poison Type:</label>
-                <input type="text" name="system.poisonType" value="{{system.poisonType}}" />
-            </div>
-            <div class="form-group">
-                <label>Save Difficulty:</label>
-                <input type="number" name="system.saveDifficulty" value="{{system.saveDifficulty}}" />
-            </div>
-            <div class="form-group">
-                <label>Damage:</label>
-                <input type="text" name="system.damage" value="{{system.damage}}" />
-            </div>
-            <div class="form-group">
-                <label>Duration:</label>
-                <input type="text" name="system.duration" value="{{system.duration}}" />
-            </div>
-            <div class="form-group">
-                <label>Effect:</label>
-                <textarea name="system.effect" rows="3">{{system.effect}}</textarea>
-            </div>
-            <div class="item-use-section">
-                {{#if system.quantity}}<span class="qty-display">Qty: {{system.quantity}}</span>{{/if}}
-                <a class="item-action-btn consume-item"><i class="fas fa-skull-crossbones"></i> Apply Poison</a>
-            </div>
+            <textarea name="system.description">{{system.description}}</textarea>
         </div>
 
         <div class="tab" data-group="primary" data-tab="attributes">
-            <div class="form-group">
-                <label>Price (sp)</label>
-                <input type="text" name="system.price" value="{{system.price}}" data-dtype="Number" />
+            {{#if system.toxicity}}
+            <div class="item-calc-bar">
+                <span class="calc-label">Toxicity:</span>
+                <span class="calc-value">{{system.toxicity}}D</span>
+                <a class="item-action-btn roll-toxicity"><i class="fas fa-dice-d10"></i> Roll Toxicity</a>
             </div>
-            <div class="form-group">
-                <label>Weight</label>
-                <input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number" />
-                <span>lbs.</span>
+            {{/if}}
+
+            <div class="item-attr-grid">
+
+                <div class="form-group">
+                    <label>Toxicity (Dice)</label>
+                    <input type="number" name="system.toxicity" value="{{system.toxicity}}" data-dtype="Number" />
+                </div>
+
+                <div class="form-group">
+                    <label>Administering</label>
+                    <select name="system.poisonType">
+                        {{selectOptions poisonAdminOptions selected=system.poisonType}}
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label>Onset</label>
+                    <select name="system.onset">
+                        {{selectOptions poisonOnsetOptions selected=system.onset}}
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label>Category</label>
+                    <select name="system.category">
+                        {{selectOptions poisonCategoryOptions selected=system.category}}
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label>Price (sp.)</label>
+                    <input type="text" name="system.price" value="{{system.price}}" data-dtype="Number" />
+                </div>
+
+                <div class="form-group">
+                    <label>Weight (lbs.)</label>
+                    <input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number" />
+                </div>
+
+                <div class="form-group">
+                    <label>Quantity</label>
+                    <input type="text" name="system.quantity" value="{{system.quantity}}" data-dtype="Number" />
+                </div>
+
+                <div class="form-group full-width">
+                    <label>Effect</label>
+                    <textarea name="system.effect" rows="3">{{system.effect}}</textarea>
+                </div>
+
             </div>
-            <div class="form-group">
-                <label>Quantity</label>
-                <input type="text" name="system.quantity" value="{{system.quantity}}" data-dtype="Number" />
+
+            <p class="hint">Toxicity attacks the target's Resilience. +4D vs targets at half HP or less. +1D per repeat exposure within 24 hours. Failing to hit Resilience by 4+ successes grants 24h immunity.</p>
+
+            <div class="item-use-section">
+                {{#if system.quantity}}<span class="qty-display">Qty: {{system.quantity}}</span>{{/if}}
+                <a class="item-action-btn consume-item"><i class="fas fa-skull-crossbones"></i> Apply Poison</a>
             </div>
         </div>
 

--- a/thefade.js
+++ b/thefade.js
@@ -27,7 +27,7 @@ function registerItemSheets() {
     Items.registerSheet("thefade", TheFadeItemSheet, {
         types: [
             "weapon", "armor", "skill", "path", "spell", "talent", "trait", "precept",
-            "species", "drug", "poison", "biological", "medical", "travel",
+            "species", "drug", "poison", "disease", "biological", "medical", "travel",
             "mount", "vehicle", "musical", "potion", "staff", "wand", "gate",
             "communication", "containment", "dream", "fleshcraft", "magicitem", "clothing"
         ],
@@ -115,7 +115,7 @@ Hooks.once('init', async function () {
     // Define all available item types (must match template.json)
     CONFIG.Item.types = [
         "weapon", "armor", "skill", "path", "spell", "talent", "species",
-        "drug", "poison", "biological", "medical", "travel", "mount", "vehicle",
+        "drug", "poison", "disease", "biological", "medical", "travel", "mount", "vehicle",
         "musical", "potion", "staff", "wand", "gate", "communication",
         "containment", "dream", "fleshcraft", "magicitem", "clothing", "trait", "precept"
     ];
@@ -133,6 +133,7 @@ Hooks.once('init', async function () {
         species: "TYPES.Item.species",
         drug: "TYPES.Item.drug",
         poison: "TYPES.Item.poison",
+        disease: "TYPES.Item.disease",
         biological: "TYPES.Item.biological",
         medical: "TYPES.Item.medical",
         travel: "TYPES.Item.travel",


### PR DESCRIPTION
## Summary
- **Poison sheet** rebuilt around the rulebook's actual properties: Toxicity (dice pool), Administering (Injury / Ingested / Inhaled / Contact), Onset (Immediate / Fast / Moderate / Slow / Insidious), Category (Neuro / Hemo / Cyto / Psycho / Thauma / Aethero / Patho / Aistheto). The old free-form Save Difficulty / Damage / Duration fields are dropped; existing \`poisonType\` data carries over as the Administering choice.
- **Roll Toxicity** button posts an NdT vs Resilience roll to chat with successes counted (12s = 2, 8-11 = 1) plus the poison's category/onset/effect.
- **New Disease item type** (\`disease\`) with Transmission, Incubation, Duration + Duration Type (Temporary / Chronic / Permanent), Virality (dice pool with derived Low 4-7D / Moderate 8-11D / High 12D+ band), Treatment DT, and the rulebook's "requires a certain vector / cure" flags.
- **Roll Virality** button mirrors Roll Toxicity for diseases.
- The existing \`biological\` item type is left untouched (different concept — creature samples).

## Files
- \`template.json\` — extended poison schema, new disease schema, registered \`disease\` in \`Item.types\`.
- \`src/item.js\` — new \`_prepareDiseaseData\` (with derived \`viralityBand\`) and updated \`_preparePoisonData\` defaults.
- \`src/item-sheet.js\` — option maps for the new selects, Roll Toxicity / Roll Virality handlers, "Disease" entry in \`itemCategoryOptions\`.
- \`templates/item/poison-sheet.html\` — rebuilt sheet.
- \`templates/item/disease-sheet.html\` — new sheet.
- \`thefade.js\` + \`lang/en.json\` — register \`disease\` in \`CONFIG.Item.types\`, sheet registration, and \`TYPES.Item.disease\` localization.

## Test plan
- [ ] Create a new Poison item — confirm Toxicity/Administering/Onset/Category fields render and persist.
- [ ] Set Toxicity to 8 and click Roll Toxicity — confirm chat card shows 8d12, successes count, and the selected category/onset.
- [ ] Open an existing (pre-migration) poison — confirm \`poisonType\` (Administering) value still selected; legacy Save Difficulty / Damage / Duration values are silently ignored.
- [ ] Click Apply Poison to confirm the existing consume handler still works and decrements quantity.
- [ ] Create a Disease item — confirm all fields render and persist.
- [ ] Set Virality to 6 → band shows "Low"; 9 → "Moderate"; 13 → "High".
- [ ] Click Roll Virality with virality 9 — confirm chat card shows 9d12, successes, transmission, duration/duration-type, treatment DT.
- [ ] Confirm Disease appears in the Item creation type list (Foundry "Create Item" dialog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)