### PR TITLE
Reorganize character sheet: Combat tab + compact Stats tab

### DIFF
--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -446,6 +446,7 @@ export class TheFadeCharacterSheet extends ActorSheet {
         actorData.spells = spells;
         actorData.skills = skills;
         actorData.talents = talents;
+        actorData.speciesItem = items.find(i => i?.type === 'species') || null;
         actorData.traits = traits;
         actorData.precepts = precepts;
         actorData.itemsOfPower = itemsOfPower;
@@ -4033,6 +4034,23 @@ export class TheFadeCharacterSheet extends ActorSheet {
         html.find('.species-browse').click(ev => {
             ev.preventDefault();
             openCompendiumBrowser("species", this.actor);
+        });
+
+        // Right-click the compact species name to open the attached Species item sheet.
+        html.find('.species-name-display').on('contextmenu', ev => {
+            ev.preventDefault();
+            const itemId = ev.currentTarget.closest('.species-card')?.dataset.itemId;
+            const item = itemId ? this.actor.items.get(itemId) : this.actor.items.find(i => i.type === 'species');
+            if (item) item.sheet.render(true);
+            else ui.notifications.info("No Species item attached. Drop a Species, browse one, or enable Manual entry.");
+        });
+
+        // Right-click a talent name in the Stats-tab summary to open its sheet.
+        html.find('.talent-summary-item').on('contextmenu', ev => {
+            ev.preventDefault();
+            const itemId = ev.currentTarget.dataset.itemId;
+            const item = itemId ? this.actor.items.get(itemId) : null;
+            if (item) item.sheet.render(true);
         });
 
         html.find('.weapon-browse').click(ev => {

--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -6646,6 +6646,8 @@ select[name="system.aura.color"] option[value="white"] {
 }
 
 .thefade .identity-row .species-item,
+.thefade .identity-row .species-card,
+.thefade .identity-row .talents-summary-card,
 .thefade .identity-row .aura-card {
     background: var(--bg-surface);
     border: 1px solid var(--border-faint);
@@ -6744,6 +6746,70 @@ select[name="system.aura.color"] option[value="white"] {
 .thefade .identity-row .aura-property .aura-bonus {
     color: var(--accent-gold);
     font-style: italic;
+    font-size: 0.9em;
+}
+
+/* ----- Compact Species card + Talents summary (top of Stats) ----- */
+.thefade .species-card h2 {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.thefade .species-manual-toggle {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.7em;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.thefade .species-manual-toggle input {
+    margin: 0;
+}
+
+.thefade .species-name-display {
+    padding: 10px 12px;
+    background: var(--bg-surface-deep);
+    border: 1px solid var(--border-faint);
+    border-radius: 3px;
+    font-size: 1.05em;
+    font-weight: 600;
+    cursor: context-menu;
+}
+
+.thefade .species-name-display.species-name-empty {
+    color: var(--text-muted);
+    font-weight: 400;
+    font-style: italic;
+}
+
+.thefade .talents-summary-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.thefade .talent-summary-item {
+    padding: 6px 10px;
+    background: var(--bg-surface-deep);
+    border: 1px solid var(--border-faint);
+    border-radius: 3px;
+    font-size: 0.9em;
+    cursor: context-menu;
+}
+
+.thefade .talents-summary-empty {
+    margin: 0;
+    color: var(--text-muted);
     font-size: 0.9em;
 }
 

--- a/template.json
+++ b/template.json
@@ -44,7 +44,8 @@
         "creatureType": "humanoid",
         "creatureSubtype": "",
         "languages": "",
-        "speciesAbilities": {}
+        "speciesAbilities": {},
+        "manualEntry": false
       },
       "movement": {
         "land": 4,

--- a/templates/actor/character-sheet.html
+++ b/templates/actor/character-sheet.html
@@ -71,8 +71,9 @@
         <a class="item" data-tab="main">Stats</a>
         <a class="item" data-tab="skills">Skills</a>
         <a class="item" data-tab="inventory">Inventory</a>
+        <a class="item" data-tab="combat">Combat</a>
         <a class="item" data-tab="paths">Abilities</a>
-        <a class="item" data-tab="spells">Spells</a>
+        <a class="item" data-tab="spells">Magic</a>
         <a class="item" data-tab="background">Background</a>
     </nav>
 
@@ -80,6 +81,68 @@
     <section class="sheet-body">
         {{!-- Main Tab --}}
         <div class="tab" data-group="primary" data-tab="main">
+            {{!-- Identity: Species + Talents summary --}}
+            <div class="identity-row identity-row-top">
+                <div class="species-card{{#if system.species.manualEntry}} species-card-manual{{/if}}" data-item-id="{{actor.speciesItem._id}}">
+                    <h2>
+                        Species
+                        <a class="species-browse" title="Browse Species"><i class="fas fa-search"></i></a>
+                        <label class="species-manual-toggle" title="Enable to edit species fields manually (disables right-click to open)">
+                            <input type="checkbox" name="system.species.manualEntry" {{#if system.species.manualEntry}}checked{{/if}} />
+                            <span>Manual</span>
+                        </label>
+                    </h2>
+
+                    {{#if system.species.manualEntry}}
+                    <div class="species-details">
+                        <div class="form-group">
+                            <label>Species</label>
+                            <input type="text" name="system.species.name" value="{{system.species.name}}" />
+                        </div>
+                        <div class="form-group">
+                            <label>Creature Type</label>
+                            <input type="text" name="system.species.creatureType" value="{{system.species.creatureType}}" />
+                        </div>
+                        <div class="form-group">
+                            <label>Subtype</label>
+                            <input type="text" name="system.species.creatureSubtype" value="{{system.species.creatureSubtype}}" />
+                        </div>
+                        <div class="form-group">
+                            <label>Base HP</label>
+                            <input type="text" name="system.species.baseHP" value="{{system.species.baseHP}}" data-dtype="Number" />
+                        </div>
+                        <div class="form-group">
+                            <label>Size</label>
+                            <select name="system.species.size">
+                                {{selectOptions sizeOptions selected=system.species.size}}
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label>Languages</label>
+                            <input type="text" name="system.species.languages" value="{{system.species.languages}}" placeholder="Common, Elvish, etc." />
+                        </div>
+                    </div>
+                    {{else}}
+                    <div class="species-name-display{{#unless actor.speciesItem}} species-name-empty{{/unless}}" title="{{#if actor.speciesItem}}Right-click to open species{{else}}No species attached — drop a Species item, browse, or enable Manual{{/if}}">
+                        {{#if system.species.name}}{{system.species.name}}{{else}}<em>No species</em>{{/if}}
+                    </div>
+                    {{/if}}
+                </div>
+
+                <div class="talents-summary-card">
+                    <h2>Talents</h2>
+                    {{#if actor.talents.length}}
+                    <ul class="talents-summary-list">
+                        {{#each actor.talents as |talent|}}
+                        <li class="talent-summary-item" data-item-id="{{talent._id}}" title="Right-click to open talent">{{talent.name}}</li>
+                        {{/each}}
+                    </ul>
+                    {{else}}
+                    <p class="talents-summary-empty"><em>No talents yet</em></p>
+                    {{/if}}
+                </div>
+            </div>
+
             {{> "systems/thefade/templates/actor/parts/attributes.html"}}
 
             {{!-- Defenses — unified 6-col band (active + passive together) --}}
@@ -173,164 +236,6 @@
                 </tbody>
             </table>
 
-            {{> "systems/thefade/templates/actor/parts/combat-state.html"}}
-            {{> "systems/thefade/templates/actor/parts/injuries.html"}}
-
-            {{!-- Species + Aura side-by-side --}}
-            <div class="identity-row">
-                <div class="species-item" data-item-id="{{species._id}}">
-                    <h2>
-                        Species
-                        <a class="species-browse" title="Browse Species"><i class="fas fa-search"></i></a>
-                    </h2>
-                    <div class="species-details">
-                        <div class="form-group">
-                            <label>Species</label>
-                            <input type="text" name="system.species.name" value="{{system.species.name}}" />
-                        </div>
-                        <div class="form-group">
-                            <label>Creature Type</label>
-                            <input type="text" name="system.species.creatureType" value="{{system.species.creatureType}}" />
-                        </div>
-                        <div class="form-group">
-                            <label>Subtype</label>
-                            <input type="text" name="system.species.creatureSubtype" value="{{system.species.creatureSubtype}}" />
-                        </div>
-                        <div class="form-group">
-                            <label>Base HP</label>
-                            <input type="text" name="system.species.baseHP" value="{{system.species.baseHP}}" data-dtype="Number" />
-                        </div>
-                        <div class="form-group">
-                            <label>Size</label>
-                            <select name="system.species.size">
-                                {{selectOptions sizeOptions selected=system.species.size}}
-                            </select>
-                        </div>
-                        <div class="form-group">
-                            <label>Languages</label>
-                            <input type="text" name="system.species.languages" value="{{system.species.languages}}" placeholder="Common, Elvish, etc." />
-                        </div>
-                        <div class="form-group species-abilities-group">
-                            <label>
-                                Abilities
-                                <a class="species-ability-add" title="Add Ability"><i class="fas fa-plus"></i></a>
-                            </label>
-                            <div class="species-abilities-list">
-                                {{#each system.species.speciesAbilities as |ability id|}}
-                                <div class="species-ability" data-ability-id="{{id}}">
-                                    <div class="ability-header flexrow">
-                                        <strong>{{ability.name}}</strong>
-                                        <div class="ability-controls">
-                                            <a class="species-ability-edit" title="Edit Ability"><i class="fas fa-edit"></i></a>
-                                            <a class="species-ability-delete" title="Delete Ability"><i class="fas fa-trash"></i></a>
-                                        </div>
-                                    </div>
-                                    <div class="ability-description">{{ability.description}}</div>
-                                </div>
-                                {{/each}}
-                            </div>
-                        </div>
-                        {{#if system.abilityEffects}}
-                        {{#if system.abilityEffects.applied.length}}
-                        <div class="form-group ability-effects-group">
-                            <label>Automated Abilities</label>
-                            <ul class="ability-effects-applied">
-                                {{#each system.abilityEffects.applied}}
-                                <li><strong>{{name}}</strong> <span class="ability-source">({{source}})</span> &mdash; {{description}}</li>
-                                {{/each}}
-                            </ul>
-                        </div>
-                        {{/if}}
-                        {{#if system.abilityEffects.unmatched.length}}
-                        <div class="form-group ability-effects-group ability-effects-unmatched">
-                            <label>Text-only abilities <span class="hint">(no automated effect; apply manually)</span></label>
-                            <ul>
-                                {{#each system.abilityEffects.unmatched}}
-                                <li><strong>{{name}}</strong> <span class="ability-source">({{source}})</span></li>
-                                {{/each}}
-                            </ul>
-                        </div>
-                        {{/if}}
-                        {{/if}}
-                    </div>
-                </div>
-
-                <div class="aura-card">
-                    <h2>Aura</h2>
-                    <div class="form-group">
-                        <label>Color</label>
-                        <select name="system.aura.color">
-                            {{selectOptions auraColorOptions selected=system.aura.color}}
-                        </select>
-                    </div>
-                    <div class="form-group">
-                        <label>Shape</label>
-                        <select name="system.aura.shape">
-                            {{selectOptions auraShapeOptions selected=system.aura.shape}}
-                        </select>
-                    </div>
-                    <div class="form-group">
-                        <label>Intensity</label>
-                        <select name="system.aura.intensity">
-                            {{selectOptions auraIntensityOptions selected=system.aura.intensity}}
-                        </select>
-                    </div>
-
-                    <div class="aura-info">
-                        {{#if system.aura.color}}
-                        <div class="aura-property">
-                            <strong>Color:</strong> {{titleCase system.aura.color}}
-                            <span class="aura-bonus">
-                                {{#if (eq system.aura.color "red")}}Athletics{{/if}}
-                                {{#if (eq system.aura.color "blue")}}Medicine{{/if}}
-                                {{#if (eq system.aura.color "green")}}Herbalism{{/if}}
-                                {{#if (eq system.aura.color "yellow")}}Research{{/if}}
-                                {{#if (eq system.aura.color "purple")}}Arcana{{/if}}
-                                {{#if (eq system.aura.color "orange")}}Etiquette{{/if}}
-                                {{#if (eq system.aura.color "pink")}}Seduction{{/if}}
-                                {{#if (eq system.aura.color "gold")}}Gambling{{/if}}
-                                {{#if (eq system.aura.color "silver")}}Symbology{{/if}}
-                                {{#if (eq system.aura.color "turquoise")}}Sight{{/if}}
-                                {{#if (eq system.aura.color "indigo")}}Ritual{{/if}}
-                                {{#if (eq system.aura.color "brown")}}Linguistics{{/if}}
-                                {{#if (eq system.aura.color "violet")}}Insight{{/if}}
-                                {{#if (eq system.aura.color "gray")}}Intimidate{{/if}}
-                                {{#if (eq system.aura.color "black")}}Toxicology{{/if}}
-                                {{#if (eq system.aura.color "white")}}Lore (Religion){{/if}}
-                            </span>
-                        </div>
-                        {{/if}}
-
-                        {{#if system.aura.shape}}
-                        <div class="aura-property">
-                            <strong>Shape:</strong> {{titleCase system.aura.shape}}
-                            <span class="aura-bonus">
-                                {{#if (eq system.aura.shape "circular")}}Etiquette{{/if}}
-                                {{#if (eq system.aura.shape "jagged")}}Trickery{{/if}}
-                                {{#if (eq system.aura.shape "flowing")}}Persuasion{{/if}}
-                                {{#if (eq system.aura.shape "spiky")}}Lockpicking{{/if}}
-                                {{#if (eq system.aura.shape "radiant")}}Deception{{/if}}
-                                {{#if (eq system.aura.shape "dense")}}Medicine{{/if}}
-                                {{#if (eq system.aura.shape "wispy")}}Sneaking{{/if}}
-                                {{#if (eq system.aura.shape "geometric")}}Research{{/if}}
-                            </span>
-                        </div>
-                        {{/if}}
-
-                        {{#if system.aura.intensity}}
-                        <div class="aura-property">
-                            <strong>Intensity:</strong> {{titleCase system.aura.intensity}}
-                            <span class="aura-bonus">
-                                {{#if (eq system.aura.intensity "faint")}}+1D, 3 hex{{/if}}
-                                {{#if (eq system.aura.intensity "moderate")}}+2D, 2 hex{{/if}}
-                                {{#if (eq system.aura.intensity "intense")}}+3D, 1 hex{{/if}}
-                            </span>
-                        </div>
-                        {{/if}}
-                    </div>
-                </div>
-            </div>
-
             {{!-- Carrying + Religion footer --}}
             <div class="minor-stats-row">
                 <div class="capacity-card">
@@ -385,6 +290,12 @@
         {{!-- Inventory Tab --}}
         <div class="tab" data-group="primary" data-tab="inventory">
             {{> "systems/thefade/templates/actor/parts/inventory.html"}}
+        </div>
+
+        {{!-- Combat Tab --}}
+        <div class="tab" data-group="primary" data-tab="combat">
+            {{> "systems/thefade/templates/actor/parts/combat-state.html"}}
+            {{> "systems/thefade/templates/actor/parts/injuries.html"}}
         </div>
 
         {{!-- Paths Tab --}}

--- a/templates/actor/parts/spells.html
+++ b/templates/actor/parts/spells.html
@@ -1,4 +1,82 @@
 <section class="spells-section">
+    <!-- Aura -->
+    <div class="aura-card">
+        <h2>Aura</h2>
+        <div class="aura-fields">
+            <div class="form-group">
+                <label>Color</label>
+                <select name="system.aura.color">
+                    {{selectOptions auraColorOptions selected=system.aura.color}}
+                </select>
+            </div>
+            <div class="form-group">
+                <label>Shape</label>
+                <select name="system.aura.shape">
+                    {{selectOptions auraShapeOptions selected=system.aura.shape}}
+                </select>
+            </div>
+            <div class="form-group">
+                <label>Intensity</label>
+                <select name="system.aura.intensity">
+                    {{selectOptions auraIntensityOptions selected=system.aura.intensity}}
+                </select>
+            </div>
+        </div>
+
+        <div class="aura-info">
+            {{#if system.aura.color}}
+            <div class="aura-property">
+                <strong>Color:</strong> {{titleCase system.aura.color}}
+                <span class="aura-bonus">
+                    {{#if (eq system.aura.color "red")}}Athletics{{/if}}
+                    {{#if (eq system.aura.color "blue")}}Medicine{{/if}}
+                    {{#if (eq system.aura.color "green")}}Herbalism{{/if}}
+                    {{#if (eq system.aura.color "yellow")}}Research{{/if}}
+                    {{#if (eq system.aura.color "purple")}}Arcana{{/if}}
+                    {{#if (eq system.aura.color "orange")}}Etiquette{{/if}}
+                    {{#if (eq system.aura.color "pink")}}Seduction{{/if}}
+                    {{#if (eq system.aura.color "gold")}}Gambling{{/if}}
+                    {{#if (eq system.aura.color "silver")}}Symbology{{/if}}
+                    {{#if (eq system.aura.color "turquoise")}}Sight{{/if}}
+                    {{#if (eq system.aura.color "indigo")}}Ritual{{/if}}
+                    {{#if (eq system.aura.color "brown")}}Linguistics{{/if}}
+                    {{#if (eq system.aura.color "violet")}}Insight{{/if}}
+                    {{#if (eq system.aura.color "gray")}}Intimidate{{/if}}
+                    {{#if (eq system.aura.color "black")}}Toxicology{{/if}}
+                    {{#if (eq system.aura.color "white")}}Lore (Religion){{/if}}
+                </span>
+            </div>
+            {{/if}}
+
+            {{#if system.aura.shape}}
+            <div class="aura-property">
+                <strong>Shape:</strong> {{titleCase system.aura.shape}}
+                <span class="aura-bonus">
+                    {{#if (eq system.aura.shape "circular")}}Etiquette{{/if}}
+                    {{#if (eq system.aura.shape "jagged")}}Trickery{{/if}}
+                    {{#if (eq system.aura.shape "flowing")}}Persuasion{{/if}}
+                    {{#if (eq system.aura.shape "spiky")}}Lockpicking{{/if}}
+                    {{#if (eq system.aura.shape "radiant")}}Deception{{/if}}
+                    {{#if (eq system.aura.shape "dense")}}Medicine{{/if}}
+                    {{#if (eq system.aura.shape "wispy")}}Sneaking{{/if}}
+                    {{#if (eq system.aura.shape "geometric")}}Research{{/if}}
+                </span>
+            </div>
+            {{/if}}
+
+            {{#if system.aura.intensity}}
+            <div class="aura-property">
+                <strong>Intensity:</strong> {{titleCase system.aura.intensity}}
+                <span class="aura-bonus">
+                    {{#if (eq system.aura.intensity "faint")}}+1D, 3 hex{{/if}}
+                    {{#if (eq system.aura.intensity "moderate")}}+2D, 2 hex{{/if}}
+                    {{#if (eq system.aura.intensity "intense")}}+3D, 1 hex{{/if}}
+                </span>
+            </div>
+            {{/if}}
+        </div>
+    </div>
+
     <!-- Spells Learned Counter -->
     <div class="spells-learned-counter">
         <h3>Spells Learned</h3>


### PR DESCRIPTION
## Summary
- Split a new **Combat** tab out of the Stats tab (between Inventory and Abilities) and moved Combat State + Permanent Injuries into it — they were taking up a massive chunk of the Stats tab.
- Promoted **Species** to the top of the Stats tab as a compact card showing only the species name. Right-click opens the attached Species item; a new **Manual** toggle (`system.species.manualEntry`) exposes the editable fields when there's no source item to defer to.
- Added a **Talents** summary card next to Species. Right-click a talent name to open its item sheet.
- Removed the Automated / Text-only ability lists from the Species card — they were incorrectly mixing species and path sources under a heading labeled "Species".
- Renamed the **Spells** tab to **Magic** and moved the Aura card into the top of that partial (was previously next to Species on Stats).

## Why
The Stats & Info tab had grown sprawling: Combat State and Permanent Injuries dominated its lower half, and Species was buried halfway down with a misleading ability-effects list that pulled in path-sourced entries. This pass tightens Stats to a clean Identity → Attributes → Defenses → Movement → Carrying/Religion flow and reorganizes the affected content into more appropriate tabs.

## Notes for reviewers
- New schema field: `system.species.manualEntry` (boolean) added to `template.json`. Existing actors default to `false`, which renders the new compact view.
- The Species card uses `actor.speciesItem` (first item of type `species` on the actor) for the right-click target.
- The Aura card markup is reused as-is; only its location changed.
- Tab key in HTML stayed `data-tab="spells"` — only the visible label changed to "Magic" to avoid breaking any external references.

## Test plan
- [ ] Open a character with a Species item attached: compact card shows species name; right-click opens the species item sheet.
- [ ] Toggle the **Manual** checkbox: editable fields reappear, right-click no longer opens the item.
- [ ] Open a character with talents: names render in the Talents card; right-click opens each talent.
- [ ] Confirm the new **Combat** tab renders Combat State + Permanent Injuries correctly.
- [ ] Confirm the **Magic** tab shows the Aura card at the top followed by the Spells Learned counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)