### PR TITLE
Prototype pencil-icon bonus/override pattern for Avoid

### DIFF
--- a/src/actor.js
+++ b/src/actor.js
@@ -247,6 +247,10 @@ export class TheFadeActor extends Actor {
             // Apply active-condition modifiers (defenses, speed, action economy)
             this._applyConditionState(data);
 
+            // Manual overrides win outright — applied last so they bypass
+            // base, bonus, facing, stance, and condition deltas.
+            this._applyDefenseOverrides(data);
+
             // Calculate carrying capacity
             this._calculateCarryingCapacity(data);
 
@@ -694,6 +698,21 @@ export class TheFadeActor extends Actor {
     }
 
     /**
+     * Apply manual user overrides for derived defense values. An override
+     * (non-null, finite number) replaces the computed total outright,
+     * bypassing base, bonus, facing, stance, and condition deltas. Runs
+     * last so it wins against every other source.
+     */
+    _applyDefenseOverrides(data) {
+        if (!data.defenses) return;
+        const o = data.defenses.avoidOverride;
+        if (o !== null && o !== undefined && o !== "" && Number.isFinite(Number(o))) {
+            data.totalAvoid = Number(o);
+            data.defenses.avoidFormula = `Manual override: ${data.totalAvoid}`;
+        }
+    }
+
+    /**
      * Compute per-roll dice modifiers from the actor's active conditions.
      * Roll handlers call this after assembling the base pool and before
      * constructing the Roll formula. Returns { bonusDice, penaltyDice,
@@ -836,6 +855,7 @@ export class TheFadeActor extends Actor {
         applyBaseDefenseStances(data);
         this._applyFacingModifiers(data);
         this._applyConditionState(data);
+        this._applyDefenseOverrides(data);
 
         // HP state label (max is stored directly, not calculated)
         if (!data.hp) data.hp = { value: 10, max: 10 };

--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -3381,6 +3381,100 @@ export class TheFadeCharacterSheet extends ActorSheet {
     // --------------------------------------------------------------------
 
     /**
+     * Stat key -> { basePath, bonusPath, overridePath, totalPath } locator.
+     * Adjustable computed values register here so the pencil-icon dialog can
+     * read/write the right fields without each call-site repeating itself.
+     */
+    static ADJUSTABLE_STATS = {
+        avoid: {
+            basePath: "system.defenses.avoid",
+            bonusPath: "system.defenses.avoidBonus",
+            overridePath: "system.defenses.avoidOverride",
+            totalPath: "system.totalAvoid"
+        }
+    };
+
+    /**
+     * Pencil-icon edit dialog for adjustable computed values. Reads/writes
+     * the bonus and override fields registered in ADJUSTABLE_STATS. Override
+     * (when non-blank) replaces the computed total outright in actor.js.
+     */
+    async _onEditAdjustable(ev) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        const el = ev.currentTarget;
+        const stat = el.dataset.stat;
+        const label = el.dataset.label || stat;
+        const cfg = TheFadeCharacterSheet.ADJUSTABLE_STATS[stat];
+        if (!cfg) return ui.notifications?.warn(`Unknown adjustable stat: ${stat}`);
+
+        const get = (path) => path.split(".").reduce((o, k) => (o == null ? o : o[k]), this.actor);
+        const base = Number(get(cfg.basePath) ?? 0);
+        const bonus = Number(get(cfg.bonusPath) ?? 0);
+        const overrideRaw = get(cfg.overridePath);
+        const total = Number(get(cfg.totalPath) ?? 0);
+
+        const content = `
+            <form class="tf-edit-adjustable">
+                <p class="tf-muted">Editing <strong>${label}</strong>. Total = Base + Bonus, unless an Override is set (which replaces the total).</p>
+                <div class="form-group">
+                    <label>Computed Base</label>
+                    <input type="number" value="${base}" disabled />
+                    <p class="hint">Derived from attributes. Use Bonus or Override to adjust.</p>
+                </div>
+                <div class="form-group">
+                    <label>Manual Bonus</label>
+                    <input type="number" name="bonus" value="${bonus}" />
+                    <p class="hint">Adds on top of the base.</p>
+                </div>
+                <div class="form-group">
+                    <label>Override</label>
+                    <input type="number" name="override" value="${overrideRaw ?? ""}" placeholder="(blank = use computed total)" />
+                    <p class="hint">If set, replaces the computed total entirely — ignores facing, stance, and conditions.</p>
+                </div>
+                <div class="form-group">
+                    <label>Current Total</label>
+                    <input type="number" value="${total}" disabled />
+                </div>
+            </form>`;
+
+        return new Promise((resolve) => {
+            new Dialog({
+                title: `Edit ${label}`,
+                content,
+                buttons: {
+                    save: {
+                        label: "Save",
+                        callback: async (html) => {
+                            const form = html[0].querySelector("form");
+                            const bonusRaw = form.elements.bonus.value;
+                            const overrideStr = form.elements.override.value;
+                            await this.actor.update({
+                                [cfg.bonusPath]: bonusRaw === "" ? 0 : Number(bonusRaw),
+                                [cfg.overridePath]: overrideStr === "" ? null : Number(overrideStr)
+                            });
+                            resolve();
+                        }
+                    },
+                    reset: {
+                        label: "Reset",
+                        callback: async () => {
+                            await this.actor.update({
+                                [cfg.bonusPath]: 0,
+                                [cfg.overridePath]: null
+                            });
+                            resolve();
+                        }
+                    },
+                    cancel: { label: "Cancel", callback: () => resolve() }
+                },
+                default: "save",
+                close: () => resolve()
+            }, { classes: ["thefade", "dialog", "tf-edit-adjustable"], width: 460 }).render(true);
+        });
+    }
+
+    /**
     * Activate sheet event listeners
     * @param {HTMLElement} html - Sheet HTML element
     */
