### PR TITLE
Register disease type in active item sheet registration

### DIFF
--- a/thefade.js
+++ b/thefade.js
@@ -212,7 +212,7 @@ Hooks.once('init', async function () {
     Items.registerSheet("thefade", TheFadeItemSheet, {
         types: [
             "weapon", "armor", "skill", "path", "spell", "talent", "trait", "precept",
-            "species", "drug", "poison", "biological", "medical", "travel", "item",
+            "species", "drug", "poison", "disease", "biological", "medical", "travel", "item",
             "mount", "vehicle", "musical", "potion", "staff", "wand", "gate",
             "communication", "containment", "dream", "fleshcraft", "magicitem", "clothing"
         ],


### PR DESCRIPTION
## Summary
- Adds `"disease"` to the `Items.registerSheet` types list at [thefade.js:215](thefade.js:215) so disease items get bound to `TheFadeItemSheet` and render the disease template.
- Without this, disease sheets only showed the default header (no tabs, no fields, no Roll Virality button) because no sheet was registered for the type after `Items.unregisterSheet("core", ItemSheet)`.

## Why
There are two `Items.registerSheet` calls in the file: one inside an unused `registerItemSheets()` helper (which includes `"disease"`) and one in the `init` hook (which did not). Only the latter runs, so disease was effectively unregistered.

## Test plan
- [ ] Reload Foundry world
- [ ] Open a disease item — confirm Description and Attributes tabs render with all fields and the Roll Virality button works