### PR TITLE
Add missing biological item sheet template

### DIFF
--- a/templates/item/biological-sheet.html
+++ b/templates/item/biological-sheet.html
@@ -1,0 +1,70 @@
+<form class="{{classes}} flexcol" autocomplete="off">
+    <header class="sheet-header flexrow">
+        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" height="64" width="64" />
+        <div class="header-fields flexcol">
+            <h1 class="item-name-dynamic"><input name="name" type="text" value="{{item.name}}" placeholder="Name" /></h1>
+            <div class="item-type-badge {{item.type}}">{{item.type}}</div>
+        </div>
+    </header>
+
+    <nav class="sheet-tabs tabs" data-group="primary">
+        <a class="item" data-tab="description">Description</a>
+        <a class="item" data-tab="details">Details</a>
+        <a class="item" data-tab="attributes">Attributes</a>
+    </nav>
+
+    <section class="sheet-body">
+        <div class="tab" data-group="primary" data-tab="description">
+            <div class="form-group">
+                <label>Description:</label>
+                <textarea name="system.description" rows="10">{{system.description}}</textarea>
+            </div>
+        </div>
+
+        <div class="tab" data-group="primary" data-tab="details">
+            <div class="form-group">
+                <label>Creature Type:</label>
+                <input type="text" name="system.creatureType" value="{{system.creatureType}}" placeholder="e.g., Beast, Aberration" />
+            </div>
+
+            <div class="form-group">
+                <label>Effect:</label>
+                <textarea name="system.effect" rows="4">{{system.effect}}</textarea>
+            </div>
+
+            <div class="form-group">
+                <label>Special Abilities:</label>
+                <textarea name="system.specialAbilities" rows="5">{{system.specialAbilities}}</textarea>
+            </div>
+
+            {{#if system.energy}}
+            <div class="item-use-section">
+                <span class="qty-display">Energy: {{system.energy}}</span>
+                <a class="item-action-btn use-energy"><i class="fas fa-bolt"></i> Use Energy</a>
+            </div>
+            {{else}}
+            <div class="form-group">
+                <label>Energy:</label>
+                <input type="number" name="system.energy" value="{{system.energy}}" data-dtype="Number" />
+            </div>
+            {{/if}}
+        </div>
+
+        <div class="tab" data-group="primary" data-tab="attributes">
+            <div class="form-group">
+                <label>Price (sp)</label>
+                <input type="text" name="system.price" value="{{system.price}}" data-dtype="Number" />
+            </div>
+            <div class="form-group">
+                <label>Weight</label>
+                <input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number" />
+                <span>lbs.</span>
+            </div>
+            <div class="form-group">
+                <label>Quantity</label>
+                <input type="text" name="system.quantity" value="{{system.quantity}}" data-dtype="Number" />
+            </div>
+        </div>
+
+    </section>
+</form>


### PR DESCRIPTION
## Summary
- Creating a biological item threw `ENOENT: no such file or directory ... biological-sheet.html` because the item-sheet renderer resolves templates as `templates/item/${item.type}-sheet.html` and that file was never added.
- Adds the template with the schema fields (`creatureType`, `specialAbilities`, `effect`), base/physical fields (description, price, weight, quantity), and the `system.energy` field that [item-sheet.js:1035](../blob/main/src/item-sheet.js#L1035) references via the `.use-energy` button.

## Test plan
- [ ] Create a new Biological item in Foundry — sheet opens without errors
- [ ] Edit each field and confirm values persist
- [ ] Click "Use Energy" when energy > 0 and confirm it decrements

🤖 Generated with [Claude Code](https://claude.com/claude-code)