@@ -3399,6 +3493,9 @@ export class TheFadeCharacterSheet extends ActorSheet {
         this._initializeExcessPenaltyTooltips(html);
 
         this._activateInventoryListeners(html);
+
+        // Pencil-icon edit dialog for adjustable computed values.
+        html.find('.tf-edit-adjustable').on('click', this._onEditAdjustable.bind(this));
 
         // Combat-state: clear all conditions + stance
         html.find('.combat-state-clear').on('click', async (ev) => {

--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -9473,3 +9473,41 @@ select[name="system.aura.color"] option[value="white"] {
     font-style: italic;
     margin: 4px 0;
 }
+
+/* ---------- Pencil-icon adjustable values (Avoid prototype) ---------- */
+.defense-compact .defense-value {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+}
+.defense-compact .tf-edit-adjustable {
+    cursor: pointer;
+    opacity: 0.55;
+    transition: opacity 0.15s ease;
+    font-size: 0.85em;
+    line-height: 1;
+}
+.defense-compact .tf-edit-adjustable:hover {
+    opacity: 1;
+    color: var(--accent, #b88846);
+}
+
+.dialog.tf-edit-adjustable .form-group { margin-bottom: 8px; }
+.dialog.tf-edit-adjustable .form-group label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 2px;
+}
+.dialog.tf-edit-adjustable .form-group input { width: 100%; }
+.dialog.tf-edit-adjustable .form-group .hint {
+    font-size: 11px;
+    color: #666;
+    margin: 2px 0 0;
+    font-style: italic;
+}
+.dialog.tf-edit-adjustable .tf-muted {
+    font-size: 0.9em;
+    color: #555;
+    margin-bottom: 8px;
+}

--- a/template.json
+++ b/template.json
@@ -77,6 +77,7 @@
         "resilienceBonus": 0,
         "avoidBonus": 0,
         "gritBonus": 0,
+        "avoidOverride": null,
         "passiveDodge": 0,
         "passiveParry": 0,
         "facing": "front"
@@ -180,6 +181,7 @@
       "defenses": {
         "resilience": 0, "avoid": 0, "grit": 0,
         "resilienceBonus": 0, "avoidBonus": 0, "gritBonus": 0,
+        "avoidOverride": null,
         "passiveDodge": 0, "passiveParry": 0, "facing": "front"
       },
       "movement": { "land": 4, "fly": 0, "swim": 0, "climb": 0, "burrow": 0 },

--- a/templates/actor/character-sheet.html
+++ b/templates/actor/character-sheet.html
@@ -105,26 +105,12 @@
                     <div class="defense-desc">vs toxins, fatigue, disease</div>
                 </div>
 
-                <div class="defense" data-defense="avoid">
-                    <input type="checkbox" id="toggle-avoid" class="defense-checkbox">
-                    <label for="toggle-avoid" class="defense-label">Avoid <span class="toggle-icon">▼</span></label>
+                <div class="defense defense-compact" data-defense="avoid">
+                    <label class="defense-label">Avoid</label>
                     <div class="defense-value">
                         <input type="text" value="{{system.totalAvoid}}" disabled class="total-value avoid-value" title="{{system.defenses.avoidFormula}}" />
                         <span class="excess-penalty avoid-excess-penalty">+0D</span>
-                    </div>
-                    <div class="defense-details">
-                        <div class="detail-row">
-                            <span>Base:</span>
-                            <input type="text" value="{{system.defenses.avoid}}" disabled class="base-value" />
-                        </div>
-                        <div class="detail-row">
-                            <span>Bonus:</span>
-                            <input type="text" name="system.defenses.avoidBonus" value="{{system.defenses.avoidBonus}}" data-dtype="Number" class="small-input" />
-                        </div>
-                        <div class="detail-row">
-                            <span>Facing:</span>
-                            <input type="text" value="{{system.defenses.avoidPenalty}}" disabled class="avoid-penalty" />
-                        </div>
+                        <a class="tf-edit-adjustable" data-action="edit-adjustable" data-stat="avoid" data-label="Avoid" title="Edit Avoid (bonus / override)"><i class="fas fa-pencil"></i></a>
                     </div>
                     <div class="defense-desc">vs physical</div>
                 </div>


### PR DESCRIPTION
## Summary

- Introduces a reusable computed-value editing pattern (modeled on the Errant Earths sheet) where a derived stat shows just its total with a small pencil icon; clicking the pencil opens a dialog for **Manual Bonus** and **Override**.
- Scoped end-to-end to the **Avoid** defense as a single prototype before rolling the pattern out to Resilience, Grit, HP, Sanity, save DCs, item stats, etc.
- **Override** semantics match Errant Earths: when set, it replaces the computed total outright — bypassing base, bonus, facing, stance, and condition deltas.

## What changed

- `template.json` — new `defenses.avoidOverride: null` on character and NPC templates.
- `src/actor.js` — new `_applyDefenseOverrides(data)` runs after `_applyConditionState` in both `_prepareCharacterData` and `_prepareNpcData`. Replaces `totalAvoid` with the override when one is set.
- `templates/actor/character-sheet.html` — Avoid block reduced from toggle-drawer + inline bonus input to a compact card: label, total value, pencil icon.
- `src/character-sheet.js` — new `_onEditAdjustable` handler + `ADJUSTABLE_STATS` registry keyed on `data-stat`. Adding the next stat is one registry entry + one HTML block.
- `styles/thefade.css` — pencil icon (55% → 100% opacity on hover) and dialog form-group styling.

## Reviewer notes

- The Avoid card will look visually different from Resilience/Grit while this prototype is in flight — that's intentional. Rollout to the other defenses is the immediate next step once this pattern is approved.
- The old inline `system.defenses.avoidBonus` input is gone from the sheet, but the existing change handler that targets it (`character-sheet.js:3464`) is untouched and simply won't fire — safe no-op.
- No migration is needed for existing actors: a missing `avoidOverride` reads as `undefined` and falls through to the computed total.

## Test plan

- [ ] Open a character sheet → Defenses band shows Avoid with a pencil icon and no drawer.
- [ ] Click pencil → dialog opens with Computed Base (disabled), Manual Bonus, Override, Current Total.
- [ ] Set Manual Bonus → total updates after save.
- [ ] Set Override → total becomes exactly that value, ignoring facing changes and conditions.
- [ ] Clear Override → reverts to computed total.
- [ ] Reset button → wipes both bonus and override.
- [ ] Confirm Resilience and Grit cards still work normally (regression check).
- [ ] Confirm NPC sheet still computes `totalAvoid` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)