### PR TITLE
Align item sheet stats with rulebook (Biological, Comms, Containment, Dream, Flesh Craft)

### DIFF
--- a/template.json
+++ b/template.json
@@ -441,7 +441,11 @@
       "templates": [ "base", "physical" ],
       "creatureType": "",
       "specialAbilities": "",
-      "effect": ""
+      "effect": "",
+      "hp": 0,
+      "maxHp": 0,
+      "energy": 0,
+      "maxEnergy": 0
     },
     "medical": {
       "templates": [ "base", "physical" ],
@@ -509,6 +513,7 @@
     },
     "containment": {
       "templates": [ "base", "physical" ],
+      "creaturesAffected": "",
       "effect": ""
     },
     "dream": {
@@ -526,7 +531,29 @@
       "hp": 0,
       "type": "",
       "sanityCost": 0,
-      "active": false
+      "active": false,
+      "el": 1,
+      "size": "medium",
+      "movement": "",
+      "skills": "",
+      "attributes": {
+        "physique": 0,
+        "finesse": 0,
+        "mind": 0,
+        "presence": 0,
+        "soul": 0
+      },
+      "defenses": {
+        "avoid": 0,
+        "resilience": 0,
+        "grit": 0
+      },
+      "nd": {
+        "head": 0,
+        "body": 0,
+        "arms": 0,
+        "legs": 0
+      }
     },
     "clothing": {
       "templates": [ "base", "physical" ],

--- a/templates/item/biological-sheet.html
+++ b/templates/item/biological-sheet.html
@@ -24,7 +24,25 @@
         <div class="tab" data-group="primary" data-tab="details">
             <div class="form-group">
                 <label>Creature Type:</label>
-                <input type="text" name="system.creatureType" value="{{system.creatureType}}" placeholder="e.g., Beast, Aberration" />
+                <input type="text" name="system.creatureType" value="{{system.creatureType}}" placeholder="e.g., Symbiotic, Plant-like" />
+            </div>
+
+            <div class="form-group">
+                <label>HP (current / max):</label>
+                <input type="number" name="system.hp" value="{{system.hp}}" data-dtype="Number" />
+                <span>/</span>
+                <input type="number" name="system.maxHp" value="{{system.maxHp}}" data-dtype="Number" />
+            </div>
+
+            <div class="form-group">
+                <label>Energy (current / max):</label>
+                <input type="number" name="system.energy" value="{{system.energy}}" data-dtype="Number" />
+                <span>/</span>
+                <input type="number" name="system.maxEnergy" value="{{system.maxEnergy}}" data-dtype="Number" />
+            </div>
+
+            <div class="item-use-section">
+                <a class="item-action-btn use-energy"><i class="fas fa-bolt"></i> Spend Energy</a>
             </div>
 
             <div class="form-group">
@@ -36,18 +54,6 @@
                 <label>Special Abilities:</label>
                 <textarea name="system.specialAbilities" rows="5">{{system.specialAbilities}}</textarea>
             </div>
-
-            {{#if system.energy}}
-            <div class="item-use-section">
-                <span class="qty-display">Energy: {{system.energy}}</span>
-                <a class="item-action-btn use-energy"><i class="fas fa-bolt"></i> Use Energy</a>
-            </div>
-            {{else}}
-            <div class="form-group">
-                <label>Energy:</label>
-                <input type="number" name="system.energy" value="{{system.energy}}" data-dtype="Number" />
-            </div>
-            {{/if}}
         </div>
 
         <div class="tab" data-group="primary" data-tab="attributes">

--- a/templates/item/communication-sheet.html
+++ b/templates/item/communication-sheet.html
@@ -26,14 +26,13 @@
                 <label>Complexity</label>
                 <select name="system.complexity">
                     <option value="audio" {{#ifEquals system.complexity "audio"}} selected{{/ifEquals}}>Audio Only</option>
-                    <option value="video" {{#ifEquals system.complexity "video"}} selected{{/ifEquals}}>Video Only</option>
-                    <option value="both" {{#ifEquals system.complexity "both"}} selected{{/ifEquals}}>Audio & Visual</option>
+                    <option value="audiovisual" {{#ifEquals system.complexity "audiovisual"}} selected{{/ifEquals}}>Audio & Visual</option>
                 </select>
             </div>
 
             <div class="form-group">
                 <label>Distance</label>
-                <input type="text" name="system.range" value="{{system.range}}" placeholder="e.g., 1 mile, Same plane, Unlimited" />
+                <input type="text" name="system.range" value="{{system.range}}" placeholder="e.g., 100 miles, Same country, Across Morta IV" />
             </div>
 
             <div class="form-group">

--- a/templates/item/dream-sheet.html
+++ b/templates/item/dream-sheet.html
@@ -23,8 +23,12 @@
 
         <div class="tab" data-group="primary" data-tab="details">
             <div class="form-group">
-                <label>Dream Type:</label>
-                <input type="text" name="system.dreamType" value="{{system.dreamType}}" />
+                <label>Dream or Nightmare:</label>
+                <select name="system.dreamType">
+                    <option value="" {{#ifEquals system.dreamType ""}} selected{{/ifEquals}}>—</option>
+                    <option value="dream" {{#ifEquals system.dreamType "dream"}} selected{{/ifEquals}}>Dream</option>
+                    <option value="nightmare" {{#ifEquals system.dreamType "nightmare"}} selected{{/ifEquals}}>Nightmare</option>
+                </select>
             </div>
             <div class="form-group">
                 <label>Effect:</label>


### PR DESCRIPTION
## Summary
Fixes the data model and sheets for several item types so they match the rulebook tables.

- **Biological**: sheet now shows HP and Energy as current/max (matching the rulebook's Name/Price/HP/Energy/Weight columns), with a Spend Energy action wired to the existing handler. Schema gains `hp`, `maxHp`, `energy`, `maxEnergy`.
- **Containment**: schema gains `creaturesAffected` so the field the sheet was already binding initializes properly.
- **Dream Harvesting**: Dream Type becomes a Dream/Nightmare/— dropdown (rulebook column is "Dream or Nightmare").
- **Communications**: removed the "Video Only" complexity option (not in the rulebook); values are now `audio` / `audiovisual`, labeled Audio Only / Audio & Visual.
- **Flesh Craft**: schema gains `el`, `size`, `movement`, `skills`, `attributes`, `defenses`, `nd` — the sheet already rendered these but the data was never initialized, so new flesh crafts came up blank.

## Test plan
- [ ] Create a Biological item; confirm HP and Energy persist and Spend Energy decrements current Energy
- [ ] Create a Containment item; confirm Creature(s) Affected persists
- [ ] Create a Dream item; confirm the Dream/Nightmare dropdown persists
- [ ] Create a Communication item; confirm the complexity selector only shows Audio Only / Audio & Visual and round-trips
- [ ] Create a Flesh Craft item; confirm Attributes/Defenses/ND inputs default to 0 (not empty) and persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)