### PR TITLE
Fix Level field double-entry and header re-render flash

### DIFF
--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -242,7 +242,6 @@
   margin-bottom: 10px;
   border-bottom: 2px solid var(--primary-color);
   padding-bottom: 5px;
-  animation: fadeIn 0.3s ease-out;
 }
 
 .thefade .profile-img {

--- a/templates/actor/parts/paths.html
+++ b/templates/actor/parts/paths.html
@@ -8,7 +8,7 @@
             <div class="core-stats">
                 <div class="form-group">
                     <label>Level</label>
-                    <input type="number" name="system.level" value="{{system.level}}" data-dtype="Number" class="level-input" />
+                    <input type="number" value="{{system.level}}" data-dtype="Number" class="level-input" readonly title="Edit Level on the Stats tab" />
                 </div>
                 <div class="form-group">
                     <label>Experience</label>


### PR DESCRIPTION
## Summary
- Two `<input name=\"system.level\">` lived on the same form (Stats tab and Abilities tab). On submit, the hidden tab's stale value overwrote the edit, so typing once appeared to do nothing — only a second edit \"took.\" The Abilities-tab Level input is now a readonly display; the Stats-tab input owns the value.
- Removed the `fadeIn` animation from `.thefade .sheet-header`. Foundry re-renders the sheet on every edit, which replayed the animation and made the header visibly flash.

## Test plan
- [ ] Open a character sheet, edit Level on the Stats tab — value sticks on first entry.
- [ ] Edit any other field — header no longer flashes.
- [ ] Abilities tab still shows the current Level (readonly) alongside Experience and Monster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)