### PR TITLE
Allow multiple transmission methods on diseases

### DIFF
--- a/src/item-sheet.js
+++ b/src/item-sheet.js
@@ -1126,7 +1126,10 @@ export class TheFadeItemSheet extends ItemSheet {
                     if (d.result >= 12) successes += 2;
                     else if (d.result >= 8) successes += 1;
                 });
-                const transmissionLabel = html.find(`select[name="system.transmission"] option[value="${sys.transmission}"]`).text() || sys.transmission;
+                const transmissionOptionMap = { airborne: "Airborne", contact: "Contact", fluid: "Fluid", ingested: "Ingested", injury: "Injury" };
+                const transmissionLabel = (sys.transmission && typeof sys.transmission === "object")
+                    ? Object.entries(sys.transmission).filter(([, v]) => v).map(([k]) => transmissionOptionMap[k] || k).join(" or ") || "—"
+                    : (transmissionOptionMap[sys.transmission] || sys.transmission || "—");
                 const durationTypeLabel = html.find(`select[name="system.durationType"] option[value="${sys.durationType}"]`).text() || sys.durationType;
                 ChatMessage.create({
                     speaker: this.item.parent ? ChatMessage.getSpeaker({ actor: this.item.parent }) : undefined,

--- a/src/item.js
+++ b/src/item.js
@@ -230,7 +230,16 @@ export class TheFadeItem extends Item {
     _prepareDiseaseData(itemData) {
         const data = itemData.system;
 
-        if (!data.transmission) data.transmission = "airborne";
+        const transmissionKeys = ["airborne", "contact", "fluid", "ingested", "injury"];
+        if (!data.transmission || typeof data.transmission !== "object" || Array.isArray(data.transmission)) {
+            const prev = data.transmission;
+            data.transmission = {};
+            for (const k of transmissionKeys) data.transmission[k] = false;
+            if (typeof prev === "string" && transmissionKeys.includes(prev)) data.transmission[prev] = true;
+            else if (Array.isArray(prev)) for (const k of prev) if (transmissionKeys.includes(k)) data.transmission[k] = true;
+        } else {
+            for (const k of transmissionKeys) if (data.transmission[k] === undefined) data.transmission[k] = false;
+        }
         if (!data.incubation) data.incubation = "";
         if (!data.duration) data.duration = "";
         if (!data.durationType) data.durationType = "temporary";

--- a/template.json
+++ b/template.json
@@ -421,7 +421,13 @@
     },
     "disease": {
       "templates": [ "base", "physical" ],
-      "transmission": "airborne",
+      "transmission": {
+        "airborne": false,
+        "contact": false,
+        "fluid": false,
+        "ingested": false,
+        "injury": false
+      },
       "incubation": "",
       "duration": "",
       "durationType": "temporary",

--- a/templates/item/disease-sheet.html
+++ b/templates/item/disease-sheet.html
@@ -38,11 +38,16 @@
                     <input type="number" name="system.treatmentDT" value="{{system.treatmentDT}}" data-dtype="Number" />
                 </div>
 
-                <div class="form-group">
+                <div class="form-group full-width">
                     <label>Transmission</label>
-                    <select name="system.transmission">
-                        {{selectOptions diseaseTransmissionOptions selected=system.transmission}}
-                    </select>
+                    <div class="checkbox-grid">
+                        {{#each diseaseTransmissionOptions as |label key|}}
+                        <label class="form-field">
+                            <input type="checkbox" name="system.transmission.{{key}}" {{checked (lookup ../system.transmission key)}} />
+                            <span>{{label}}</span>
+                        </label>
+                        {{/each}}
+                    </div>
                 </div>
 
                 <div class="form-group">


### PR DESCRIPTION
## Summary
- Diseases can now have multiple transmission vectors (e.g. Bubonic Plague: Airborne or Injury, Cholera: Ingested or Injury).
- `system.transmission` is now an object of booleans `{airborne, contact, fluid, ingested, injury}` instead of a single string.
- Sheet renders one checkbox per vector instead of a single `<select>`.
- `_prepareDiseaseData` migrates legacy string/array values into the object form on first load.
- Roll Virality chat card joins all selected vectors with `" or "`.

## Why
Several diseases in the source material (Bubonic Plague, Cholera, etc.) list multiple valid transmission methods. The single-select dropdown could not represent this.

## Test plan
- [ ] Open a freshly created disease — all five transmission checkboxes render unchecked.
- [ ] Tick Airborne and Injury, save, reopen — both stay checked.
- [ ] Open a disease created before this change (transmission was `"airborne"`) — Airborne is checked, others unchecked.
- [ ] Roll Virality on a disease with two vectors — chat card shows e.g. `Disease · Airborne or Injury`.