### PR TITLE
Swap Talents card for Paths card on Stats tab

### DIFF
--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -4045,8 +4045,8 @@ export class TheFadeCharacterSheet extends ActorSheet {
             else ui.notifications.info("No Species item attached. Drop a Species, browse one, or enable Manual entry.");
         });
 
-        // Right-click a talent name in the Stats-tab summary to open its sheet.
-        html.find('.talent-summary-item').on('contextmenu', ev => {
+        // Right-click a path name in the Stats-tab summary to open its sheet.
+        html.find('.path-summary-item').on('contextmenu', ev => {
             ev.preventDefault();
             const itemId = ev.currentTarget.dataset.itemId;
             const item = itemId ? this.actor.items.get(itemId) : null;

--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -6647,7 +6647,7 @@ select[name="system.aura.color"] option[value="white"] {
 
 .thefade .identity-row .species-item,
 .thefade .identity-row .species-card,
-.thefade .identity-row .talents-summary-card,
+.thefade .identity-row .paths-summary-card,
 .thefade .identity-row .aura-card {
     background: var(--bg-surface);
     border: 1px solid var(--border-faint);
@@ -6789,7 +6789,36 @@ select[name="system.aura.color"] option[value="white"] {
     font-style: italic;
 }
 
-.thefade .talents-summary-list {
+.thefade .paths-summary-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 8px;
+}
+
+.thefade .paths-summary-header h2 {
+    margin: 0 !important;
+}
+
+.thefade .level-inline {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.75em;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    color: var(--text-muted);
+    font-weight: 600;
+    margin-left: auto;
+    order: 2;
+}
+
+.thefade .level-inline input {
+    width: 48px;
+    text-align: center;
+}
+
+.thefade .paths-summary-list {
     list-style: none;
     margin: 0;
     padding: 0;
@@ -6798,7 +6827,11 @@ select[name="system.aura.color"] option[value="white"] {
     gap: 4px;
 }
 
-.thefade .talent-summary-item {
+.thefade .path-summary-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
     padding: 6px 10px;
     background: var(--bg-surface-deep);
     border: 1px solid var(--border-faint);
@@ -6807,7 +6840,14 @@ select[name="system.aura.color"] option[value="white"] {
     cursor: context-menu;
 }
 
-.thefade .talents-summary-empty {
+.thefade .path-summary-tier {
+    font-size: 0.8em;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+}
+
+.thefade .paths-summary-empty {
     margin: 0;
     color: var(--text-muted);
     font-size: 0.9em;

--- a/templates/actor/character-sheet.html
+++ b/templates/actor/character-sheet.html
@@ -81,7 +81,7 @@
     <section class="sheet-body">
         {{!-- Main Tab --}}
         <div class="tab" data-group="primary" data-tab="main">
-            {{!-- Identity: Species + Talents summary --}}
+            {{!-- Identity: Species + Paths summary --}}
             <div class="identity-row identity-row-top">
                 <div class="species-card{{#if system.species.manualEntry}} species-card-manual{{/if}}" data-item-id="{{actor.speciesItem._id}}">
                     <h2>
@@ -129,16 +129,25 @@
                     {{/if}}
                 </div>
 
-                <div class="talents-summary-card">
-                    <h2>Talents</h2>
-                    {{#if actor.talents.length}}
-                    <ul class="talents-summary-list">
-                        {{#each actor.talents as |talent|}}
-                        <li class="talent-summary-item" data-item-id="{{talent._id}}" title="Right-click to open talent">{{talent.name}}</li>
+                <div class="paths-summary-card">
+                    <div class="paths-summary-header">
+                        <label class="level-inline">
+                            <span>Level</span>
+                            <input type="number" name="system.level" value="{{system.level}}" data-dtype="Number" min="0" />
+                        </label>
+                        <h2>Paths</h2>
+                    </div>
+                    {{#if actor.paths.length}}
+                    <ul class="paths-summary-list">
+                        {{#each actor.paths as |path|}}
+                        <li class="path-summary-item" data-item-id="{{path._id}}" title="Right-click to open path">
+                            <span class="path-summary-name">{{path.name}}</span>
+                            {{#if path.system.tier}}<span class="path-summary-tier">Tier {{path.system.tier}}</span>{{/if}}
+                        </li>
                         {{/each}}
                     </ul>
                     {{else}}
-                    <p class="talents-summary-empty"><em>No talents yet</em></p>
+                    <p class="paths-summary-empty"><em>No paths yet</em></p>
                     {{/if}}
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Replaces the Talents summary card next to Species on the Stats tab with a **Paths** card — talents already live on the Abilities tab, so the adjacency that makes sense is Species + Paths.
- Adds a compact inline **Level** field in the Paths card header.
- Right-clicking a path in the summary opens that path's item sheet.

## Why
After the previous Stats-tab cleanup landed, the identity row paired Species with Talents — but the intent was Species + Paths. This corrects that and surfaces Level alongside Paths since they're conceptually tied.

## Test plan
- [ ] Open a character with paths attached: each path renders with name + Tier; right-click opens the path item.
- [ ] Open a character with no paths: shows "No paths yet" placeholder.
- [ ] Edit the Level field inline; confirm it persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)