### PR TITLE
Clean up Abilities tab: remove progression blocks, unify section styling

### DIFF
--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -9633,3 +9633,222 @@ select[name="system.aura.color"] option[value="white"] {
     color: #555;
     margin-bottom: 8px;
 }
+
+/* ============================================================
+   ABILITIES TAB — unified Paths / Talents / Precepts / Traits
+   ============================================================ */
+.thefade .paths-section {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.thefade .abilities-block {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-faint);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.thefade .abilities-heading {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0 !important;
+    padding: 10px 14px;
+    background: var(--bg-surface-deep);
+    border-bottom: 1px solid var(--border-faint);
+    font-size: 0.85em !important;
+    text-transform: uppercase;
+    letter-spacing: 1.2px;
+    color: var(--accent-gold) !important;
+    font-weight: 600;
+}
+
+.thefade .abilities-heading::before { display: none !important; }
+
+.thefade .abilities-heading > i {
+    color: var(--accent-crimson);
+    font-size: 1.05em;
+}
+
+.thefade .abilities-heading .abilities-title { flex: 0 0 auto; }
+
+.thefade .abilities-heading .abilities-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 22px;
+    height: 18px;
+    padding: 0 6px;
+    border-radius: 9px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-faint);
+    color: var(--text-muted);
+    font-size: 0.75em;
+    font-weight: 600;
+    letter-spacing: 0;
+}
+
+.thefade .abilities-heading .abilities-actions {
+    margin-left: auto;
+    display: inline-flex;
+    gap: 10px;
+}
+
+.thefade .abilities-heading .abilities-actions a {
+    color: var(--text-muted);
+    transition: color var(--transition-speed) ease;
+}
+
+.thefade .abilities-heading .abilities-actions a:hover {
+    color: var(--accent-hot);
+}
+
+.thefade .abilities-list {
+    display: flex;
+    flex-direction: column;
+    border: none !important;
+    border-radius: 0 !important;
+    background: transparent;
+}
+
+.thefade .abilities-list:empty {
+    display: none;
+}
+
+.thefade .ability-entry {
+    border: none;
+    border-bottom: 1px solid var(--border-faint);
+    background: var(--bg-surface);
+    transition: background var(--transition-speed) ease;
+    position: relative;
+}
+
+.thefade .ability-entry:last-child { border-bottom: none; }
+
+.thefade .ability-entry:hover {
+    background: var(--bg-surface-alt);
+}
+
+.thefade .ability-entry::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: transparent;
+    transition: background var(--transition-speed) ease;
+}
+
+.thefade .ability-entry:hover::before {
+    background: var(--accent-crimson);
+}
+
+.thefade .ability-checkbox { display: none; }
+
+.thefade .ability-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 9px 14px;
+    cursor: pointer;
+    background: transparent !important;
+    border: none !important;
+}
+
+.thefade .ability-name-container {
+    flex: 1;
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    min-width: 0;
+}
+
+.thefade .ability-name {
+    font-weight: 600;
+    color: var(--text-primary);
+    font-size: 0.95em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.thefade .ability-meta {
+    font-size: 0.78em;
+    color: var(--text-muted);
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: 0.3px;
+    padding: 1px 7px;
+    border: 1px solid var(--border-faint);
+    border-radius: 9px;
+    background: var(--bg-surface-deep);
+}
+
+.thefade .paths-section .path-tier.ability-meta {
+    color: var(--accent-gold);
+    border-color: var(--accent-gold);
+    background: transparent;
+}
+
+.thefade .ability-controls {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.thefade .ability-controls a {
+    color: var(--text-muted);
+    transition: color var(--transition-speed) ease;
+}
+
+.thefade .ability-controls a:hover { color: var(--accent-hot); }
+.thefade .ability-controls a.item-edit:hover { color: var(--accent-gold); }
+
+.thefade .ability-toggle-icon {
+    color: var(--text-muted);
+    font-size: 0.85em;
+    transition: transform var(--transition-speed) ease;
+    margin-left: 2px;
+}
+
+.thefade .ability-checkbox:checked ~ .ability-header .ability-toggle-icon {
+    transform: rotate(180deg);
+    color: var(--accent-crimson);
+}
+
+.thefade .ability-description {
+    max-height: 0;
+    overflow: hidden;
+    padding: 0 14px;
+    background: var(--bg-surface-deep);
+    border-top: 0 solid var(--border-faint);
+    color: var(--text-primary);
+    transition: max-height 0.25s ease, padding 0.25s ease, border-width 0.25s ease;
+}
+
+.thefade .ability-checkbox:checked ~ .ability-description {
+    max-height: 1000px;
+    padding: 10px 14px;
+    border-top-width: 1px;
+}
+
+.thefade .ability-description p { margin: 0 0 6px; line-height: 1.45; }
+.thefade .ability-description p:last-child { margin-bottom: 0; }
+
+.thefade .ability-description strong { color: var(--accent-gold); font-weight: 600; }
+
+.thefade .ability-description .path-abilities {
+    margin-top: 6px;
+    padding-top: 6px;
+    border-top: 1px dashed var(--border-faint);
+}
+
+.thefade .ability-description .path-ability {
+    margin: 3px 0;
+    padding-left: 10px;
+    border-left: 2px solid var(--border-faint);
+}
+

--- a/templates/actor/parts/paths.html
+++ b/templates/actor/parts/paths.html
@@ -1,90 +1,32 @@
 <section class="paths-section">
-    <!-- Character Progression Section -->
-    <div class="character-progression">
-        <h3>Character Progression</h3>
-
-        <!-- Core Stats -->
-        <div class="progression-core">
-            <div class="core-stats">
-                <div class="form-group">
-                    <label>Level</label>
-                    <input type="number" value="{{system.level}}" data-dtype="Number" class="level-input" readonly title="Edit Level on the Stats tab" />
-                </div>
-                <div class="form-group">
-                    <label>Experience</label>
-                    <input type="number" name="system.experience" value="{{system.experience}}" data-dtype="Number" />
-                </div>
-                <div class="form-group checkbox-group">
-                    <label>
-                        <input type="checkbox" name="system.isMonster" {{#if system.isMonster}} checked{{/if}} />
-                        Monster
-                    </label>
-                </div>
-            </div>
-        </div>
-
-        <!-- Path Progression -->
-        <div class="progression-paths">
-            <h4>Path Progression</h4>
-            <div class="path-stats">
-                <div class="form-group">
-                    <label>Paths Allowed</label>
-                    <input type="number" name="system.pathsAllowed" value="{{system.pathsAllowed}}" data-dtype="Number" readonly />
-                </div>
-                <div class="form-group">
-                    <label>Max Tier</label>
-                    <input type="number" name="system.maxTier" value="{{system.maxTier}}" data-dtype="Number" readonly />
-                </div>
-            </div>
-        </div>
-
-        <!-- Tier Levels (Collapsible) -->
-        <div class="progression-tiers">
-            <h4 class="progression-stats" data-target="tier-levels-content">
-                Tier Effective Levels
-            </h4>
-            <div class="collapsible-content" id="tier-levels-content">
-                <div class="tier-grid">
-                    <div class="tier-stat">
-                        <label>Tier 1 TL</label>
-                        <input type="number" name="system.tier1tl" value="{{system.tier1tl}}" data-dtype="Number" readonly />
-                    </div>
-                    <div class="tier-stat">
-                        <label>Tier 2 TL</label>
-                        <input type="number" name="system.tier2tl" value="{{system.tier2tl}}" data-dtype="Number" readonly />
-                    </div>
-                    <div class="tier-stat">
-                        <label>Tier 3 TL</label>
-                        <input type="number" name="system.tier3tl" value="{{system.tier3tl}}" data-dtype="Number" readonly />
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
     <!-- Paths -->
-    <div class="paths">
-        <h2>
-            Paths
-            <a class="item-create" title="Add Path" data-type="path"><i class="fas fa-plus"></i></a>
-            <a class="path-browse" title="Browse Paths"><i class="fas fa-search"></i></a>
+    <div class="paths abilities-block">
+        <h2 class="abilities-heading">
+            <i class="fas fa-road"></i>
+            <span class="abilities-title">Paths</span>
+            <span class="abilities-count">{{actor.paths.length}}</span>
+            <span class="abilities-actions">
+                <a class="item-create" title="Add Path" data-type="path"><i class="fas fa-plus"></i></a>
+                <a class="path-browse" title="Browse Paths"><i class="fas fa-search"></i></a>
+            </span>
         </h2>
 
-        <div class="paths-list">
+        <div class="paths-list abilities-list">
             {{#each actor.paths as |path id|}}
-            <div class="path-item" data-item-id="{{path._id}}">
-                <input type="checkbox" id="toggle-path-{{path._id}}" class="path-checkbox">
-                <div class="path-header">
-                    <label for="toggle-path-{{path._id}}" class="path-name-container">
-                        <div class="path-name">{{path.name}} <span class="path-tier">(Tier {{path.system.tier}})</span></div>
-                        <i class="fas fa-chevron-down path-toggle-icon"></i>
-                    </label>
-                    <div class="path-controls">
+            <div class="path-item ability-entry" data-item-id="{{path._id}}">
+                <input type="checkbox" id="toggle-path-{{path._id}}" class="path-checkbox ability-checkbox">
+                <label for="toggle-path-{{path._id}}" class="path-header ability-header">
+                    <div class="path-name-container ability-name-container">
+                        <span class="path-name ability-name">{{path.name}}</span>
+                        <span class="path-tier ability-meta">Tier {{path.system.tier}}</span>
+                    </div>
+                    <div class="path-controls ability-controls">
                         <a class="item-edit" title="Edit Path"><i class="fas fa-edit"></i></a>
                         <a class="item-delete" title="Delete Path"><i class="fas fa-trash"></i></a>
+                        <i class="fas fa-chevron-down path-toggle-icon ability-toggle-icon"></i>
                     </div>
-                </div>
-                <div class="path-description">
+                </label>
+                <div class="path-description ability-description">
                     <p><strong>Base HP:</strong> {{path.system.baseHP}}</p>
                     {{#if path.system.description}}
                     <p>{{path.system.description}}</p>
@@ -106,32 +48,36 @@
     </div>
 
     <!-- Talents -->
-    <div class="talents">
-        <h2>
-            Talents
-            <a class="item-create" title="Add Talent" data-type="talent"><i class="fas fa-plus"></i></a>
-            <a class="talent-browse" title="Browse Talents"><i class="fas fa-search"></i></a>
+    <div class="talents abilities-block">
+        <h2 class="abilities-heading">
+            <i class="fas fa-star"></i>
+            <span class="abilities-title">Talents</span>
+            <span class="abilities-count">{{actor.talents.length}}</span>
+            <span class="abilities-actions">
+                <a class="item-create" title="Add Talent" data-type="talent"><i class="fas fa-plus"></i></a>
+                <a class="talent-browse" title="Browse Talents"><i class="fas fa-search"></i></a>
+            </span>
         </h2>
 
-        <div class="talents-list">
+        <div class="talents-list abilities-list">
             {{#each actor.talents as |talent id|}}
-            <div class="talent-item" data-item-id="{{talent._id}}">
-                <input type="checkbox" id="toggle-talent-{{talent._id}}" class="talent-checkbox">
-                <div class="talent-header">
-                    <label for="toggle-talent-{{talent._id}}" class="talent-name-container">
-                        <div class="talent-name">{{talent.name}}</div>
-                        <i class="fas fa-chevron-down talent-toggle-icon"></i>
-                    </label>
-                    <div class="talent-controls">
+            <div class="talent-item ability-entry" data-item-id="{{talent._id}}">
+                <input type="checkbox" id="toggle-talent-{{talent._id}}" class="talent-checkbox ability-checkbox">
+                <label for="toggle-talent-{{talent._id}}" class="talent-header ability-header">
+                    <div class="talent-name-container ability-name-container">
+                        <span class="talent-name ability-name">{{talent.name}}</span>
+                        {{#if talent.system.usesPerDay}}
+                        <span class="ability-meta">{{talent.system.usesPerDay}}/day</span>
+                        {{/if}}
+                    </div>
+                    <div class="talent-controls ability-controls">
                         <a class="item-edit" title="Edit Talent"><i class="fas fa-edit"></i></a>
                         <a class="item-delete" title="Delete Talent"><i class="fas fa-trash"></i></a>
+                        <i class="fas fa-chevron-down talent-toggle-icon ability-toggle-icon"></i>
                     </div>
-                </div>
-                <div class="talent-description">
+                </label>
+                <div class="talent-description ability-description">
                     <p>{{talent.system.description}}</p>
-                    {{#if talent.system.usesPerDay}}
-                    <p><strong>Uses per Day:</strong> {{talent.system.usesPerDay}}</p>
-                    {{/if}}
                     {{#if talent.system.prerequisites}}
                     <p><strong>Prerequisites:</strong> {{talent.system.prerequisites}}</p>
                     {{/if}}
@@ -141,52 +87,37 @@
         </div>
     </div>
 
-    <!-- Talents Counter -->
-    <div class="talents-counter">
-        <h3>Talent Count</h3>
-        <div class="talent-numbers">
-            <div class="form-group">
-                <label>From Level</label>
-                <input type="number" name="system.talentsFromLevel" value="{{system.talentsFromLevel}}" data-dtype="Number" readonly />
-            </div>
-            <div class="form-group">
-                <label>Bonus</label>
-                <input type="number" name="system.talentsBonus" value="{{system.talentsBonus}}" data-dtype="Number" />
-            </div>
-            <div class="form-group">
-                <label>Total</label>
-                <input type="number" name="system.talentsTotal" value="{{system.talentsTotal}}" data-dtype="Number" readonly />
-            </div>
-        </div>
-    </div>
-
     <!-- Precepts -->
-    <div class="precepts">
-        <h2>
-            Precepts
-            <a class="item-create" title="Add Precept" data-type="precept"><i class="fas fa-plus"></i></a>
-            <a class="precept-browse" title="Browse Precepts"><i class="fas fa-search"></i></a>
+    <div class="precepts abilities-block">
+        <h2 class="abilities-heading">
+            <i class="fas fa-book"></i>
+            <span class="abilities-title">Precepts</span>
+            <span class="abilities-count">{{actor.precepts.length}}</span>
+            <span class="abilities-actions">
+                <a class="item-create" title="Add Precept" data-type="precept"><i class="fas fa-plus"></i></a>
+                <a class="precept-browse" title="Browse Precepts"><i class="fas fa-search"></i></a>
+            </span>
         </h2>
 
-        <div class="precepts-list">
+        <div class="precepts-list abilities-list">
             {{#each actor.precepts as |precept id|}}
-            <div class="precept-item" data-item-id="{{precept._id}}">
-                <input type="checkbox" id="toggle-precept-{{precept._id}}" class="precept-checkbox">
-                <div class="precept-header">
-                    <label for="toggle-precept-{{precept._id}}" class="precept-name-container">
-                        <div class="precept-name">{{precept.name}}</div>
-                        <i class="fas fa-chevron-down precept-toggle-icon"></i>
-                    </label>
-                    <div class="precept-controls">
+            <div class="precept-item ability-entry" data-item-id="{{precept._id}}">
+                <input type="checkbox" id="toggle-precept-{{precept._id}}" class="precept-checkbox ability-checkbox">
+                <label for="toggle-precept-{{precept._id}}" class="precept-header ability-header">
+                    <div class="precept-name-container ability-name-container">
+                        <span class="precept-name ability-name">{{precept.name}}</span>
+                        {{#if precept.system.deity}}
+                        <span class="ability-meta">{{precept.system.deity}}</span>
+                        {{/if}}
+                    </div>
+                    <div class="precept-controls ability-controls">
                         <a class="item-edit" title="Edit Precept"><i class="fas fa-edit"></i></a>
                         <a class="item-delete" title="Delete Precept"><i class="fas fa-trash"></i></a>
+                        <i class="fas fa-chevron-down precept-toggle-icon ability-toggle-icon"></i>
                     </div>
-                </div>
-                <div class="precept-description">
+                </label>
+                <div class="precept-description ability-description">
                     <p>{{precept.system.description}}</p>
-                    {{#if precept.system.deity}}
-                    <p><strong>Deity:</strong> {{precept.system.deity}}</p>
-                    {{/if}}
                     {{#if precept.system.domain}}
                     <p><strong>Domain:</strong> {{precept.system.domain}}</p>
                     {{/if}}
@@ -199,36 +130,39 @@
         </div>
     </div>
 
-
     <!-- Traits -->
-    <div class="traits">
-        <h2>
-            Traits
-            <a class="item-create" title="Add Trait" data-type="trait"><i class="fas fa-plus"></i></a>
-            <a class="trait-browse" title="Browse Traits"><i class="fas fa-search"></i></a>
+    <div class="traits abilities-block">
+        <h2 class="abilities-heading">
+            <i class="fas fa-feather"></i>
+            <span class="abilities-title">Traits</span>
+            <span class="abilities-count">{{actor.traits.length}}</span>
+            <span class="abilities-actions">
+                <a class="item-create" title="Add Trait" data-type="trait"><i class="fas fa-plus"></i></a>
+                <a class="trait-browse" title="Browse Traits"><i class="fas fa-search"></i></a>
+            </span>
         </h2>
 
-        <div class="traits-list">
+        <div class="traits-list abilities-list">
             {{#each actor.traits as |trait id|}}
-            <div class="trait-item" data-item-id="{{trait._id}}">
-                <input type="checkbox" id="toggle-trait-{{trait._id}}" class="trait-checkbox">
-                <div class="trait-header">
-                    <label for="toggle-trait-{{trait._id}}" class="trait-name-container">
-                        <div class="trait-name">{{trait.name}}</div>
-                        <i class="fas fa-chevron-down trait-toggle-icon"></i>
-                    </label>
-                    <div class="trait-controls">
+            <div class="trait-item ability-entry" data-item-id="{{trait._id}}">
+                <input type="checkbox" id="toggle-trait-{{trait._id}}" class="trait-checkbox ability-checkbox">
+                <label for="toggle-trait-{{trait._id}}" class="trait-header ability-header">
+                    <div class="trait-name-container ability-name-container">
+                        <span class="trait-name ability-name">{{trait.name}}</span>
+                        {{#if trait.system.source}}
+                        <span class="ability-meta">{{trait.system.source}}</span>
+                        {{/if}}
+                    </div>
+                    <div class="trait-controls ability-controls">
                         <a class="item-edit" title="Edit Trait"><i class="fas fa-edit"></i></a>
                         <a class="item-delete" title="Delete Trait"><i class="fas fa-trash"></i></a>
+                        <i class="fas fa-chevron-down trait-toggle-icon ability-toggle-icon"></i>
                     </div>
-                </div>
-                <div class="trait-description">
+                </label>
+                <div class="trait-description ability-description">
                     <p>{{trait.system.description}}</p>
                     {{#if trait.system.prerequisites}}
                     <p><strong>Prerequisites:</strong> {{trait.system.prerequisites}}</p>
-                    {{/if}}
-                    {{#if trait.system.source}}
-                    <p><strong>Source:</strong> {{trait.system.source}}</p>
                     {{/if}}
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Remove the **Character Progression** block (Level/XP/Monster, Paths Allowed/Max Tier, Tier Effective Levels) and the **Talent Count** block from the Abilities tab. Path Progression info is already surfaced on the Stats tab, so these were redundant clutter.
- Unify **Paths / Talents / Precepts / Traits** under a shared `.abilities-block` / `.ability-entry` structure with section icons, item count badges, inline meta chips (Tier, uses/day, deity, source), a hover accent strip, and a smoother collapse animation for descriptions.

## Why
The Abilities tab was visually noisy and duplicated data shown elsewhere. The four list sections also had inconsistent styling across older CSS passes. This consolidates them behind one polished pattern.

## Test plan
- [ ] Open a character sheet and switch to the Abilities tab — confirm Character Progression and Talent Count are gone.
- [ ] Verify each of Paths, Talents, Precepts, Traits renders the section header with icon, name, count badge, and + / search buttons.
- [ ] Expand/collapse an item in each section and confirm the chevron rotates and the description animates open smoothly.
- [ ] Confirm meta chips render: Tier on paths (gold), uses/day on talents, deity on precepts, source on traits.
- [ ] Edit / delete affordances still work on each row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)