### PR TITLE
Polish Inventory and Magic tabs to match Abilities styling

### DIFF
--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -9852,3 +9852,808 @@ select[name="system.aura.color"] option[value="white"] {
     border-left: 2px solid var(--border-faint);
 }
 
+/* ============================================================
+   INVENTORY + MAGIC TABS — unified polish (matches Abilities)
+   ============================================================ */
+
+/* ----- Section block card (mirrors .abilities-block) ----- */
+.thefade .inv-block {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-faint);
+    border-radius: 4px;
+    overflow: hidden;
+    margin-bottom: 14px;
+}
+
+.thefade .inv-block + .inv-block,
+.thefade .inv-subblock + .inv-subblock {
+    margin-top: 0;
+}
+
+.thefade .inv-block-body {
+    padding: 12px 14px;
+}
+
+/* ----- Section heading bar ----- */
+.thefade .inv-heading,
+.thefade .inv-subheading {
+    display: flex !important;
+    align-items: center;
+    justify-content: flex-start !important;
+    gap: 8px;
+    margin: 0 !important;
+    padding: 10px 14px !important;
+    background: var(--bg-surface-deep);
+    border: none !important;
+    border-bottom: 1px solid var(--border-faint) !important;
+    font-size: 0.85em !important;
+    text-transform: uppercase;
+    letter-spacing: 1.2px;
+    color: var(--accent-gold) !important;
+    font-weight: 600;
+    line-height: 1.4;
+}
+
+.thefade .inv-subheading {
+    padding: 8px 12px !important;
+    font-size: 0.78em !important;
+    letter-spacing: 1px;
+    background: linear-gradient(180deg, var(--bg-surface-deep) 0%, var(--bg-surface) 100%);
+}
+
+/* Neutralize generic sheet-body h2 underline pseudo */
+.thefade .inv-heading::before,
+.thefade .inv-subheading::before { display: none !important; }
+
+.thefade .inv-heading > i,
+.thefade .inv-subheading > i:first-of-type {
+    color: var(--accent-crimson);
+    font-size: 1.05em;
+    flex: 0 0 auto;
+}
+
+.thefade .inv-heading .inv-title,
+.thefade .inv-subheading .inv-title {
+    flex: 0 0 auto;
+    color: var(--accent-gold);
+}
+
+.thefade .inv-heading .inv-count,
+.thefade .inv-subheading .inv-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 22px;
+    height: 18px;
+    padding: 0 6px;
+    border-radius: 9px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-faint);
+    color: var(--text-muted);
+    font-size: 0.78em;
+    font-weight: 600;
+    letter-spacing: 0;
+}
+
+.thefade .inv-heading .inv-actions,
+.thefade .inv-subheading .inv-actions {
+    margin-left: auto;
+    display: inline-flex;
+    gap: 10px;
+    align-items: center;
+}
+
+.thefade .inv-heading .inv-actions a,
+.thefade .inv-subheading .inv-actions a {
+    color: var(--text-muted);
+    transition: color var(--transition-speed) ease;
+    cursor: pointer;
+}
+
+.thefade .inv-heading .inv-actions a:hover,
+.thefade .inv-subheading .inv-actions a:hover { color: var(--accent-hot); }
+
+/* Crimson-accent variant (e.g. Sin block) */
+.thefade .inv-block--crimson .inv-heading {
+    color: var(--accent-hot) !important;
+    border-bottom-color: var(--accent-crimson) !important;
+}
+
+.thefade .inv-block--crimson .inv-heading > i,
+.thefade .inv-block--crimson .inv-heading .inv-title {
+    color: var(--accent-hot);
+}
+
+/* Attunement chip in Items of Power heading */
+.thefade .inv-heading .attunement-limit {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 9px;
+    border-radius: 9px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-faint);
+    color: var(--text-muted);
+    font-size: 0.78em;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+    text-transform: none;
+}
+
+.thefade .inv-heading .attunement-limit i { color: var(--accent-gold); font-size: 0.9em; }
+.thefade .inv-heading .attunement-limit .current-attunements { color: var(--accent-gold); }
+.thefade .inv-heading .attunement-limit .attunement-sep { color: var(--text-muted); margin: 0 2px; }
+
+/* ----- Currency card (uses inv-block) ----- */
+.thefade .inventory-section .currency.inv-block {
+    border-left: 3px solid var(--accent-gold);
+    display: block;
+    margin-bottom: 14px;
+    padding: 0;
+    background: var(--bg-surface);
+}
+
+.thefade .inventory-section .currency .currency-body {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 10px 14px;
+}
+
+.thefade .inventory-section .currency .currency-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.thefade .inventory-section .currency .currency-item label {
+    font-size: 0.78em;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    margin: 0;
+}
+
+.thefade .inventory-section .currency .currency-item input {
+    width: 90px;
+    text-align: right;
+    background: var(--bg-surface-deep);
+    border: 1px solid var(--border-faint);
+    color: var(--text-primary);
+    padding: 3px 6px;
+    border-radius: 2px;
+}
+
+/* Hide the old .currency h2 styling within inv-block (now handled by .inv-heading) */
+.thefade .inventory-section .currency.inv-block > .inv-heading { margin: 0 !important; }
+
+/* ----- Inventory subtab nav (top: Weapons/Armor/...) — chrome refinement ----- */
+.thefade .inventory-tabs .tab-nav {
+    gap: 4px;
+    padding: 4px 4px 0;
+    background: var(--bg-surface-deep);
+    border: 1px solid var(--border-faint);
+    border-bottom: none;
+    border-radius: 4px 4px 0 0;
+    margin-bottom: 0;
+}
+
+.thefade .inventory-tabs .tab-button {
+    background: transparent;
+    border: 1px solid transparent;
+    border-bottom: none;
+    color: var(--text-muted);
+    padding: 7px 14px;
+    font-size: 0.82em;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    font-weight: 600;
+    border-radius: 3px 3px 0 0;
+    position: relative;
+    top: 1px;
+}
+
+.thefade .inventory-tabs .tab-button:hover {
+    color: var(--text-primary);
+    background: var(--bg-surface-alt);
+}
+
+.thefade .inventory-tabs .tab-button.active {
+    background: var(--bg-surface);
+    color: var(--accent-gold);
+    border-color: var(--border-faint);
+    border-bottom-color: var(--bg-surface);
+}
+
+.thefade .inventory-tabs .tab-button.active::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    height: 2px;
+    background: var(--accent-crimson);
+}
+
+.thefade .inventory-tabs > .tab-content {
+    border: 1px solid var(--border-faint);
+    border-top: none;
+    border-radius: 0 0 4px 4px;
+    padding: 14px;
+    background: var(--bg-surface);
+}
+
+/* ----- Subtab nav inside tabs (Potions/Drugs/Poisons etc.) ----- */
+.thefade .subtab-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2px;
+    background: var(--bg-surface-deep);
+    border: 1px solid var(--border-faint);
+    border-radius: 3px;
+    padding: 3px;
+    margin-bottom: 12px;
+}
+
+.thefade .subtab-button {
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--text-muted);
+    padding: 5px 11px;
+    font-size: 0.78em;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    font-weight: 600;
+    border-radius: 2px;
+    transition: all var(--transition-speed) ease;
+    cursor: pointer;
+}
+
+.thefade .subtab-button:hover {
+    color: var(--text-primary);
+    background: var(--bg-surface-alt);
+    border-bottom-color: transparent;
+}
+
+.thefade .subtab-button.active {
+    color: var(--accent-gold);
+    background: var(--bg-surface);
+    border-color: var(--border-faint);
+    border-bottom-color: var(--accent-crimson);
+}
+
+/* ----- Column header (gear-header / weapon-header) — tighter inside inv-block ----- */
+.thefade .inv-block .gear-header,
+.thefade .inv-subblock .gear-header,
+.thefade .inv-block .weapon-header,
+.thefade .inv-block .armor-header,
+.thefade .inv-block .companions-header,
+.thefade .inv-block .items-of-power-header,
+.thefade .inv-block .magic-gear-header,
+.thefade .inv-block .consumables-header {
+    background: var(--bg-surface-deep);
+    border: none;
+    border-bottom: 1px solid var(--border-faint);
+    border-radius: 0;
+    color: var(--text-muted);
+    font-size: 0.72em;
+    text-transform: uppercase;
+    letter-spacing: 0.9px;
+    font-weight: 600;
+    padding: 7px 12px;
+    margin: 0;
+}
+
+/* ----- Items list — hover crimson accent stripe ----- */
+.thefade .inv-block .items-list,
+.thefade .inv-subblock .items-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.thefade .inv-block .items-list .item,
+.thefade .inv-subblock .items-list .item {
+    background: var(--bg-surface);
+    border: none;
+    border-bottom: 1px solid var(--border-faint);
+    border-radius: 0;
+    color: var(--text-primary);
+    padding: 6px 12px;
+    transition: background var(--transition-speed) ease;
+    position: relative;
+}
+
+.thefade .inv-block .items-list .item::before,
+.thefade .inv-subblock .items-list .item::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: transparent;
+    transition: background var(--transition-speed) ease;
+}
+
+.thefade .inv-block .items-list .item:hover::before,
+.thefade .inv-subblock .items-list .item:hover::before {
+    background: var(--accent-crimson);
+}
+
+.thefade .inv-block .items-list .item:nth-child(even),
+.thefade .inv-subblock .items-list .item:nth-child(even) {
+    background: var(--bg-surface-alt);
+}
+
+.thefade .inv-block .items-list .item:hover,
+.thefade .inv-subblock .items-list .item:hover {
+    background: var(--bg-surface-alt);
+}
+
+.thefade .inv-block .items-list .item:last-child,
+.thefade .inv-subblock .items-list .item:last-child { border-bottom: none; }
+
+/* ----- Armor section ----- */
+.thefade .armor-section.inv-block .armor-slots-grid {
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.thefade .armor-section.inv-block .slot-row {
+    display: flex;
+    gap: 10px;
+}
+
+.thefade .armor-section.inv-block .slot-row > .armor-slot-container {
+    flex: 1;
+    min-width: 0;
+}
+
+/* Single-item rows (Shield) shouldn't stretch full width — keep half-width */
+.thefade .armor-section.inv-block .slot-row > .armor-slot-container.shield-section {
+    flex: 0 1 calc(50% - 5px);
+}
+
+/* Collapsible armor slot panels */
+.thefade .armor-slot-container.panel {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-faint);
+    border-radius: 4px;
+    padding: 0;
+    overflow: hidden;
+    position: relative;
+    transition: border-color var(--transition-speed) ease;
+}
+
+.thefade .armor-slot-container.panel:hover {
+    border-color: var(--accent-crimson);
+}
+
+.thefade .armor-slot-checkbox { display: none; }
+
+.thefade .armor-slot-container .slot-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 9px 12px;
+    cursor: pointer;
+    background: var(--bg-surface-deep);
+    border-bottom: 1px solid var(--border-faint);
+    margin: 0;
+    transition: background var(--transition-speed) ease;
+}
+
+.thefade .armor-slot-container .slot-header:hover {
+    background: var(--bg-surface-alt);
+}
+
+.thefade .armor-slot-container .slot-header .slot-icon {
+    color: var(--accent-crimson);
+    font-size: 0.95em;
+    flex: 0 0 auto;
+}
+
+.thefade .armor-slot-container .slot-header h4 {
+    margin: 0;
+    font-size: 0.8em;
+    text-transform: uppercase;
+    letter-spacing: 0.9px;
+    color: var(--accent-gold);
+    font-weight: 600;
+    flex: 0 0 auto;
+}
+
+.thefade .armor-slot-container .slot-header .total-ap {
+    margin-left: auto;
+    font-size: 0.78em;
+    color: var(--text-muted);
+    text-transform: none;
+    letter-spacing: 0.3px;
+}
+
+.thefade .armor-slot-container .slot-header .current-total-ap,
+.thefade .armor-slot-container .slot-header .max-total-ap {
+    color: var(--text-primary);
+    font-weight: 600;
+}
+
+.thefade .armor-slot-container .slot-header .armor-slot-toggle {
+    color: var(--text-muted);
+    font-size: 0.85em;
+    transition: transform var(--transition-speed) ease;
+    flex: 0 0 auto;
+    margin-left: 6px;
+}
+
+.thefade .armor-slot-container .armor-slot-checkbox:not(:checked) ~ .slot-header .armor-slot-toggle {
+    transform: rotate(-90deg);
+    color: var(--accent-gold);
+}
+
+/* Collapse children when unchecked */
+.thefade .armor-slot-container .natural-deflection-row,
+.thefade .armor-slot-container .derived-armor-section,
+.thefade .armor-slot-container .equipped-armor-list {
+    overflow: hidden;
+    max-height: 600px;
+    transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.2s ease, margin 0.2s ease;
+    opacity: 1;
+    padding-left: 12px;
+    padding-right: 12px;
+}
+
+.thefade .armor-slot-container .natural-deflection-row { padding-top: 10px; padding-bottom: 6px; }
+.thefade .armor-slot-container .equipped-armor-list,
+.thefade .armor-slot-container .derived-armor-section { padding-bottom: 8px; }
+
+.thefade .armor-slot-container .armor-slot-checkbox:not(:checked) ~ .natural-deflection-row,
+.thefade .armor-slot-container .armor-slot-checkbox:not(:checked) ~ .derived-armor-section,
+.thefade .armor-slot-container .armor-slot-checkbox:not(:checked) ~ .equipped-armor-list {
+    max-height: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    opacity: 0;
+    border: none;
+}
+
+/* Equipped armor row inside slot */
+.thefade .armor-slot-container .equipped-armor-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 0;
+    border-top: 1px dashed var(--border-faint);
+}
+
+.thefade .armor-slot-container .equipped-armor-item:first-child { border-top: none; }
+
+.thefade .armor-slot-container .equipped-armor-item .armor-icon {
+    width: 28px;
+    height: 28px;
+    border-radius: 2px;
+    border: 1px solid var(--border-faint);
+    object-fit: cover;
+    flex: 0 0 28px;
+}
+
+.thefade .armor-slot-container .equipped-armor-item .armor-info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+}
+
+.thefade .armor-slot-container .equipped-armor-item .armor-name {
+    font-size: 0.88em;
+    color: var(--text-primary);
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.thefade .armor-slot-container .equipped-armor-item .armor-ap-display {
+    font-size: 0.78em;
+    color: var(--text-muted);
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+}
+
+.thefade .armor-slot-container .equipped-armor-item .armor-current,
+.thefade .armor-slot-container .equipped-armor-item .derived-current { color: var(--accent-gold); font-weight: 600; }
+
+.thefade .armor-slot-container .equipped-armor-item .armor-current-ap {
+    width: 38px;
+    text-align: right;
+    background: var(--bg-surface-deep);
+    border: 1px solid var(--border-faint);
+    color: var(--accent-gold);
+    padding: 1px 4px;
+    font-size: 0.95em;
+    border-radius: 2px;
+}
+
+.thefade .armor-slot-container .equipped-armor-item .armor-controls {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.thefade .armor-slot-container .equipped-armor-item .armor-controls a,
+.thefade .armor-slot-container .equipped-armor-item .armor-controls button {
+    color: var(--text-muted);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 2px 4px;
+    font-size: 0.85em;
+    transition: color var(--transition-speed) ease;
+}
+
+.thefade .armor-slot-container .equipped-armor-item .armor-controls a:hover,
+.thefade .armor-slot-container .equipped-armor-item .armor-controls button:hover { color: var(--accent-hot); }
+
+/* Natural deflection row inside slot */
+.thefade .armor-slot-container .natural-deflection-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+    font-size: 0.82em;
+    border-bottom: 1px dashed var(--border-faint);
+    margin-bottom: 6px;
+}
+
+.thefade .armor-slot-container .natural-deflection-row .nd-input {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.thefade .armor-slot-container .natural-deflection-row .nd-input label {
+    font-size: 0.85em;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin: 0;
+}
+
+.thefade .armor-slot-container .natural-deflection-row .nd-input input {
+    width: 38px;
+    text-align: right;
+    background: var(--bg-surface-deep);
+    border: 1px solid var(--border-faint);
+    color: var(--text-primary);
+    padding: 1px 4px;
+    border-radius: 2px;
+}
+
+.thefade .armor-slot-container .natural-deflection-row .nd-controls .checkbox-label {
+    font-size: 0.85em;
+    color: var(--text-muted);
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.thefade .armor-slot-container .natural-deflection-row .nd-action-buttons {
+    margin-left: auto;
+    display: inline-flex;
+    gap: 4px;
+}
+
+.thefade .armor-slot-container .natural-deflection-row .nd-action-buttons button {
+    background: var(--bg-surface-deep);
+    border: 1px solid var(--border-faint);
+    color: var(--text-muted);
+    width: 24px;
+    height: 22px;
+    border-radius: 2px;
+    cursor: pointer;
+    transition: all var(--transition-speed) ease;
+}
+
+.thefade .armor-slot-container .natural-deflection-row .nd-action-buttons button:hover {
+    color: var(--accent-gold);
+    border-color: var(--accent-gold);
+}
+
+/* ----- Aura / Spells-Learned / Sin cards — drop legacy left-border, rely on inv-block ----- */
+.thefade .aura-card.inv-block,
+.thefade .spells-learned-counter.inv-block,
+.thefade .sin-dark-magic-section.inv-block {
+    border-left: 1px solid var(--border-faint);
+    padding: 0;
+    margin-bottom: 14px;
+}
+
+.thefade .aura-card.inv-block { border-left: 3px solid var(--accent-gold); }
+.thefade .spells-learned-counter.inv-block { border-left: 3px solid var(--accent-gold); }
+.thefade .sin-dark-magic-section.inv-block { border-left: 3px solid var(--accent-crimson); }
+
+.thefade .aura-card.inv-block > h2.inv-heading,
+.thefade .spells-learned-counter.inv-block > h2.inv-heading,
+.thefade .sin-dark-magic-section.inv-block > h2.inv-heading {
+    margin: 0 !important;
+    padding: 10px 14px !important;
+}
+
+.thefade .aura-card .aura-fields {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 10px;
+    margin-bottom: 10px;
+}
+
+.thefade .aura-card .aura-fields .form-group label {
+    font-size: 0.72em;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.thefade .aura-card .aura-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding-top: 8px;
+    border-top: 1px dashed var(--border-faint);
+}
+
+.thefade .aura-card .aura-property {
+    display: flex;
+    gap: 6px;
+    font-size: 0.88em;
+    color: var(--text-primary);
+}
+
+.thefade .aura-card .aura-property strong { color: var(--accent-gold); min-width: 80px; }
+.thefade .aura-card .aura-bonus { color: var(--text-muted); margin-left: auto; }
+
+.thefade .spells-learned-counter .spell-numbers {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+}
+
+.thefade .sin-dark-magic-section .sin-management {
+    margin-top: 8px;
+}
+
+.thefade .sin-dark-magic-section .sin-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.thefade .sin-dark-magic-section .sin-actions button {
+    background: var(--bg-surface-deep);
+    border: 1px solid var(--border-faint);
+    color: var(--text-primary);
+    padding: 4px 8px;
+    border-radius: 2px;
+    font-size: 0.82em;
+    cursor: pointer;
+    transition: all var(--transition-speed) ease;
+}
+
+.thefade .sin-dark-magic-section .sin-actions button:hover {
+    border-color: var(--accent-crimson);
+    color: var(--accent-hot);
+}
+
+.thefade .sin-dark-magic-section .addiction-stage-summary {
+    margin: 8px 0 0;
+    padding: 6px 10px;
+    background: var(--bg-surface-deep);
+    border-left: 2px solid var(--accent-crimson);
+    color: var(--text-muted);
+    font-size: 0.85em;
+}
+
+/* ----- Spells block ----- */
+.thefade .spells-block .spell-filters {
+    margin: 12px 14px 8px;
+    padding: 8px 10px;
+}
+
+.thefade .spells-block .spell-header {
+    margin: 0 14px;
+    background: var(--bg-surface-deep);
+    border: none;
+    border-bottom: 1px solid var(--border-faint);
+    color: var(--text-muted);
+    font-size: 0.72em;
+    text-transform: uppercase;
+    letter-spacing: 0.9px;
+    font-weight: 600;
+    padding: 7px 0;
+    display: flex;
+    gap: 6px;
+}
+
+.thefade .spells-block .spells-list { margin: 0 14px 12px; }
+
+.thefade .spell-wrapper {
+    border-bottom: 1px solid var(--border-faint);
+    background: var(--bg-surface);
+    position: relative;
+    transition: background var(--transition-speed) ease;
+}
+
+.thefade .spell-wrapper::before {
+    content: "";
+    position: absolute;
+    left: 0; top: 0; bottom: 0;
+    width: 2px;
+    background: transparent;
+    transition: background var(--transition-speed) ease;
+}
+
+.thefade .spell-wrapper:hover { background: var(--bg-surface-alt); }
+.thefade .spell-wrapper:hover::before { background: var(--accent-crimson); }
+.thefade .spell-wrapper:last-child { border-bottom: none; }
+
+.thefade .spell-checkbox { display: none; }
+
+.thefade .spell-item { background: transparent !important; border: none !important; }
+
+.thefade .spell-toggle-icon {
+    color: var(--text-muted);
+    font-size: 0.8em;
+    margin-left: 4px;
+    transition: transform var(--transition-speed) ease;
+}
+
+.thefade .spell-checkbox:checked ~ .spell-item .spell-toggle-icon {
+    transform: rotate(180deg);
+    color: var(--accent-crimson);
+}
+
+.thefade .spells-block .spell-description {
+    display: block;
+    max-height: 0;
+    overflow: hidden;
+    padding: 0 12px;
+    background: var(--bg-surface-deep);
+    border-top: 0 solid var(--border-faint);
+    transition: max-height 0.28s ease, padding 0.25s ease, border-width 0.25s ease;
+    animation: none;
+    margin: 0;
+}
+
+.thefade .spells-block .spell-checkbox:checked ~ .spell-description {
+    max-height: 1200px;
+    padding: 10px 12px;
+    border-top-width: 1px;
+}
+
+.thefade .spell-description-content { color: var(--text-primary); font-size: 0.92em; line-height: 1.5; margin-bottom: 6px; }
+.thefade .spell-details { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 4px 12px; }
+.thefade .spell-detail-label { font-size: 0.78em; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.4px; }
+.thefade .spell-detail-value { color: var(--accent-gold); font-size: 0.88em; }
+
+/* Sub-block bodies — give them a bit of breathing room */
+.thefade .inv-subblock { background: var(--bg-surface); border: 1px solid var(--border-faint); border-radius: 3px; margin-bottom: 12px; overflow: hidden; }
+.thefade .inv-subblock:last-child { margin-bottom: 0; }
+
+/* Old plain h2/h3 inside inventory/spells without inv-heading — keep clean if any */
+.thefade .inv-block > h2:not(.inv-heading),
+.thefade .inv-subblock > h3:not(.inv-subheading) {
+    margin: 0;
+    padding: 10px 14px;
+    background: var(--bg-surface-deep);
+    border-bottom: 1px solid var(--border-faint);
+    font-size: 0.85em;
+    text-transform: uppercase;
+    letter-spacing: 1.2px;
+    color: var(--accent-gold);
+    font-weight: 600;
+}
+

--- a/templates/actor/parts/inventory.html
+++ b/templates/actor/parts/inventory.html
@@ -1,10 +1,15 @@
 ﻿<section class="inventory-section">
     <!-- Currency -->
-    <div class="currency">
-        <h2>Currency</h2>
-        <div class="currency-item">
-            <label>Serpents (sp)</label>
-            <input type="text" name="system.currency.serpents" value="{{system.currency.serpents}}" data-dtype="Number" />
+    <div class="currency inv-block">
+        <h2 class="inv-heading">
+            <i class="fas fa-coins"></i>
+            <span class="inv-title">Currency</span>
+        </h2>
+        <div class="inv-block-body currency-body">
+            <div class="currency-item">
+                <label>Serpents (sp)</label>
+                <input type="text" name="system.currency.serpents" value="{{system.currency.serpents}}" data-dtype="Number" />
+            </div>
         </div>
     </div>
 
@@ -21,9 +26,17 @@
         </div>
 
         <div class="tab-content active" id="weapons-tab">
-            <div class="weapons">
-                <h2>Weapons</h2>
-                <header class="weapon-header flexrow">
+            <div class="weapons inv-block">
+                <h2 class="inv-heading">
+                    <i class="fas fa-gavel"></i>
+                    <span class="inv-title">Weapons</span>
+                    <span class="inv-count">{{actor.weapons.length}}</span>
+                    <span class="inv-actions">
+                        <a class="item-create" title="Add Weapon" data-type="weapon"><i class="fas fa-plus"></i></a>
+                        <a class="weapon-browse" title="Browse Weapons"><i class="fas fa-search"></i></a>
+                    </span>
+                </h2>
+                <header class="weapon-header flexrow gear-header">
                     <div class="weapon-icon">Icon</div>
                     <div class="weapon-name">Name</div>
                     <div class="weapon-skill">Skill</div>
@@ -33,10 +46,7 @@
                     <div class="weapon-crit">Crit</div>
                     <div class="weapon-range">Range</div>
                     <div class="weapon-qualities">Qualities</div>
-                    <div class="weapon-controls">
-                        <a class="item-create" title="Add Weapon" data-type="weapon"><i class="fas fa-plus"></i></a>
-                        <a class="weapon-browse" title="Browse Weapons"><i class="fas fa-search"></i></a>
-                    </div>
+                    <div class="weapon-controls"></div>
                 </header>
 
                 <ol class="items-list">
@@ -65,10 +75,13 @@
         </div>
 
         <div class="tab-content" id="armor-tab">
-            <div class="armor-section">
-                <h2>
-                    Armor
-                    <a class="reset-all-armor" title="Reset All Armor"><i class="fas fa-sync-alt"></i></a>
+            <div class="armor-section inv-block">
+                <h2 class="inv-heading">
+                    <i class="fas fa-shield-halved"></i>
+                    <span class="inv-title">Armor</span>
+                    <span class="inv-actions">
+                        <a class="reset-all-armor" title="Reset All Armor"><i class="fas fa-sync-alt"></i></a>
+                    </span>
                 </h2>
 
                 <!-- Armor Slots Grid -->
@@ -76,12 +89,15 @@
                     <!-- Row 1: Head and Body -->
                     <div class="slot-row">
                         <div class="armor-slot-container panel" data-slot="head">
-                            <div class="slot-header">
+                            <input type="checkbox" id="armor-slot-head" class="armor-slot-checkbox" checked>
+                            <label class="slot-header" for="armor-slot-head">
+                                <i class="fas fa-user-helmet-safety slot-icon"></i>
                                 <h4>Head</h4>
                                 <div class="total-ap">
                                     Total AP: <span class="current-total-ap">{{actor.armorTotals.head.current}}</span> / <span class="max-total-ap">{{actor.armorTotals.head.max}}</span>
                                 </div>
-                            </div>
+                                <i class="fas fa-chevron-down armor-slot-toggle"></i>
+                            </label>
 
                             <div class="natural-deflection-row">
                                 <div class="nd-input" title="Natural Deflection (Head)">
@@ -125,12 +141,15 @@
                         </div>
 
                         <div class="armor-slot-container panel" data-slot="body">
-                            <div class="slot-header">
+                            <input type="checkbox" id="armor-slot-body" class="armor-slot-checkbox" checked>
+                            <label class="slot-header" for="armor-slot-body">
+                                <i class="fas fa-shirt slot-icon"></i>
                                 <h4>Body</h4>
                                 <div class="total-ap">
                                     Total AP: <span class="current-total-ap">{{actor.armorTotals.body.current}}</span> / <span class="max-total-ap">{{actor.armorTotals.body.max}}</span>
                                 </div>
-                            </div>
+                                <i class="fas fa-chevron-down armor-slot-toggle"></i>
+                            </label>
 
                             <div class="natural-deflection-row">
                                 <div class="nd-input" title="Natural Deflection (Body)">
@@ -177,12 +196,15 @@
                     <!-- Row 2: Left Arm and Right Arm -->
                     <div class="slot-row">
                         <div class="armor-slot-container panel" data-slot="leftarm">
-                            <div class="slot-header">
+                            <input type="checkbox" id="armor-slot-leftarm" class="armor-slot-checkbox" checked>
+                            <label class="slot-header" for="armor-slot-leftarm">
+                                <i class="fas fa-hand-fist slot-icon"></i>
                                 <h4>Left Arm</h4>
                                 <div class="total-ap">
                                     Total AP: <span class="current-total-ap">{{actor.armorTotals.leftarm.current}}</span> / <span class="max-total-ap">{{actor.armorTotals.leftarm.max}}</span>
                                 </div>
-                            </div>
+                                <i class="fas fa-chevron-down armor-slot-toggle"></i>
+                            </label>
 
                             <div class="natural-deflection-row">
                                 <div class="nd-input" title="Natural Deflection (Left Arm)">
@@ -249,12 +271,15 @@
                         </div>
 
                         <div class="armor-slot-container panel" data-slot="rightarm">
-                            <div class="slot-header">
+                            <input type="checkbox" id="armor-slot-rightarm" class="armor-slot-checkbox" checked>
+                            <label class="slot-header" for="armor-slot-rightarm">
+                                <i class="fas fa-hand-fist slot-icon fa-flip-horizontal"></i>
                                 <h4>Right Arm</h4>
                                 <div class="total-ap">
                                     Total AP: <span class="current-total-ap">{{actor.armorTotals.rightarm.current}}</span> / <span class="max-total-ap">{{actor.armorTotals.rightarm.max}}</span>
                                 </div>
-                            </div>
+                                <i class="fas fa-chevron-down armor-slot-toggle"></i>
+                            </label>
 
                             <div class="natural-deflection-row">
                                 <div class="nd-input" title="Natural Deflection (Right Arm)">
@@ -324,12 +349,15 @@
                     <!-- Row 3: Left Leg and Right Leg -->
                     <div class="slot-row">
                         <div class="armor-slot-container panel" data-slot="leftleg">
-                            <div class="slot-header">
+                            <input type="checkbox" id="armor-slot-leftleg" class="armor-slot-checkbox" checked>
+                            <label class="slot-header" for="armor-slot-leftleg">
+                                <i class="fas fa-shoe-prints slot-icon"></i>
                                 <h4>Left Leg</h4>
                                 <div class="total-ap">
                                     Total AP: <span class="current-total-ap">{{actor.armorTotals.leftleg.current}}</span> / <span class="max-total-ap">{{actor.armorTotals.leftleg.max}}</span>
                                 </div>
-                            </div>
+                                <i class="fas fa-chevron-down armor-slot-toggle"></i>
+                            </label>
 
                             <div class="natural-deflection-row">
                                 <div class="nd-input" title="Natural Deflection (Left Leg)">
@@ -396,12 +424,15 @@
                         </div>
 
                         <div class="armor-slot-container panel" data-slot="rightleg">
-                            <div class="slot-header">
+                            <input type="checkbox" id="armor-slot-rightleg" class="armor-slot-checkbox" checked>
+                            <label class="slot-header" for="armor-slot-rightleg">
+                                <i class="fas fa-shoe-prints slot-icon fa-flip-horizontal"></i>
                                 <h4>Right Leg</h4>
                                 <div class="total-ap">
                                     Total AP: <span class="current-total-ap">{{actor.armorTotals.rightleg.current}}</span> / <span class="max-total-ap">{{actor.armorTotals.rightleg.max}}</span>
                                 </div>
-                            </div>
+                                <i class="fas fa-chevron-down armor-slot-toggle"></i>
+                            </label>
 
                             <div class="natural-deflection-row">
                                 <div class="nd-input" title="Natural Deflection (Right Leg)">
@@ -471,12 +502,15 @@
                     <!-- Shield Section -->
                     <div class="slot-row">
                         <div class="armor-slot-container panel shield-section" data-slot="shield">
-                            <div class="slot-header">
+                            <input type="checkbox" id="armor-slot-shield" class="armor-slot-checkbox" checked>
+                            <label class="slot-header" for="armor-slot-shield">
+                                <i class="fas fa-shield slot-icon"></i>
                                 <h4>Shield</h4>
                                 <div class="total-ap">
                                     Total AP: <span class="current-total-ap">{{actor.armorTotals.shield.current}}</span> / <span class="max-total-ap">{{actor.armorTotals.shield.max}}</span>
                                 </div>
-                            </div>
+                                <i class="fas fa-chevron-down armor-slot-toggle"></i>
+                            </label>
 
                             <div class="equipped-armor-list">
                                 {{#each actor.equippedArmor.shield as |armor|}}
@@ -504,17 +538,22 @@
                 </div>
 
                 <!-- Unequipped Armor -->
-                <div class="unequipped-armor">
-                    <h3>Unequipped Armor</h3>
+                <div class="unequipped-armor inv-subblock">
+                    <h3 class="inv-subheading">
+                        <i class="fas fa-box-archive"></i>
+                        <span class="inv-title">Unequipped Armor</span>
+                        <span class="inv-count">{{actor.unequippedArmor.length}}</span>
+                        <span class="inv-actions">
+                            <a class="item-create" title="Add Armor" data-type="armor"><i class="fas fa-plus"></i></a>
+                            <a class="armor-browse" title="Browse Armor"><i class="fas fa-search"></i></a>
+                        </span>
+                    </h3>
 
                     <header class="gear-header flexrow">
                         <div class="armor-name">Name</div>
                         <div class="armor-location">Location</div>
                         <div class="armor-ap">AP</div>
-                        <div class="armor-controls">
-                            <a class="item-create" title="Add Armor" data-type="armor"><i class="fas fa-plus"></i></a>
-                            <a class="armor-browse" title="Browse Armor"><i class="fas fa-search"></i></a>
-                        </div>
+                        <div class="armor-controls"></div>
                     </header>
 
                     <div class="items-list armor-items-list">
@@ -537,11 +576,14 @@
 
         <div class="tab-content" id="items-of-power-tab">
             <!-- Items of Power -->
-            <div class="magical-items">
-                <h2>
-                    Items of Power
-                    <span class="attunement-limit">
-                        Attuned: <span class="current-attunements">{{actor.currentAttunements}}</span> /
+            <div class="magical-items inv-block">
+                <h2 class="inv-heading">
+                    <i class="fas fa-gem"></i>
+                    <span class="inv-title">Items of Power</span>
+                    <span class="attunement-limit" title="Attuned / Max">
+                        <i class="fas fa-link"></i>
+                        <span class="current-attunements">{{actor.currentAttunements}}</span>
+                        <span class="attunement-sep">/</span>
                         <span class="max-attunements">{{actor.maxAttunements}}</span>
                     </span>
                 </h2>
@@ -798,16 +840,21 @@
                 </div>
 
                 <!-- Unequipped Items of Power -->
-                <div class="unequipped-magic-items">
-                    <h3>Unequipped Items of Power</h3>
+                <div class="unequipped-magic-items inv-subblock">
+                    <h3 class="inv-subheading">
+                        <i class="fas fa-box-archive"></i>
+                        <span class="inv-title">Unequipped Items of Power</span>
+                        <span class="inv-count">{{actor.unequippedItemsOfPower.length}}</span>
+                        <span class="inv-actions">
+                            <a class="item-create" title="Add Item of Power" data-type="magicitem"><i class="fas fa-plus"></i></a>
+                            <a class="item-browse" title="Browse Items"><i class="fas fa-search"></i></a>
+                        </span>
+                    </h3>
                     <header class="gear-header flexrow">
                         <div class="item-name">Name</div>
                         <div class="item-slot">Slot</div>
                         <div class="item-attunement">Attuned</div>
-                        <div class="item-controls">
-                            <a class="item-create" title="Add Item of Power" data-type="magicitem"><i class="fas fa-plus"></i></a>
-                            <a class="item-browse" title="Browse Items"><i class="fas fa-search"></i></a>
-                        </div>
+                        <div class="item-controls"></div>
                     </header>
 
                     <div class="items-list magic-items-list">
@@ -833,8 +880,11 @@
 
         <!-- Consumables Tab -->
         <div class="tab-content" id="consumables-tab">
-            <div class="consumables-section">
-                <h2>Consumables</h2>
+            <div class="consumables-section inv-block">
+                <h2 class="inv-heading">
+                    <i class="fas fa-flask"></i>
+                    <span class="inv-title">Consumables</span>
+                </h2>
 
                 <!-- Consumables Subtabs -->
                 <div class="subtab-nav">
@@ -845,18 +895,23 @@
 
                 <!-- Potions Subtab -->
                 <div class="subtab-content active" id="potions-subtab">
-                    <div class="potions">
-                        <h3>Potions</h3>
+                    <div class="potions inv-subblock">
+                        <h3 class="inv-subheading">
+                            <i class="fas fa-prescription-bottle"></i>
+                            <span class="inv-title">Potions</span>
+                            <span class="inv-count">{{actor.potion.length}}</span>
+                            <span class="inv-actions">
+                                <a class="item-create" title="Add Potion" data-type="potion"><i class="fas fa-plus"></i></a>
+                                <a class="potion-browse" title="Browse Potions"><i class="fas fa-search"></i></a>
+                            </span>
+                        </h3>
                         <header class="gear-header flexrow">
                             <div class="potion-name">Name</div>
                             <div class="potion-quantity">Quantity</div>
                             <div class="potion-effect">Effect</div>
                             <div class="potion-duration">Duration</div>
                             <div class="potion-rarity">Rarity</div>
-                            <div class="potion-controls">
-                                <a class="item-create" title="Add Potion" data-type="potion"><i class="fas fa-plus"></i></a>
-                                <a class="potion-browse" title="Browse Potions"><i class="fas fa-search"></i></a>
-                            </div>
+                            <div class="potion-controls"></div>
                         </header>
 
                         <ol class="items-list">
@@ -885,18 +940,23 @@
 
                 <!-- Drugs Subtab -->
                 <div class="subtab-content" id="drugs-subtab">
-                    <div class="drugs">
-                        <h3>Drugs</h3>
+                    <div class="drugs inv-subblock">
+                        <h3 class="inv-subheading">
+                            <i class="fas fa-pills"></i>
+                            <span class="inv-title">Drugs</span>
+                            <span class="inv-count">{{actor.drugs.length}}</span>
+                            <span class="inv-actions">
+                                <a class="item-create" title="Add Drug" data-type="drug"><i class="fas fa-plus"></i></a>
+                                <a class="drug-browse" title="Browse Drugs"><i class="fas fa-search"></i></a>
+                            </span>
+                        </h3>
                         <header class="gear-header flexrow">
                             <div class="drug-name">Name</div>
                             <div class="drug-quantity">Quantity</div>
                             <div class="drug-effect">Effect</div>
                             <div class="drug-addiction">Addiction Risk</div>
                             <div class="drug-tolerance">Tolerance</div>
-                            <div class="drug-controls">
-                                <a class="item-create" title="Add Drug" data-type="drug"><i class="fas fa-plus"></i></a>
-                                <a class="drug-browse" title="Browse Drugs"><i class="fas fa-search"></i></a>
-                            </div>
+                            <div class="drug-controls"></div>
                         </header>
 
                         <ol class="items-list">
@@ -927,18 +987,23 @@
 
                 <!-- Poisons Subtab -->
                 <div class="subtab-content" id="poisons-subtab">
-                    <div class="poisons">
-                        <h3>Poisons</h3>
+                    <div class="poisons inv-subblock">
+                        <h3 class="inv-subheading">
+                            <i class="fas fa-vial-virus"></i>
+                            <span class="inv-title">Poisons</span>
+                            <span class="inv-count">{{actor.poisons.length}}</span>
+                            <span class="inv-actions">
+                                <a class="item-create" title="Add Poison" data-type="poison"><i class="fas fa-plus"></i></a>
+                                <a class="poison-browse" title="Browse Poisons"><i class="fas fa-search"></i></a>
+                            </span>
+                        </h3>
                         <header class="gear-header flexrow">
                             <div class="poison-name">Name</div>
                             <div class="poison-quantity">Quantity</div>
                             <div class="poison-type">Type</div>
                             <div class="poison-potency">Potency</div>
                             <div class="poison-delivery">Delivery</div>
-                            <div class="poison-controls">
-                                <a class="item-create" title="Add Poison" data-type="poison"><i class="fas fa-plus"></i></a>
-                                <a class="poison-browse" title="Browse Poisons"><i class="fas fa-search"></i></a>
-                            </div>
+                            <div class="poison-controls"></div>
                         </header>
 
                         <ol class="items-list">
@@ -969,8 +1034,11 @@
 
         <!-- Magic Gear Tab -->
         <div class="tab-content" id="magic-gear-tab">
-            <div class="magic-gear-section">
-                <h2>Magic Gear</h2>
+            <div class="magic-gear-section inv-block">
+                <h2 class="inv-heading">
+                    <i class="fas fa-hat-wizard"></i>
+                    <span class="inv-title">Magic Gear</span>
+                </h2>
 
                 <!-- Magic Gear Subtabs -->
                 <div class="subtab-nav">
@@ -984,16 +1052,21 @@
 
                 <!-- Staffs Subtab -->
                 <div class="subtab-content active" id="staffs-subtab">
-                    <div class="staffs">
-                        <h3>Staffs</h3>
+                    <div class="staffs inv-subblock">
+                        <h3 class="inv-subheading">
+                            <i class="fas fa-staff-snake"></i>
+                            <span class="inv-title">Staffs</span>
+                            <span class="inv-count">{{actor.staff.length}}</span>
+                            <span class="inv-actions">
+                                <a class="item-create" title="Add Staff" data-type="staff"><i class="fas fa-plus"></i></a>
+                                <a class="staff-browse" title="Browse Staffs"><i class="fas fa-search"></i></a>
+                            </span>
+                        </h3>
                         <header class="gear-header flexrow">
                             <div class="staff-name">Name</div>
                             <div class="staff-charges">Uses Per Day</div>
                             <div class="staff-spells">Spell Level</div>
-                            <div class="staff-controls">
-                                <a class="item-create" title="Add Staff" data-type="staff"><i class="fas fa-plus"></i></a>
-                                <a class="staff-browse" title="Browse Staffs"><i class="fas fa-search"></i></a>
-                            </div>
+                            <div class="staff-controls"></div>
                         </header>
 
                         <ol class="items-list">
@@ -1021,17 +1094,22 @@
 
                 <!-- Wands Subtab -->
                 <div class="subtab-content" id="wands-subtab">
-                    <div class="wands">
-                        <h3>Wands</h3>
+                    <div class="wands inv-subblock">
+                        <h3 class="inv-subheading">
+                            <i class="fas fa-wand-sparkles"></i>
+                            <span class="inv-title">Wands</span>
+                            <span class="inv-count">{{actor.wand.length}}</span>
+                            <span class="inv-actions">
+                                <a class="item-create" title="Add Wand" data-type="wand"><i class="fas fa-plus"></i></a>
+                                <a class="wand-browse" title="Browse Wands"><i class="fas fa-search"></i></a>
+                            </span>
+                        </h3>
                         <header class="gear-header flexrow">
                             <div class="wand-name">Name</div>
                             <div class="wand-charges">Charges</div>
                             <div class="wand-spell">Spell</div>
                             <div class="wand-level">Spell Level</div>
-                            <div class="wand-controls">
-                                <a class="item-create" title="Add Wand" data-type="wand"><i class="fas fa-plus"></i></a>
-                                <a class="wand-browse" title="Browse Wands"><i class="fas fa-search"></i></a>
-                            </div>
+                            <div class="wand-controls"></div>
                         </header>
 
                         <ol class="items-list">
@@ -1061,17 +1139,22 @@
 
                 <!-- Communication Subtab -->
                 <div class="subtab-content" id="communication-subtab">
-                    <div class="communication">
-                        <h3>Communication</h3>
+                    <div class="communication inv-subblock">
+                        <h3 class="inv-subheading">
+                            <i class="fas fa-tower-broadcast"></i>
+                            <span class="inv-title">Communication</span>
+                            <span class="inv-count">{{actor.communication.length}}</span>
+                            <span class="inv-actions">
+                                <a class="item-create" title="Add Communication Device" data-type="communication"><i class="fas fa-plus"></i></a>
+                                <a class="comm-browse" title="Browse Communication"><i class="fas fa-search"></i></a>
+                            </span>
+                        </h3>
                         <header class="gear-header flexrow">
                             <div class="comm-name">Name</div>
                             <div class="comm-range">Range</div>
                             <div class="comm-type">Type</div>
                             <div class="comm-active">Active</div>
-                            <div class="comm-controls">
-                                <a class="item-create" title="Add Communication Device" data-type="communication"><i class="fas fa-plus"></i></a>
-                                <a class="comm-browse" title="Browse Communication"><i class="fas fa-search"></i></a>
-                            </div>
+                            <div class="comm-controls"></div>
                         </header>
 
                         <ol class="items-list">
@@ -1099,17 +1182,22 @@
 
                 <!-- Containment Subtab -->
                 <div class="subtab-content" id="containment-subtab">
-                    <div class="containment">
-                        <h3>Containment</h3>
+                    <div class="containment inv-subblock">
+                        <h3 class="inv-subheading">
+                            <i class="fas fa-box"></i>
+                            <span class="inv-title">Containment</span>
+                            <span class="inv-count">{{actor.containment.length}}</span>
+                            <span class="inv-actions">
+                                <a class="item-create" title="Add Container" data-type="containment"><i class="fas fa-plus"></i></a>
+                                <a class="container-browse" title="Browse Containers"><i class="fas fa-search"></i></a>
+                            </span>
+                        </h3>
                         <header class="gear-header flexrow">
                             <div class="container-name">Name</div>
                             <div class="container-capacity">Capacity</div>
                             <div class="container-contents">Contents</div>
                             <div class="container-security">Security</div>
-                            <div class="container-controls">
-                                <a class="item-create" title="Add Container" data-type="containment"><i class="fas fa-plus"></i></a>
-                                <a class="container-browse" title="Browse Containers"><i class="fas fa-search"></i></a>
-                            </div>
+                            <div class="container-controls"></div>
                         </header>
 
                         <ol class="items-list">
@@ -1135,17 +1223,22 @@
 
                 <!-- Dimensional Gates Subtab -->
                 <div class="subtab-content" id="gates-subtab">
-                    <div class="gates">
-                        <h3>Dimensional Gates</h3>
+                    <div class="gates inv-subblock">
+                        <h3 class="inv-subheading">
+                            <i class="fas fa-dharmachakra"></i>
+                            <span class="inv-title">Dimensional Gates</span>
+                            <span class="inv-count">{{actor.gate.length}}</span>
+                            <span class="inv-actions">
+                                <a class="item-create" title="Add Gate" data-type="gate"><i class="fas fa-plus"></i></a>
+                                <a class="gate-browse" title="Browse Gates"><i class="fas fa-search"></i></a>
+                            </span>
+                        </h3>
                         <header class="gear-header flexrow">
                             <div class="gate-name">Name</div>
                             <div class="gate-destination">Destination</div>
                             <div class="gate-stability">Stability</div>
                             <div class="gate-uses">Uses</div>
-                            <div class="gate-controls">
-                                <a class="item-create" title="Add Gate" data-type="gate"><i class="fas fa-plus"></i></a>
-                                <a class="gate-browse" title="Browse Gates"><i class="fas fa-search"></i></a>
-                            </div>
+                            <div class="gate-controls"></div>
                         </header>
 
                         <ol class="items-list">
@@ -1175,17 +1268,22 @@
 
                 <!-- Dream Harvesting Subtab -->
                 <div class="subtab-content" id="dream-subtab">
-                    <div class="dream-harvesting">
-                        <h3>Dream Harvesting</h3>
+                    <div class="dream-harvesting inv-subblock">
+                        <h3 class="inv-subheading">
+                            <i class="fas fa-moon"></i>
+                            <span class="inv-title">Dream Harvesting</span>
+                            <span class="inv-count">{{actor.dream.length}}</span>
+                            <span class="inv-actions">
+                                <a class="item-create" title="Add Dream Device" data-type="dream"><i class="fas fa-plus"></i></a>
+                                <a class="dream-browse" title="Browse Dream Devices"><i class="fas fa-search"></i></a>
+                            </span>
+                        </h3>
                         <header class="gear-header flexrow">
                             <div class="dream-name">Name</div>
                             <div class="dream-capacity">Capacity</div>
                             <div class="dream-stored">Stored Dreams</div>
                             <div class="dream-quality">Quality</div>
-                            <div class="dream-controls">
-                                <a class="item-create" title="Add Dream Device" data-type="dream"><i class="fas fa-plus"></i></a>
-                                <a class="dream-browse" title="Browse Dream Devices"><i class="fas fa-search"></i></a>
-                            </div>
+                            <div class="dream-controls"></div>
                         </header>
 
                         <ol class="items-list">
@@ -1213,8 +1311,11 @@
 
         <!-- Mundane Gear Tab -->
         <div class="tab-content" id="mundane-gear-tab">
-            <div class="mundane-gear-section">
-                <h2>Mundane Gear</h2>
+            <div class="mundane-gear-section inv-block">
+                <h2 class="inv-heading">
+                    <i class="fas fa-screwdriver-wrench"></i>
+                    <span class="inv-title">Mundane Gear</span>
+                </h2>
 
                 <!-- Mundane Gear Subtabs -->
                 <div class="subtab-nav">
@@ -1227,18 +1328,23 @@
 
                 <!-- Medical Subtab -->
                 <div class="subtab-content active" id="medical-subtab">
-                    <div class="medical">
-                        <h3>Medical Gear</h3>
+                    <div class="medical inv-subblock">
+                        <h3 class="inv-subheading">
+                            <i class="fas fa-kit-medical"></i>
+                            <span class="inv-title">Medical Gear</span>
+                            <span class="inv-count">{{actor.medical.length}}</span>
+                            <span class="inv-actions">
+                                <a class="item-create" title="Add Medical Item" data-type="medical"><i class="fas fa-plus"></i></a>
+                                <a class="medical-browse" title="Browse Medical"><i class="fas fa-search"></i></a>
+                            </span>
+                        </h3>
                         <header class="gear-header flexrow">
                             <div class="medical-name">Name</div>
                             <div class="medical-quantity">Quantity</div>
                             <div class="medical-type">Type</div>
                             <div class="medical-bonus">Bonus</div>
                             <div class="medical-uses">Uses</div>
-                            <div class="medical-controls">
-                                <a class="item-create" title="Add Medical Item" data-type="medical"><i class="fas fa-plus"></i></a>
-                                <a class="medical-browse" title="Browse Medical"><i class="fas fa-search"></i></a>
-                            </div>
+                            <div class="medical-controls"></div>
                         </header>
 
                         <ol class="items-list">
@@ -1271,18 +1377,23 @@
 
                 <!-- Biological Subtab -->
                 <div class="subtab-content" id="biological-subtab">
-                    <div class="biological">
-                        <h3>Biological</h3>
+                    <div class="biological inv-subblock">
+                        <h3 class="inv-subheading">
+                            <i class="fas fa-dna"></i>
+                            <span class="inv-title">Biological</span>
+                            <span class="inv-count">{{actor.biological.length}}</span>
+                            <span class="inv-actions">
+                                <a class="item-create" title="Add Biological Item" data-type="biological"><i class="fas fa-plus"></i></a>
+                                <a class="bio-browse" title="Browse Biological"><i class="fas fa-search"></i></a>
+                            </span>
+                        </h3>
                         <header class="gear-header flexrow">
                             <div class="bio-name">Name</div>
                             <div class="bio-quantity">Quantity</div>
                             <div class="bio-type">Type</div>
                             <div class="bio-condition">Condition</div>
                             <div class="bio-value">Value</div>
-                            <div class="bio-controls">
-                                <a class="item-create" title="Add Biological Item" data-type="biological"><i class="fas fa-plus"></i></a>
-                                <a class="bio-browse" title="Browse Biological"><i class="fas fa-search"></i></a>
-                            </div>
+                            <div class="bio-controls"></div>
                         </header>
 
                         <ol class="items-list">
@@ -1311,17 +1422,22 @@
 
                 <!-- Travel Subtab -->
                 <div class="subtab-content" id="travel-subtab">
-                    <div class="travel">
-                        <h3>Travel Gear</h3>
+                    <div class="travel inv-subblock">
+                        <h3 class="inv-subheading">
+                            <i class="fas fa-person-hiking"></i>
+                            <span class="inv-title">Travel Gear</span>
+                            <span class="inv-count">{{actor.travel.length}}</span>
+                            <span class="inv-actions">
+                                <a class="item-create" title="Add Travel Item" data-type="travel"><i class="fas fa-plus"></i></a>
+                                <a class="travel-browse" title="Browse Travel Gear"><i class="fas fa-search"></i></a>
+                            </span>
+                        </h3>
                         <header class="gear-header flexrow">
                             <div class="travel-name">Name</div>
                             <div class="travel-quantity">Quantity</div>
                             <div class="travel-weight">Weight</div>
                             <div class="travel-durability">Durability</div>
-                            <div class="travel-controls">
-                                <a class="item-create" title="Add Travel Item" data-type="travel"><i class="fas fa-plus"></i></a>
-                                <a class="travel-browse" title="Browse Travel Gear"><i class="fas fa-search"></i></a>
-                            </div>
+                            <div class="travel-controls"></div>
                         </header>
 
                         <ol class="items-list">
@@ -1349,17 +1465,22 @@
 
                 <!-- Musical Subtab -->
                 <div class="subtab-content" id="musical-subtab">
-                    <div class="musical">
-                        <h3>Musical Instruments</h3>
+                    <div class="musical inv-subblock">
+                        <h3 class="inv-subheading">
+                            <i class="fas fa-music"></i>
+                            <span class="inv-title">Musical Instruments</span>
+                            <span class="inv-count">{{actor.musical.length}}</span>
+                            <span class="inv-actions">
+                                <a class="item-create" title="Add Instrument" data-type="musical"><i class="fas fa-plus"></i></a>
+                                <a class="musical-browse" title="Browse Instruments"><i class="fas fa-search"></i></a>
+                            </span>
+                        </h3>
                         <header class="gear-header flexrow">
                             <div class="musical-name">Name</div>
                             <div class="musical-type">Type</div>
                             <div class="musical-quality">Quality</div>
                             <div class="musical-condition">Condition</div>
-                            <div class="musical-controls">
-                                <a class="item-create" title="Add Instrument" data-type="musical"><i class="fas fa-plus"></i></a>
-                                <a class="musical-browse" title="Browse Instruments"><i class="fas fa-search"></i></a>
-                            </div>
+                            <div class="musical-controls"></div>
                         </header>
 
                         <ol class="items-list">
@@ -1384,8 +1505,16 @@
                 </div>
 
                 <div class="subtab-content" id="clothing-subtab">
-                    <div class="clothing">
-                        <h3>Clothing & Accessories</h3>
+                    <div class="clothing inv-subblock">
+                        <h3 class="inv-subheading">
+                            <i class="fas fa-shirt"></i>
+                            <span class="inv-title">Clothing & Accessories</span>
+                            <span class="inv-count">{{actor.clothing.length}}</span>
+                            <span class="inv-actions">
+                                <a class="item-create" title="Add Clothing" data-type="clothing"><i class="fas fa-plus"></i></a>
+                                <a class="clothing-browse" title="Browse Clothing"><i class="fas fa-search"></i></a>
+                            </span>
+                        </h3>
                         <header class="gear-header flexrow">
                             <div class="clothing-name">Name</div>
                             <div class="clothing-type">Type</div>
@@ -1393,10 +1522,7 @@
                             <div class="clothing-material">Material</div>
                             <div class="clothing-quality">Quality</div>
                             <div class="clothing-protection">Protection</div>
-                            <div class="clothing-controls">
-                                <a class="item-create" title="Add Clothing" data-type="clothing"><i class="fas fa-plus"></i></a>
-                                <a class="clothing-browse" title="Browse Clothing"><i class="fas fa-search"></i></a>
-                            </div>
+                            <div class="clothing-controls"></div>
                         </header>
 
                         <ol class="items-list">
@@ -1428,8 +1554,11 @@
 
         <!-- Companions & Ridden Tab -->
         <div class="tab-content" id="companions-tab">
-            <div class="companions-section">
-                <h2>Companions & Ridden</h2>
+            <div class="companions-section inv-block">
+                <h2 class="inv-heading">
+                    <i class="fas fa-horse"></i>
+                    <span class="inv-title">Companions & Ridden</span>
+                </h2>
 
                 <!-- Companions Subtabs -->
                 <div class="subtab-nav">
@@ -1440,18 +1569,23 @@
 
                 <!-- Mounts Subtab -->
                 <div class="subtab-content active" id="mounts-subtab">
-                    <div class="mounts">
-                        <h3>Mounts</h3>
+                    <div class="mounts inv-subblock">
+                        <h3 class="inv-subheading">
+                            <i class="fas fa-horse"></i>
+                            <span class="inv-title">Mounts</span>
+                            <span class="inv-count">{{actor.mount.length}}</span>
+                            <span class="inv-actions">
+                                <a class="item-create" title="Add Mount" data-type="mount"><i class="fas fa-plus"></i></a>
+                                <a class="mount-browse" title="Browse Mounts"><i class="fas fa-search"></i></a>
+                            </span>
+                        </h3>
                         <header class="gear-header flexrow">
                             <div class="mount-name">Name</div>
                             <div class="mount-type">Type</div>
                             <div class="mount-hp">HP</div>
                             <div class="mount-speed">Speed</div>
                             <div class="mount-loyalty">Loyalty</div>
-                            <div class="mount-controls">
-                                <a class="item-create" title="Add Mount" data-type="mount"><i class="fas fa-plus"></i></a>
-                                <a class="mount-browse" title="Browse Mounts"><i class="fas fa-search"></i></a>
-                            </div>
+                            <div class="mount-controls"></div>
                         </header>
 
                         <ol class="items-list">
@@ -1484,18 +1618,23 @@
 
                 <!-- Fleshcraft Subtab -->
                 <div class="subtab-content" id="fleshcraft-subtab">
-                    <div class="fleshcraft">
-                        <h3>Fleshcraft</h3>
+                    <div class="fleshcraft inv-subblock">
+                        <h3 class="inv-subheading">
+                            <i class="fas fa-spaghetti-monster-flying"></i>
+                            <span class="inv-title">Fleshcraft</span>
+                            <span class="inv-count">{{actor.fleshcraft.length}}</span>
+                            <span class="inv-actions">
+                                <a class="item-create" title="Add Fleshcraft" data-type="fleshcraft"><i class="fas fa-plus"></i></a>
+                                <a class="fleshcraft-browse" title="Browse Fleshcraft"><i class="fas fa-search"></i></a>
+                            </span>
+                        </h3>
                         <header class="gear-header flexrow">
                             <div class="fleshcraft-name">Name</div>
                             <div class="fleshcraft-type">Type</div>
                             <div class="fleshcraft-hp">HP</div>
                             <div class="fleshcraft-sanity">Sanity Cost</div>
                             <div class="fleshcraft-active">Active</div>
-                            <div class="fleshcraft-controls">
-                                <a class="item-create" title="Add Fleshcraft" data-type="fleshcraft"><i class="fas fa-plus"></i></a>
-                                <a class="fleshcraft-browse" title="Browse Fleshcraft"><i class="fas fa-search"></i></a>
-                            </div>
+                            <div class="fleshcraft-controls"></div>
                         </header>
 
                         <ol class="items-list">
@@ -1557,18 +1696,23 @@
 
                 <!-- Vehicles Subtab -->
                 <div class="subtab-content" id="vehicles-subtab">
-                    <div class="vehicles">
-                        <h3>Vehicles</h3>
+                    <div class="vehicles inv-subblock">
+                        <h3 class="inv-subheading">
+                            <i class="fas fa-truck-pickup"></i>
+                            <span class="inv-title">Vehicles</span>
+                            <span class="inv-count">{{actor.vehicle.length}}</span>
+                            <span class="inv-actions">
+                                <a class="item-create" title="Add Vehicle" data-type="vehicle"><i class="fas fa-plus"></i></a>
+                                <a class="vehicle-browse" title="Browse Vehicles"><i class="fas fa-search"></i></a>
+                            </span>
+                        </h3>
                         <header class="gear-header flexrow">
                             <div class="vehicle-name">Name</div>
                             <div class="vehicle-type">Type</div>
                             <div class="vehicle-size">Size</div>
                             <div class="vehicle-speed">Speed</div>
                             <div class="vehicle-condition">Condition</div>
-                            <div class="vehicle-controls">
-                                <a class="item-create" title="Add Vehicle" data-type="vehicle"><i class="fas fa-plus"></i></a>
-                                <a class="vehicle-browse" title="Browse Vehicles"><i class="fas fa-search"></i></a>
-                            </div>
+                            <div class="vehicle-controls"></div>
                         </header>
 
                         <ol class="items-list">

--- a/templates/actor/parts/spells.html
+++ b/templates/actor/parts/spells.html
@@ -1,246 +1,265 @@
 <section class="spells-section">
     <!-- Aura -->
-    <div class="aura-card">
-        <h2>Aura</h2>
-        <div class="aura-fields">
-            <div class="form-group">
-                <label>Color</label>
-                <select name="system.aura.color">
-                    {{selectOptions auraColorOptions selected=system.aura.color}}
-                </select>
+    <div class="aura-card inv-block">
+        <h2 class="inv-heading">
+            <i class="fas fa-eye"></i>
+            <span class="inv-title">Aura</span>
+        </h2>
+        <div class="inv-block-body">
+            <div class="aura-fields">
+                <div class="form-group">
+                    <label>Color</label>
+                    <select name="system.aura.color">
+                        {{selectOptions auraColorOptions selected=system.aura.color}}
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label>Shape</label>
+                    <select name="system.aura.shape">
+                        {{selectOptions auraShapeOptions selected=system.aura.shape}}
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label>Intensity</label>
+                    <select name="system.aura.intensity">
+                        {{selectOptions auraIntensityOptions selected=system.aura.intensity}}
+                    </select>
+                </div>
             </div>
-            <div class="form-group">
-                <label>Shape</label>
-                <select name="system.aura.shape">
-                    {{selectOptions auraShapeOptions selected=system.aura.shape}}
-                </select>
-            </div>
-            <div class="form-group">
-                <label>Intensity</label>
-                <select name="system.aura.intensity">
-                    {{selectOptions auraIntensityOptions selected=system.aura.intensity}}
-                </select>
-            </div>
-        </div>
 
-        <div class="aura-info">
-            {{#if system.aura.color}}
-            <div class="aura-property">
-                <strong>Color:</strong> {{titleCase system.aura.color}}
-                <span class="aura-bonus">
-                    {{#if (eq system.aura.color "red")}}Athletics{{/if}}
-                    {{#if (eq system.aura.color "blue")}}Medicine{{/if}}
-                    {{#if (eq system.aura.color "green")}}Herbalism{{/if}}
-                    {{#if (eq system.aura.color "yellow")}}Research{{/if}}
-                    {{#if (eq system.aura.color "purple")}}Arcana{{/if}}
-                    {{#if (eq system.aura.color "orange")}}Etiquette{{/if}}
-                    {{#if (eq system.aura.color "pink")}}Seduction{{/if}}
-                    {{#if (eq system.aura.color "gold")}}Gambling{{/if}}
-                    {{#if (eq system.aura.color "silver")}}Symbology{{/if}}
-                    {{#if (eq system.aura.color "turquoise")}}Sight{{/if}}
-                    {{#if (eq system.aura.color "indigo")}}Ritual{{/if}}
-                    {{#if (eq system.aura.color "brown")}}Linguistics{{/if}}
-                    {{#if (eq system.aura.color "violet")}}Insight{{/if}}
-                    {{#if (eq system.aura.color "gray")}}Intimidate{{/if}}
-                    {{#if (eq system.aura.color "black")}}Toxicology{{/if}}
-                    {{#if (eq system.aura.color "white")}}Lore (Religion){{/if}}
-                </span>
-            </div>
-            {{/if}}
+            <div class="aura-info">
+                {{#if system.aura.color}}
+                <div class="aura-property">
+                    <strong>Color:</strong> {{titleCase system.aura.color}}
+                    <span class="aura-bonus">
+                        {{#if (eq system.aura.color "red")}}Athletics{{/if}}
+                        {{#if (eq system.aura.color "blue")}}Medicine{{/if}}
+                        {{#if (eq system.aura.color "green")}}Herbalism{{/if}}
+                        {{#if (eq system.aura.color "yellow")}}Research{{/if}}
+                        {{#if (eq system.aura.color "purple")}}Arcana{{/if}}
+                        {{#if (eq system.aura.color "orange")}}Etiquette{{/if}}
+                        {{#if (eq system.aura.color "pink")}}Seduction{{/if}}
+                        {{#if (eq system.aura.color "gold")}}Gambling{{/if}}
+                        {{#if (eq system.aura.color "silver")}}Symbology{{/if}}
+                        {{#if (eq system.aura.color "turquoise")}}Sight{{/if}}
+                        {{#if (eq system.aura.color "indigo")}}Ritual{{/if}}
+                        {{#if (eq system.aura.color "brown")}}Linguistics{{/if}}
+                        {{#if (eq system.aura.color "violet")}}Insight{{/if}}
+                        {{#if (eq system.aura.color "gray")}}Intimidate{{/if}}
+                        {{#if (eq system.aura.color "black")}}Toxicology{{/if}}
+                        {{#if (eq system.aura.color "white")}}Lore (Religion){{/if}}
+                    </span>
+                </div>
+                {{/if}}
 
-            {{#if system.aura.shape}}
-            <div class="aura-property">
-                <strong>Shape:</strong> {{titleCase system.aura.shape}}
-                <span class="aura-bonus">
-                    {{#if (eq system.aura.shape "circular")}}Etiquette{{/if}}
-                    {{#if (eq system.aura.shape "jagged")}}Trickery{{/if}}
-                    {{#if (eq system.aura.shape "flowing")}}Persuasion{{/if}}
-                    {{#if (eq system.aura.shape "spiky")}}Lockpicking{{/if}}
-                    {{#if (eq system.aura.shape "radiant")}}Deception{{/if}}
-                    {{#if (eq system.aura.shape "dense")}}Medicine{{/if}}
-                    {{#if (eq system.aura.shape "wispy")}}Sneaking{{/if}}
-                    {{#if (eq system.aura.shape "geometric")}}Research{{/if}}
-                </span>
-            </div>
-            {{/if}}
+                {{#if system.aura.shape}}
+                <div class="aura-property">
+                    <strong>Shape:</strong> {{titleCase system.aura.shape}}
+                    <span class="aura-bonus">
+                        {{#if (eq system.aura.shape "circular")}}Etiquette{{/if}}
+                        {{#if (eq system.aura.shape "jagged")}}Trickery{{/if}}
+                        {{#if (eq system.aura.shape "flowing")}}Persuasion{{/if}}
+                        {{#if (eq system.aura.shape "spiky")}}Lockpicking{{/if}}
+                        {{#if (eq system.aura.shape "radiant")}}Deception{{/if}}
+                        {{#if (eq system.aura.shape "dense")}}Medicine{{/if}}
+                        {{#if (eq system.aura.shape "wispy")}}Sneaking{{/if}}
+                        {{#if (eq system.aura.shape "geometric")}}Research{{/if}}
+                    </span>
+                </div>
+                {{/if}}
 
-            {{#if system.aura.intensity}}
-            <div class="aura-property">
-                <strong>Intensity:</strong> {{titleCase system.aura.intensity}}
-                <span class="aura-bonus">
-                    {{#if (eq system.aura.intensity "faint")}}+1D, 3 hex{{/if}}
-                    {{#if (eq system.aura.intensity "moderate")}}+2D, 2 hex{{/if}}
-                    {{#if (eq system.aura.intensity "intense")}}+3D, 1 hex{{/if}}
-                </span>
+                {{#if system.aura.intensity}}
+                <div class="aura-property">
+                    <strong>Intensity:</strong> {{titleCase system.aura.intensity}}
+                    <span class="aura-bonus">
+                        {{#if (eq system.aura.intensity "faint")}}+1D, 3 hex{{/if}}
+                        {{#if (eq system.aura.intensity "moderate")}}+2D, 2 hex{{/if}}
+                        {{#if (eq system.aura.intensity "intense")}}+3D, 1 hex{{/if}}
+                    </span>
+                </div>
+                {{/if}}
             </div>
-            {{/if}}
         </div>
     </div>
 
     <!-- Spells Learned Counter -->
-    <div class="spells-learned-counter">
-        <h3>Spells Learned</h3>
-        <div class="spell-numbers">
-            <div class="form-group">
-                <label>Base</label>
-                <input type="number" name="system.spellsLearnedBase" value="{{system.spellsLearnedBase}}" data-dtype="Number" />
-            </div>
-            <div class="form-group">
-                <label>From Level</label>
-                <input type="number" name="system.spellsLearnedFromLevel" value="{{system.spellsLearnedFromLevel}}" data-dtype="Number" readonly />
-            </div>
-            <div class="form-group">
-                <label>Total</label>
-                <input type="number" name="system.spellsLearnedTotal" value="{{system.spellsLearnedTotal}}" data-dtype="Number" readonly />
-            </div>
-        </div>
-    </div>
-
-    <hr />
-
-    <h2>Sin and Dark Magic</h2>
-
-    <div class="sin-dark-magic-section">
-        <!-- Dark Magic Spells Learned -->
-        <div class="dark-magic-spells">
-            <label>Dark Magic Spells Learned:</label>
-            <div class="dark-magic-checkboxes">
-                {{#times 10}}
-                <label class="checkbox-label">
-                    <input type="checkbox" name="system.darkMagic.spellsLearned.spell{{this}}"
-                           {{#if (lookup ../system.darkMagic.spellsLearned (concat "spell" this))}} checked{{/if}} />
-                    <span>{{this}}</span>
-                </label>
-                {{/times}}
-            </div>
-        </div>
-
-        <!-- Sin Management -->
-        <div class="sin-management grid grid-4col">
-            <div class="form-group">
-                <label>Current Sin</label>
-                <input type="number" name="system.darkMagic.currentSin" value="{{system.darkMagic.currentSin}}" data-dtype="Number" />
-            </div>
-
-            <div class="form-group">
-                <label>Sin Threshold</label>
-                <div class="flexrow">
-                    <input type="number" value="{{system.darkMagic.sinThreshold}}" disabled class="sin-threshold-value" />
-                    <span>+</span>
-                    <input type="number" name="system.darkMagic.sinThresholdBonus" value="{{system.darkMagic.sinThresholdBonus}}"
-                           data-dtype="Number" title="Bonus" class="small-input" />
+    <div class="spells-learned-counter inv-block">
+        <h2 class="inv-heading">
+            <i class="fas fa-book-sparkles"></i>
+            <span class="inv-title">Spells Learned</span>
+            <span class="inv-count">{{system.spellsLearnedTotal}}</span>
+        </h2>
+        <div class="inv-block-body">
+            <div class="spell-numbers">
+                <div class="form-group">
+                    <label>Base</label>
+                    <input type="number" name="system.spellsLearnedBase" value="{{system.spellsLearnedBase}}" data-dtype="Number" />
+                </div>
+                <div class="form-group">
+                    <label>From Level</label>
+                    <input type="number" name="system.spellsLearnedFromLevel" value="{{system.spellsLearnedFromLevel}}" data-dtype="Number" readonly />
+                </div>
+                <div class="form-group">
+                    <label>Total</label>
+                    <input type="number" name="system.spellsLearnedTotal" value="{{system.spellsLearnedTotal}}" data-dtype="Number" readonly />
                 </div>
             </div>
-
-            <div class="form-group">
-                <label>Addiction Level</label>
-                <select name="system.darkMagic.addictionLevel">
-                    {{selectOptions addictionLevelOptions selected=system.darkMagic.addictionLevel}}
-                </select>
-            </div>
-
-            <div class="form-group">
-                <button class="roll-addiction" type="button">Roll for Dark Magic Addiction</button>
-                <button class="rest-daily" type="button" title="Scrub accumulated Sin for the day (stages persist)">Rest (Clear Sin)</button>
-            </div>
         </div>
-        {{#if system.darkMagic.stageSummary}}
-        <p class="addiction-stage-summary"><em>Addiction: {{system.darkMagic.stageSummary}}</em></p>
-        {{/if}}
     </div>
 
-    <hr />
-
-    <h2>
-        Spells
-        <a class="item-create" title="Add Spell" data-type="spell"><i class="fas fa-plus"></i></a>
-        <a class="spell-browse" title="Browse Spells"><i class="fas fa-search"></i></a>
-    </h2>
-
-    <!-- Filter Controls -->
-    <div class="spell-filters">
-        <select class="spell-school-filter">
-            <option value="all">All Schools</option>
-            <option value="General">General</option>
-            <option value="Alchemy">Alchemy</option>
-            <option value="Divine">Divine</option>
-            <option value="Elementalism">Elementalism</option>
-            <option value="Malevolent">Malevolent</option>
-            <option value="Martial">Martial</option>
-            <option value="Naturalism">Naturalism</option>
-            <option value="Preternaturalism">Preternaturalism</option>
-            <option value="Rituals">Rituals</option>
-            <option value="Runes">Runes</option>
-            <option value="Spiritualism">Spiritualism</option>
-        </select>
-        <input type="text" class="spell-search" placeholder="Search spells..." />
-    </div>
-
-    <!-- Spell List -->
-    <div class="spell-header">
-        <div class="spell-name">Name</div>
-        <div class="spell-school">School</div>
-        <div class="spell-damage">Damage</div>
-        <div class="spell-time">Time</div>
-        <div class="spell-successes">Successes</div>
-        <div class="spell-attack">Attack</div>
-        <div class="spell-controls"></div>
-    </div>
-
-    <div class="spells-list">
-        {{#each actor.spells as |spell id|}}
-        <div class="spell-wrapper">
-            <input type="checkbox" id="toggle-spell-{{spell._id}}" class="spell-checkbox">
-            <div class="spell-item" data-item-id="{{spell._id}}" data-school="{{spell.system.school}}">
-                <div class="spell-name">
-                    <label for="toggle-spell-{{spell._id}}" class="spell-name-container">
-                        {{spell.name}}
-                        <i class="fas fa-chevron-down spell-toggle-icon"></i>
+    <!-- Sin and Dark Magic -->
+    <div class="sin-dark-magic-section inv-block inv-block--crimson">
+        <h2 class="inv-heading">
+            <i class="fas fa-skull"></i>
+            <span class="inv-title">Sin and Dark Magic</span>
+        </h2>
+        <div class="inv-block-body">
+            <!-- Dark Magic Spells Learned -->
+            <div class="dark-magic-spells">
+                <label>Dark Magic Spells Learned:</label>
+                <div class="dark-magic-checkboxes">
+                    {{#times 10}}
+                    <label class="checkbox-label">
+                        <input type="checkbox" name="system.darkMagic.spellsLearned.spell{{this}}"
+                               {{#if (lookup ../system.darkMagic.spellsLearned (concat "spell" this))}} checked{{/if}} />
+                        <span>{{this}}</span>
                     </label>
-                </div>
-                <div class="spell-school {{lowercase spell.system.school}}">{{spell.system.school}}</div>
-                <div class="spell-damage">{{#if spell.system.damage}}{{spell.system.damage}} {{spell.system.damageType}}{{else}}-{{/if}}</div>
-                <div class="spell-time">{{spell.system.time}}</div>
-                <div class="spell-successes">{{spell.system.successes}}</div>
-                <div class="spell-attack">{{#if spell.system.attack}}vs. {{spell.system.attack}}{{else}}-{{/if}}</div>
-                <div class="spell-controls">
-                    <a class="cast-spell" title="Cast Spell"><i class="fas fa-magic"></i></a>
-                    <a class="item-edit" title="Edit Spell"><i class="fas fa-edit"></i></a>
-                    <a class="item-delete" title="Delete Spell"><i class="fas fa-trash"></i></a>
+                    {{/times}}
                 </div>
             </div>
-            <div class="spell-description">
-                <div class="spell-description-content">
-                    {{spell.system.description}}
+
+            <!-- Sin Management -->
+            <div class="sin-management grid grid-4col">
+                <div class="form-group">
+                    <label>Current Sin</label>
+                    <input type="number" name="system.darkMagic.currentSin" value="{{system.darkMagic.currentSin}}" data-dtype="Number" />
                 </div>
-                <div class="spell-details">
-                    {{#if spell.system.range}}
-                    <div class="spell-detail-item">
-                        <div class="spell-detail-label">Range:</div>
-                        <div class="spell-detail-value">{{spell.system.range}}</div>
+
+                <div class="form-group">
+                    <label>Sin Threshold</label>
+                    <div class="flexrow">
+                        <input type="number" value="{{system.darkMagic.sinThreshold}}" disabled class="sin-threshold-value" />
+                        <span>+</span>
+                        <input type="number" name="system.darkMagic.sinThresholdBonus" value="{{system.darkMagic.sinThresholdBonus}}"
+                               data-dtype="Number" title="Bonus" class="small-input" />
                     </div>
-                    {{/if}}
-                    {{#if spell.system.bonusEffect}}
-                    <div class="spell-detail-item">
-                        <div class="spell-detail-label">Bonus Effect:</div>
-                        <div class="spell-detail-value">{{spell.system.bonusEffect}}</div>
-                    </div>
-                    {{/if}}
-                    {{#if spell.system.mishapModifier}}
-                    <div class="spell-detail-item">
-                        <div class="spell-detail-label">Mishap Modifier:</div>
-                        <div class="spell-detail-value">{{spell.system.mishapModifier}}</div>
-                    </div>
-                    {{/if}}
-                    {{#if spell.system.isDarkMagic}}
-                    <div class="spell-detail-item">
-                        <div class="spell-detail-label">Dark Magic:</div>
-                        <div class="spell-detail-value">Yes</div>
-                    </div>
-                    {{/if}}
+                </div>
+
+                <div class="form-group">
+                    <label>Addiction Level</label>
+                    <select name="system.darkMagic.addictionLevel">
+                        {{selectOptions addictionLevelOptions selected=system.darkMagic.addictionLevel}}
+                    </select>
+                </div>
+
+                <div class="form-group sin-actions">
+                    <button class="roll-addiction" type="button">Roll for Dark Magic Addiction</button>
+                    <button class="rest-daily" type="button" title="Scrub accumulated Sin for the day (stages persist)">Rest (Clear Sin)</button>
                 </div>
             </div>
+            {{#if system.darkMagic.stageSummary}}
+            <p class="addiction-stage-summary"><em>Addiction: {{system.darkMagic.stageSummary}}</em></p>
+            {{/if}}
         </div>
-        {{/each}}
+    </div>
+
+    <!-- Spells -->
+    <div class="spells-block inv-block">
+        <h2 class="inv-heading">
+            <i class="fas fa-wand-magic-sparkles"></i>
+            <span class="inv-title">Spells</span>
+            <span class="inv-count">{{actor.spells.length}}</span>
+            <span class="inv-actions">
+                <a class="item-create" title="Add Spell" data-type="spell"><i class="fas fa-plus"></i></a>
+                <a class="spell-browse" title="Browse Spells"><i class="fas fa-search"></i></a>
+            </span>
+        </h2>
+
+        <!-- Filter Controls -->
+        <div class="spell-filters">
+            <select class="spell-school-filter">
+                <option value="all">All Schools</option>
+                <option value="General">General</option>
+                <option value="Alchemy">Alchemy</option>
+                <option value="Divine">Divine</option>
+                <option value="Elementalism">Elementalism</option>
+                <option value="Malevolent">Malevolent</option>
+                <option value="Martial">Martial</option>
+                <option value="Naturalism">Naturalism</option>
+                <option value="Preternaturalism">Preternaturalism</option>
+                <option value="Rituals">Rituals</option>
+                <option value="Runes">Runes</option>
+                <option value="Spiritualism">Spiritualism</option>
+            </select>
+            <input type="text" class="spell-search" placeholder="Search spells..." />
+        </div>
+
+        <!-- Spell List -->
+        <div class="spell-header">
+            <div class="spell-name">Name</div>
+            <div class="spell-school">School</div>
+            <div class="spell-damage">Damage</div>
+            <div class="spell-time">Time</div>
+            <div class="spell-successes">Successes</div>
+            <div class="spell-attack">Attack</div>
+            <div class="spell-controls"></div>
+        </div>
+
+        <div class="spells-list">
+            {{#each actor.spells as |spell id|}}
+            <div class="spell-wrapper">
+                <input type="checkbox" id="toggle-spell-{{spell._id}}" class="spell-checkbox">
+                <div class="spell-item" data-item-id="{{spell._id}}" data-school="{{spell.system.school}}">
+                    <div class="spell-name">
+                        <label for="toggle-spell-{{spell._id}}" class="spell-name-container">
+                            {{spell.name}}
+                            <i class="fas fa-chevron-down spell-toggle-icon"></i>
+                        </label>
+                    </div>
+                    <div class="spell-school {{lowercase spell.system.school}}">{{spell.system.school}}</div>
+                    <div class="spell-damage">{{#if spell.system.damage}}{{spell.system.damage}} {{spell.system.damageType}}{{else}}-{{/if}}</div>
+                    <div class="spell-time">{{spell.system.time}}</div>
+                    <div class="spell-successes">{{spell.system.successes}}</div>
+                    <div class="spell-attack">{{#if spell.system.attack}}vs. {{spell.system.attack}}{{else}}-{{/if}}</div>
+                    <div class="spell-controls">
+                        <a class="cast-spell" title="Cast Spell"><i class="fas fa-magic"></i></a>
+                        <a class="item-edit" title="Edit Spell"><i class="fas fa-edit"></i></a>
+                        <a class="item-delete" title="Delete Spell"><i class="fas fa-trash"></i></a>
+                    </div>
+                </div>
+                <div class="spell-description">
+                    <div class="spell-description-content">
+                        {{spell.system.description}}
+                    </div>
+                    <div class="spell-details">
+                        {{#if spell.system.range}}
+                        <div class="spell-detail-item">
+                            <div class="spell-detail-label">Range:</div>
+                            <div class="spell-detail-value">{{spell.system.range}}</div>
+                        </div>
+                        {{/if}}
+                        {{#if spell.system.bonusEffect}}
+                        <div class="spell-detail-item">
+                            <div class="spell-detail-label">Bonus Effect:</div>
+                            <div class="spell-detail-value">{{spell.system.bonusEffect}}</div>
+                        </div>
+                        {{/if}}
+                        {{#if spell.system.mishapModifier}}
+                        <div class="spell-detail-item">
+                            <div class="spell-detail-label">Mishap Modifier:</div>
+                            <div class="spell-detail-value">{{spell.system.mishapModifier}}</div>
+                        </div>
+                        {{/if}}
+                        {{#if spell.system.isDarkMagic}}
+                        <div class="spell-detail-item">
+                            <div class="spell-detail-label">Dark Magic:</div>
+                            <div class="spell-detail-value">Yes</div>
+                        </div>
+                        {{/if}}
+                    </div>
+                </div>
+            </div>
+            {{/each}}
+        </div>
     </div>
 </section>


### PR DESCRIPTION
## Summary
- Unifies Inventory and Magic tabs around the Abilities-tab visual pattern: card-style `inv-block` sections with icon + gold uppercase title + count chip + right-aligned create/browse actions, plus a crimson hover accent stripe on list rows.
- Armor slot grid now has collapsible slots (Head, Body, L/R Arm, L/R Leg, Shield) with a label-as-toggle, slot icon, rotating chevron, and animated collapse — pure CSS via a hidden checkbox, no JS changes.
- Magic tab: Aura, Spells Learned, Sin & Dark Magic, and Spells are unified `inv-block` cards (Sin gets a crimson-accent variant). Spell descriptions use a smooth `max-height` collapse instead of the old hard `display:none` toggle.

## What changed
- **`templates/actor/parts/inventory.html`** — every top-level section (Currency, Weapons, Armor, Items of Power, Consumables, Magic Gear, Mundane Gear, Companions) and every nested subsection (Potions/Drugs/Poisons, Staffs/Wands/Communication/Containment/Gates/Dream, Medical/Biological/Travel/Musical/Clothing, Mounts/Fleshcraft/Vehicles, Unequipped Armor, Unequipped Items of Power) wears the unified heading bar. Duplicate create/browse actions inside column-header rows were removed in favor of the heading-level actions. Items of Power Attuned counter is now a chip in the heading. The 7 armor slots became collapsible.
- **`templates/actor/parts/spells.html`** — rewritten to use `inv-block` cards. Sin uses `inv-block--crimson`.
- **`styles/thefade.css`** — ~800-line addition at the end defining `.inv-block` / `.inv-subblock` / `.inv-heading` / `.inv-subheading` / `.inv-title` / `.inv-count` / `.inv-actions`, plus polished chrome for the inventory tab nav, subtab pills, gear-header column row, items-list hover accent stripe, armor slot collapse, and aura/spells-learned/sin cards. Scoped to override the older `.inventory-section h2` / `.spells-section h2` rules without disturbing unrelated styling.

## Why
Abilities was recently polished into a unified, scannable card pattern (#51). Inventory and Magic still carried the older v2 layout — inconsistent headings, scattered create/browse icons in column rows, no count chips, no collapsible armor slots. This pass brings them into visual parity so the whole sheet reads as one design system.

## Notes for reviewer
- No JS changes. The collapsible armor slots use a hidden `armor-slot-checkbox` sibling — `.slot-header` was converted from `<div>` to `<label>`, and no code searches the codebase reference `.slot-header` as a div selector.
- Count chips read from existing actor properties (`actor.weapons`, `actor.potion` singular, `actor.staff` singular, `actor.unequippedArmor`, etc.) — verified against `_prepareCharacterItems` in `src/character-sheet.js`.
- One concrete cascade fix included: the old `.spell-description { display: none }` rule would have killed the new `max-height` transition, so the new selectors set `display: block` explicitly under `.spells-block`.

## Test plan
- [ ] Open a character sheet and visit the Magic tab — confirm Aura / Spells Learned / Sin / Spells render as unified cards, spell rows expand/collapse smoothly, Sin card reads crimson.
- [ ] Visit the Inventory tab — confirm every section/subsection has the unified heading with count chip and working create/browse actions.
- [ ] On the Armor subtab, expand and collapse each of the 7 slot panels; verify the chevron rotates and the natural-deflection / equipped rows animate.
- [ ] Confirm row hover crimson stripe appears on weapon/spell/gear lists.
- [ ] Sanity-check at narrow window widths that headings still align.

🤖 Generated with [Claude Code](https://claude.com/claude-code)