### PR TITLE
Preload disease-sheet template

### DIFF
--- a/thefade.js
+++ b/thefade.js
@@ -251,6 +251,7 @@ Hooks.once('init', async function () {
         "systems/thefade/templates/item/mount-sheet.html",
         "systems/thefade/templates/item/musical-sheet.html",
         "systems/thefade/templates/item/poison-sheet.html",
+        "systems/thefade/templates/item/disease-sheet.html",
         "systems/thefade/templates/item/potion-sheet.html",
         "systems/thefade/templates/item/staff-sheet.html",
         "systems/thefade/templates/item/travel-sheet.html",


### PR DESCRIPTION
## Summary
Follow-up to #37 — \`thefade.js\` calls \`loadTemplates([...])\` at system init with an explicit list of every item sheet template, and \`disease-sheet.html\` wasn't on it. Without preloading, the render call left the sheet body empty: the title bar said "Disease: Bubonic Plague" (type was registered) but no tabs or form fields appeared.

This adds the one missing line.

## Test plan
- [ ] Reload world.
- [ ] Open an existing Disease item — confirm the full sheet body renders (Description / Attributes tabs, all form fields, Roll Virality button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)