### PR TITLE
Register disease type in system.json itemTypes

### DIFF
--- a/system.json
+++ b/system.json
@@ -136,6 +136,7 @@
     "species",
     "drug",
     "poison",
+    "disease",
     "biological",
     "medical",
     "travel",


### PR DESCRIPTION
## Summary
Follow-up to #36 — the disease item type was registered in \`template.json\`, \`CONFIG.Item.types\`, the sheet registration, and the localization file, but I missed \`system.json\`'s \`itemTypes\` array. Foundry treats that array as the canonical manifest, so the type was effectively half-registered: it appeared internally but Foundry refused to actually open the sheet, breaking the disease item entirely.

This single-line addition fixes that.

## Test plan
- [ ] Reload Foundry world.
- [ ] Create a new Disease item — confirm the sheet opens without errors.
- [ ] Confirm Disease appears in the Item-creation type list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)