### PR TITLE
Skills refactor: move off the Item model + polish Skills tab

### DIFF
--- a/src/actor.js
+++ b/src/actor.js
@@ -4,6 +4,7 @@ import { aggregateConditionState, computeRollModifiers, summarizeConditionState 
 import { applyBaseDefenseStances, applyPassiveStances, summarizeStance, getDamageMitigation } from './stances.js';
 import { applyAddictionPenalties, resetDailySin } from './dark-magic.js';
 import { applyAbilityEffects } from './abilities.js';
+import { getSkill } from './skills.js';
 
 /**
 * Base Actor class for The Fade system
@@ -579,11 +580,10 @@ export class TheFadeActor extends Actor {
         let finesseDodge = Math.floor(data.attributes.finesse.total / 4);
 
         // Find Acrobatics skill
-        const acrobaticsSkill = actor.items.find(i =>
-            i.type === 'skill' && i.name.toLowerCase() === 'acrobatics');
+        const acrobaticsSkill = getSkill(actor, "Acrobatics");
 
         if (acrobaticsSkill) {
-            const rank = acrobaticsSkill.system.rank;
+            const rank = acrobaticsSkill.rank;
             if (rank === 'adept') acrobonaticsDodge = 1;
             else if (rank === 'experienced') acrobonaticsDodge = 1;
             else if (rank === 'expert') acrobonaticsDodge = 2;
@@ -599,21 +599,19 @@ export class TheFadeActor extends Actor {
 
         // Calculate Passive Parry based on highest weapon skill
         let highestParry = 0;
-        const weaponSkills = actor.items.filter(i =>
-            i.type === 'skill' && ['Sword', 'Axe', 'Cudgel', 'Polearm', 'Unarmed'].includes(i.name));
-
-        weaponSkills.forEach(skill => {
+        const weaponSkillNames = ['Sword', 'Axe', 'Cudgel', 'Polearm', 'Unarmed'];
+        for (const name of weaponSkillNames) {
+            const skill = getSkill(actor, name);
+            if (!skill) continue;
             let parryValue = 0;
-            const rank = skill.system.rank;
-
+            const rank = skill.rank;
             if (rank === 'practiced') parryValue = 1;
             else if (rank === 'adept') parryValue = 2;
             else if (rank === 'experienced') parryValue = 3;
             else if (rank === 'expert') parryValue = 4;
             else if (rank === 'mastered') parryValue = 6;
-
             if (parryValue > highestParry) highestParry = parryValue;
-        });
+        }
 
         data.defenses.basePassiveParry = highestParry;
         const pParryBonus = Number(data.defenses.passiveParryBonus || 0);

--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -103,6 +103,9 @@ export class TheFadeCharacterSheet extends ActorSheet {
             "mastered": "Mastered"
         };
 
+        // Build the Skills tab view-model: groups by category with icons.
+        data.skillCategoryGroups = this._buildSkillCategoryGroups();
+
         // Additional safety checks
         if (!data.actor) {
             console.error("Actor missing from getData result");
@@ -1023,6 +1026,51 @@ export class TheFadeCharacterSheet extends ActorSheet {
                 skill.skillTypeDisplay = skill.skillType.charAt(0).toUpperCase() + skill.skillType.slice(1);
             }
         }
+    }
+
+    /**
+     * Build the grouped view-model the Skills tab renders from.
+     * Each group has { key, label, icon, skills: [...] } and each skill
+     * gets `attributeAbbr` + `calculatedDice` populated for the template.
+     */
+    _buildSkillCategoryGroups() {
+        const ATTR_ABBR = {
+            "physique": "PHY", "finesse": "FIN", "mind": "MND",
+            "presence": "PRS", "soul": "SOL",
+            "physique_finesse": "PHY/FIN", "physique_mind": "PHY/MND",
+            "mind_soul": "MND/SOL", "finesse_presence": "FIN/PRS"
+        };
+        const CATEGORY_META = [
+            { key: "Combat",    label: "Combat",    icon: "fa-gavel" },
+            { key: "Physical",  label: "Physical",  icon: "fa-person-running" },
+            { key: "Craft",     label: "Craft",     icon: "fa-hammer" },
+            { key: "Knowledge", label: "Knowledge", icon: "fa-book" },
+            { key: "Magical",   label: "Magical",   icon: "fa-wand-sparkles" },
+            { key: "Sense",     label: "Sense",     icon: "fa-eye" },
+            { key: "Social",    label: "Social",    icon: "fa-comments" }
+        ];
+
+        const byCategory = getSkillsByCategory(this.actor);
+        for (const list of Object.values(byCategory)) {
+            for (const skill of list) {
+                skill.calculatedDice = calculateSkillDice(this.actor, skill);
+                skill.attributeAbbr = ATTR_ABBR[skill.attribute] || (skill.attribute || "").toUpperCase();
+                skill.isCustomSkill = !!skill.isCustom;
+                skill.canDelete = !!skill.isCustom;
+            }
+        }
+
+        const groups = [];
+        for (const meta of CATEGORY_META) {
+            const list = byCategory[meta.key];
+            if (list && list.length) groups.push({ ...meta, skills: list });
+        }
+        // Any unknown category (defensive) gets dumped at the end.
+        for (const [cat, list] of Object.entries(byCategory)) {
+            if (CATEGORY_META.find(m => m.key === cat)) continue;
+            groups.push({ key: cat, label: cat, icon: "fa-star", skills: list });
+        }
+        return groups;
     }
 
     // --------------------------------------------------------------------

--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -7,6 +7,10 @@ import {
     openCompendiumBrowser, initializeDefaultSkills,
     createCustomSkill, showCustomSkillDialog
 } from './helpers.js';
+import {
+    getSkill, getSkillByKey, getAllSkills, getSkillsByCategory,
+    calculateSkillDice, deleteCustomSkill, slugifySkill
+} from './skills.js';
 import { renderModifierHtml } from './conditions.js';
 import { handleDarkCast } from './dark-magic.js';
 import { openOpposedRollDialog, openAidAnotherDialog } from './opposed.js';
@@ -277,7 +281,6 @@ export class TheFadeCharacterSheet extends ActorSheet {
         const armor = [];
         const paths = [];
         const spells = [];
-        const skills = [];
         const talents = [];
         const traits = [];
         const precepts = [];
@@ -382,7 +385,8 @@ export class TheFadeCharacterSheet extends ActorSheet {
                     spells.push(i);
                 }
                 else if (i.type === 'skill') {
-                    skills.push(i);
+                    // Skills are no longer items; legacy skill items are
+                    // migrated to actor.system.skills on world ready. Drop.
                 }
                 else if (i.type === 'talent') {
                     talents.push(i);
@@ -402,22 +406,8 @@ export class TheFadeCharacterSheet extends ActorSheet {
             }
         }
 
-        // Sort skills safely
-        try {
-            skills.sort((a, b) => {
-                const aCat = a.system?.category || '';
-                const bCat = b.system?.category || '';
-                const aName = a.name || '';
-                const bName = b.name || '';
-
-                if (aCat !== bCat) {
-                    return aCat.localeCompare(bCat);
-                }
-                return aName.localeCompare(bName);
-            });
-        } catch (error) {
-            console.error("Error sorting skills:", error);
-        }
+        // Skills now come from actor.system.skills (data, not items).
+        const skills = getAllSkills(this.actor);
 
         // Process Items of Power with ring slot logic
         const { equippedItemsOfPower, unequippedItemsOfPower } = this._processItemsOfPower(itemsOfPower);
@@ -520,48 +510,16 @@ export class TheFadeCharacterSheet extends ActorSheet {
      * @param {Object} actorData - Actor data
      */
     _calculateSkillDicePools(skills, actorData) {
-        if (!Array.isArray(skills) || !actorData?.system?.attributes) return;
-
-        skills.forEach(skill => {
-            if (!skill || !skill.system) return;
-
+        if (!Array.isArray(skills)) return;
+        for (const skill of skills) {
+            if (!skill) continue;
             try {
-                const attributeName = skill.system.attribute;
-                let attrValue = 0;
-
-                if (attributeName && attributeName.includes('_')) {
-                    const attributes = attributeName.split('_');
-                    const attr1 = actorData.system.attributes[attributes[0]]?.value || 0;
-                    const attr2 = actorData.system.attributes[attributes[1]]?.value || 0;
-                    attrValue = Math.floor((attr1 + attr2) / 2);
-                } else if (attributeName) {
-                    attrValue = actorData.system.attributes[attributeName]?.value || 0;
-                }
-
-                let dicePool = attrValue;
-
-                switch (skill.system.rank) {
-                    case "practiced": dicePool += 1; break;
-                    case "adept": dicePool += 2; break;
-                    case "experienced": dicePool += 3; break;
-                    case "expert": dicePool += 4; break;
-                    case "mastered": dicePool += 6; break;
-                    case "untrained": dicePool = Math.floor(dicePool / 2); break;
-                }
-
-                dicePool += (skill.system.miscBonus || 0);
-                // Apply bonuses from equipped Items of Power
-                const eb = actorData.system?.equippedBonuses;
-                if (eb) {
-                    dicePool += (eb.skills?.[skill.name] || 0) + (eb.skills?.all || 0);
-                    if (skill.system.category === "Magical") dicePool += (eb.spell || 0);
-                }
-                skill.calculatedDice = Math.max(1, dicePool);
+                skill.calculatedDice = calculateSkillDice(this.actor, skill);
             } catch (error) {
                 console.warn(`Error calculating dice pool for skill ${skill.name}:`, error);
                 skill.calculatedDice = 1;
             }
-        });
+        }
     }
 
     /**
@@ -754,19 +712,12 @@ export class TheFadeCharacterSheet extends ActorSheet {
 
     // Calculate spells learned from level (even levels if has spellcasting)
     _calculateSpellsLearnedFromLevel(level) {
-        // Check if character has spellcasting skill at Learned or higher
-        const spellcastingSkill = this.actor.items.find(i =>
-            i.type === 'skill' &&
-            i.name.toLowerCase().includes('spellcasting') &&
-            ['learned', 'practiced', 'adept', 'experienced', 'expert', 'mastered'].includes(i.system.rank)
-        );
-
-        if (!spellcastingSkill) return 0;
+        const spellcasting = getSkill(this.actor, "Spellcasting");
+        const trained = ['learned', 'practiced', 'adept', 'experienced', 'expert', 'mastered'];
+        if (!spellcasting || !trained.includes(spellcasting.rank)) return 0;
 
         let spells = 0;
-        for (let i = 2; i <= level; i += 2) { // Even levels starting at 2
-            spells++;
-        }
+        for (let i = 2; i <= level; i += 2) spells++;
         return spells;
     }
 
@@ -837,13 +788,9 @@ export class TheFadeCharacterSheet extends ActorSheet {
 
         // Spells learned (handled automatically in _prepareCharacterData)
         if (level % 2 === 0) {
-            const hasSpellcasting = this.actor.items.find(i =>
-                i.type === 'skill' &&
-                i.name.toLowerCase().includes('spellcasting') &&
-                ['learned', 'practiced', 'adept', 'experienced', 'expert', 'mastered'].includes(i.system.rank)
-            );
-
-            if (hasSpellcasting) {
+            const spellcasting = getSkill(this.actor, "Spellcasting");
+            const trained = ['learned', 'practiced', 'adept', 'experienced', 'expert', 'mastered'];
+            if (spellcasting && trained.includes(spellcasting.rank)) {
                 ui.notifications.info("You can learn a new spell! Check your spells learned count.");
             }
         }
@@ -1067,17 +1014,15 @@ export class TheFadeCharacterSheet extends ActorSheet {
     * @param {Array} skills - Array of skills
     */
     _markCustomSkills(skills) {
-        skills.forEach(skill => {
-            if (skill && skill.system) {
-                skill.isCustomSkill = !skill.system.isCore;
-                skill.canDelete = !skill.system.isCore;
-
-                // Add skill type display for custom skills
-                if (skill.system.skillType) {
-                    skill.skillTypeDisplay = skill.system.skillType.charAt(0).toUpperCase() + skill.system.skillType.slice(1);
-                }
+        if (!Array.isArray(skills)) return;
+        for (const skill of skills) {
+            if (!skill) continue;
+            skill.isCustomSkill = !!skill.isCustom;
+            skill.canDelete = !!skill.isCustom;
+            if (skill.skillType) {
+                skill.skillTypeDisplay = skill.skillType.charAt(0).toUpperCase() + skill.skillType.slice(1);
             }
-        });
+        }
     }
 
     // --------------------------------------------------------------------
@@ -1618,11 +1563,10 @@ export class TheFadeCharacterSheet extends ActorSheet {
         let finesseDodge = Math.floor((data.attributes.finesse.total ?? data.attributes.finesse.value) / 4);
 
         // Find Acrobatics skill
-        const acrobaticsSkill = actor.items.find(i =>
-            i.type === 'skill' && i.name.toLowerCase() === 'acrobatics');
+        const acrobaticsSkill = getSkill(actor, "Acrobatics");
 
         if (acrobaticsSkill) {
-            const rank = acrobaticsSkill.system.rank;
+            const rank = acrobaticsSkill.rank;
             if (rank === 'adept') acrobonaticsDodge = 1;
             else if (rank === 'experienced') acrobonaticsDodge = 1;
             else if (rank === 'expert') acrobonaticsDodge = 2;
@@ -1634,21 +1578,19 @@ export class TheFadeCharacterSheet extends ActorSheet {
 
         // Calculate Passive Parry from weapon skills
         let highestParry = 0;
-        const weaponSkills = actor.items.filter(i =>
-            i.type === 'skill' && ['Sword', 'Axe', 'Cudgel', 'Polearm', 'Heavy Weaponry', 'Unarmed'].includes(i.name));
-
-        weaponSkills.forEach(skill => {
+        const weaponSkillNames = ['Sword', 'Axe', 'Cudgel', 'Polearm', 'Heavy Weaponry', 'Unarmed'];
+        for (const name of weaponSkillNames) {
+            const skill = getSkill(actor, name);
+            if (!skill) continue;
             let parryValue = 0;
-            const rank = skill.system.rank;
-
+            const rank = skill.rank;
             if (rank === 'practiced') parryValue = 1;
             else if (rank === 'adept') parryValue = 2;
             else if (rank === 'experienced') parryValue = 3;
             else if (rank === 'expert') parryValue = 4;
             else if (rank === 'mastered') parryValue = 6;
-
             if (parryValue > highestParry) highestParry = parryValue;
-        });
+        }
 
         const basePassiveParry = highestParry;
 
@@ -1996,8 +1938,9 @@ export class TheFadeCharacterSheet extends ActorSheet {
     async _onSkillRoll(event) {
         event.preventDefault();
         const element = event.currentTarget;
-        const skillId = element.closest(".item").dataset.itemId;
-        const skill = this.actor.items.get(skillId);
+        const row = element.closest("[data-skill-key]");
+        const skillKey = row?.dataset.skillKey;
+        const skill = getSkillByKey(this.actor, skillKey);
 
         if (!skill) return;
 
@@ -2005,69 +1948,21 @@ export class TheFadeCharacterSheet extends ActorSheet {
         const dt = await this._getDifficultyThreshold("Skill Check Difficulty");
         if (dt === null) return; // User cancelled the dialog
 
-        const skillData = skill.system;
-        const attributeName = skillData.attribute;
-
-        // Get attribute value, handling combined attributes
-        let attrValue = 0;
-
-        if (attributeName.includes('_')) {
-            // Handle combined attributes like "physique_finesse"
-            const attributes = attributeName.split('_');
-            const attr1 = this.actor.system.attributes[attributes[0]]?.value || 0;
-            const attr2 = this.actor.system.attributes[attributes[1]]?.value || 0;
-            attrValue = Math.floor((attr1 + attr2) / 2); // Calculate average
-        } else {
-            // Normal single attribute
-            attrValue = this.actor.system.attributes[attributeName]?.value || 0;
-        }
-
-        let dicePool = attrValue;
-
-        // Add bonus dice based on skill rank
-        switch (skillData.rank) {
-            case "practiced":
-                dicePool += 1;
-                break;
-            case "adept":
-                dicePool += 2;
-                break;
-            case "experienced":
-                dicePool += 3;
-                break;
-            case "expert":
-                dicePool += 4;
-                break;
-            case "mastered":
-                dicePool += 6;
-                break;
-            case "untrained":
-                dicePool = Math.floor(dicePool / 2);
-                break;
-        }
-
-        // Add misc bonus dice
-        dicePool += (skillData.miscBonus || 0);
-
-        // Add bonuses from equipped Items of Power
-        const rollEb = this.actor.system?.equippedBonuses;
-        if (rollEb) {
-            dicePool += (rollEb.skills?.[skill.name] || 0) + (rollEb.skills?.all || 0);
-            if (skillData.category === "Magical") dicePool += (rollEb.spell || 0);
-        }
+        const attributeName = skill.attribute;
+        let dicePool = calculateSkillDice(this.actor, skill);
 
         // Apply active-condition modifiers before min-1 clamp
         const condMods = this.actor.getConditionRollModifiers({
             kind: "skill",
             skillName: skill.name,
-            skillCategory: skillData.category,
+            skillCategory: skill.category,
             attributeName: attributeName
         });
 
         if (condMods.autoFail) {
             ChatMessage.create({
                 speaker: ChatMessage.getSpeaker({ actor: this.actor }),
-                flavor: `${skill.name} Check (${skillData.rank})`,
+                flavor: `${skill.name} Check (${skill.rank})`,
                 content: renderModifierHtml(condMods) +
                     `<p><strong>${this.actor.name}</strong> cannot attempt this check due to an active condition.</p>`
             });
@@ -2114,8 +2009,8 @@ export class TheFadeCharacterSheet extends ActorSheet {
             successes: successes,
             dt: dt,
             success: rollSucceeds,
-            miscBonus: skillData.miscBonus || null,
-            rank: skillData.rank
+            miscBonus: skill.miscBonus || null,
+            rank: skill.rank
         };
 
         // Render the template, prepend condition modifier banner if any
@@ -2125,7 +2020,7 @@ export class TheFadeCharacterSheet extends ActorSheet {
         // Send to chat
         roll.toMessage({
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
-            flavor: `${skill.name} Check (${skillData.rank})`,
+            flavor: `${skill.name} Check (${skill.rank})`,
             content: content
         });
     }
@@ -2267,7 +2162,7 @@ export class TheFadeCharacterSheet extends ActorSheet {
         const skillName = weaponData.skill;
 
         // Find the appropriate skill
-        const skill = this.actor.items.find(i => i.type === "skill" && i.name === skillName);
+        const skill = getSkill(this.actor, skillName);
 
         if (!skill) {
             // Default to untrained if skill not found
@@ -2406,7 +2301,7 @@ export class TheFadeCharacterSheet extends ActorSheet {
             return;
         }
 
-        const skillData = skill.system;
+        const skillData = skill; // skill is already a merged data object
         const attributeName = skillData.attribute;
         // Get attribute value, handling combined attributes
         let attrValue = 0;
@@ -2856,14 +2751,14 @@ export class TheFadeCharacterSheet extends ActorSheet {
         const spellData = spell.system;
 
         // Find the Spellcasting skill
-        const spellcasting = this.actor.items.find(i => i.type === "skill" && i.name === "Spellcasting");
+        const spellcasting = getSkill(this.actor, "Spellcasting");
 
         if (!spellcasting) {
             ui.notifications.warn("Character does not have the Spellcasting skill.");
             return;
         }
 
-        const skillData = spellcasting.system;
+        const skillData = spellcasting; // merged data object
         // Get the attribute name from the skill
         const attributeName = skillData.attribute || "soul"; // Default to "soul" if not specified
         let attrValue = 0;
@@ -3883,40 +3778,38 @@ export class TheFadeCharacterSheet extends ActorSheet {
             const item = this.actor.items.get(itemId);
             if (!item) return;
 
-            // Prevent deletion of core skills
-            if (item.type === 'skill' && item.system.isCore) {
+            this.actor.deleteEmbeddedDocuments("Item", [itemId]);
+            li.slideUp(200, () => this.render(false));
+        });
+
+        // Custom-skill deletion (skills live on system.skills, not as items)
+        html.find('.skill-delete').off('click').click(ev => {
+            ev.preventDefault();
+            const row = ev.currentTarget.closest("[data-skill-key]");
+            const key = row?.dataset.skillKey;
+            if (!key) return;
+            const skill = getSkillByKey(this.actor, key);
+            if (!skill) return;
+            if (!skill.isCustom) {
                 ui.notifications.warn("Core skills cannot be deleted.");
                 return;
             }
-
-            // Allow deletion of custom skills only
-            if (item.type === 'skill' && !item.system.isCore) {
-                const confirmDialog = new Dialog({
-                    title: "Delete Custom Skill",
-                    content: `<p>Are you sure you want to delete the custom skill "${item.name}"?</p>`,
-                    buttons: {
-                        delete: {
-                            icon: '<i class="fas fa-trash"></i>',
-                            label: "Delete",
-                            callback: () => {
-                                this.actor.deleteEmbeddedDocuments("Item", [itemId]);
-                                li.slideUp(200, () => this.render(false));
-                            }
-                        },
-                        cancel: {
-                            icon: '<i class="fas fa-times"></i>',
-                            label: "Cancel"
+            new Dialog({
+                title: "Delete Custom Skill",
+                content: `<p>Are you sure you want to delete the custom skill "${skill.name}"?</p>`,
+                buttons: {
+                    delete: {
+                        icon: '<i class="fas fa-trash"></i>',
+                        label: "Delete",
+                        callback: async () => {
+                            await deleteCustomSkill(this.actor, key);
+                            this.render(false);
                         }
                     },
-                    default: "cancel"
-                });
-                confirmDialog.render(true);
-                return;
-            }
-
-            // Regular deletion for non-skill items
-            this.actor.deleteEmbeddedDocuments("Item", [itemId]);
-            li.slideUp(200, () => this.render(false));
+                    cancel: { icon: '<i class="fas fa-times"></i>', label: "Cancel" }
+                },
+                default: "cancel"
+            }).render(true);
         });
 
         html.find('.species-ability-add').click(async ev => {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,23 +1,16 @@
 // Utility helpers for The Fade system (extracted from thefade.js).
 import { DEFAULT_SKILLS, PATH_SKILL_TYPES, DEFAULT_TOKEN } from './constants.js';
+import {
+    getSkill,
+    getSkillByKey,
+    slugifySkill,
+    setSkillRank,
+    createCustomSkill as createCustomSkillData,
+    getRankValue as getRankValueImpl
+} from './skills.js';
 
-/**
-* Convert skill rank to numeric value for comparison
-* @param {string} rank - The skill rank
-* @returns {number} Numeric value of the rank
-*/
-export function getRankValue(rank) {
-    switch (rank) {
-        case "untrained": return 0;
-        case "learned": return 1;
-        case "practiced": return 2;
-        case "adept": return 3;
-        case "experienced": return 4;
-        case "expert": return 5;
-        case "mastered": return 6;
-        default: return 0;
-    }
-}
+/** Re-export for callers that still import getRankValue from helpers. */
+export const getRankValue = getRankValueImpl;
 
 /**
 * Apply spell filtering based on stored filter criteria
@@ -213,110 +206,29 @@ export function openCompendiumBrowser(itemType, actor, compendiumName = null) {
 }
 
 /**
-* Initialize default skills for a new character
-* Call this when creating a new character or when migrating existing characters
-*/
+ * Reset skills on an actor. Core skills are inherent (no creation needed);
+ * this clears all overrides so every core skill returns to its default rank
+ * and zero miscBonus. Custom skills are preserved by default.
+ *
+ * Retained for backward compat with the "Reset Skills" sheet button.
+ */
 export async function initializeDefaultSkills(actor) {
-    if (actor.type !== 'character') return;
-    if (actor.getFlag("thefade", "addingSkills")) return;
-    await actor.setFlag("thefade", "addingSkills", true);
-
-    const skillsToCreate = [];
-
-    for (const skill of DEFAULT_SKILLS) {
-        // Check if character already has this skill
-        const existingSkill = actor.items.find(i =>
-            i.type === 'skill' && i.name === skill.name
-        );
-
-        if (!existingSkill) {
-            skillsToCreate.push({
-                name: skill.name,
-                type: "skill",
-                system: {
-                    rank: skill.rank,
-                    category: skill.category,
-                    attribute: skill.attribute,
-                    description: "",
-                    miscBonus: 0,
-                    isCore: true // Flag to mark as core skill
-                }
-            });
-        }
+    if (!actor || actor.type !== 'character') return;
+    const overrides = actor.system?.skills || {};
+    const updates = {};
+    let cleared = 0;
+    for (const [key, data] of Object.entries(overrides)) {
+        if (data?.isCustom) continue;
+        updates[`system.skills.-=${key}`] = null;
+        cleared++;
     }
-
-    if (skillsToCreate.length > 0) {
-        await actor.createEmbeddedDocuments("Item", skillsToCreate);
-        ui.notifications.info(`Added ${skillsToCreate.length} missing default skills to ${actor.name}.`);
-    }
-
-    await actor.unsetFlag("thefade", "addingSkills");
-
+    if (Object.keys(updates).length) await actor.update(updates);
+    ui.notifications.info(`Reset ${cleared} core skill override(s) on ${actor.name}.`);
 }
 
-/**
- * Create a custom skill (Custom Craft, Lore, or Perform)
- */
+/** Create a custom skill (Custom Craft, Lore, or Perform). Thin wrapper. */
 export async function createCustomSkill(actor, skillType, subtype, rank = "untrained") {
-    if (!subtype || subtype.trim() === "") {
-        ui.notifications.error("Subtype is required for custom skills.");
-        return null;
-    }
-
-    let skillName, category, attribute;
-
-    switch (skillType.toLowerCase()) {
-        case "craft":
-            skillName = subtype.trim(); // Custom crafts are just the name (e.g., "Soapmaking")
-            category = "Craft";
-            attribute = "mind"; // Default to mind, but can be changed
-            break;
-
-        case "lore":
-            skillName = `Lore (${subtype.trim()})`;
-            category = "Knowledge";
-            attribute = "mind";
-            break;
-
-        case "perform":
-            skillName = `Perform (${subtype.trim()})`;
-            category = "Physical";
-            attribute = "finesse_presence"; // Combined attribute
-            break;
-
-        default:
-            ui.notifications.error("Invalid custom skill type. Must be Craft, Lore, or Perform.");
-            return null;
-    }
-
-    // Check if skill already exists
-    const existingSkill = actor.items.find(i =>
-        i.type === 'skill' && i.name === skillName
-    );
-
-    if (existingSkill) {
-        ui.notifications.warn(`${skillName} already exists.`);
-        return existingSkill;
-    }
-
-    const skillData = {
-        name: skillName,
-        type: "skill",
-        system: {
-            rank: rank,
-            category: category,
-            attribute: attribute,
-            description: "",
-            miscBonus: 0,
-            isCore: false, // Mark as custom skill
-            skillType: skillType.toLowerCase(),
-            subtype: subtype.trim()
-        }
-    };
-
-    const createdSkills = await actor.createEmbeddedDocuments("Item", [skillData]);
-    ui.notifications.info(`Created custom skill: ${skillName}`);
-    return createdSkills[0];
+    return createCustomSkillData(actor, skillType, subtype, rank);
 }
 
 /**
@@ -424,24 +336,18 @@ export async function applyPathSkillModifications(actor, path) {
         const entryType = pathSkill.system.entryType;
 
         switch (entryType) {
-            case PATH_SKILL_TYPES.SPECIFIC_SKILL:
-                // Improve existing core skill
-                const coreSkill = actor.items.find(i =>
-                    i.type === 'skill' && i.name === pathSkill.name
-                );
-
-                if (coreSkill) {
-                    const currentRankValue = getRankValue(coreSkill.system.rank);
+            case PATH_SKILL_TYPES.SPECIFIC_SKILL: {
+                const skill = getSkill(actor, pathSkill.name);
+                if (skill) {
+                    const currentRankValue = getRankValue(skill.rank);
                     const pathRankValue = getRankValue(pathSkill.system.rank);
-
                     if (pathRankValue > currentRankValue) {
-                        await coreSkill.update({
-                            "system.rank": pathSkill.system.rank
-                        });
+                        await setSkillRank(actor, skill.key, pathSkill.system.rank);
                         skillsModified++;
                     }
                 }
                 break;
+            }
 
             case PATH_SKILL_TYPES.SPECIFIC_CUSTOM:
                 // Create specific custom skill
@@ -508,38 +414,20 @@ export async function applyPathSkillModifications(actor, path) {
 }
 
 /**
-* Improve a character's skill to the specified rank
-* @param {Actor} actor - The character actor
-* @param {Object} skillData - The skill data from DEFAULT_SKILLS
-* @param {string} targetRank - The rank to improve to
-*/
+ * Improve a character's skill to the specified rank if higher than current.
+ * Works on core skills (overrides system.skills[key].rank) and noops for
+ * unknown skills — custom skills must be created via createCustomSkill.
+ */
 export async function improveCharacterSkill(actor, skillData, targetRank) {
-    // Find existing skill on character
-    const existingSkill = actor.items.find(i =>
-        i.type === 'skill' && i.name === skillData.name
-    );
-
-    if (existingSkill) {
-        // Update existing skill if target rank is higher
-        const currentRankValue = getRankValue(existingSkill.system.rank);
-        const targetRankValue = getRankValue(targetRank);
-
-        if (targetRankValue > currentRankValue) {
-            await existingSkill.update({ "system.rank": targetRank });
-        }
-    } else {
-        // Create new skill
-        const newSkill = {
-            name: skillData.name,
-            type: "skill",
-            system: {
-                rank: targetRank,
-                category: skillData.category,
-                attribute: skillData.attribute
-            }
-        };
-
-        await actor.createEmbeddedDocuments("Item", [newSkill]);
+    const skill = getSkill(actor, skillData.name);
+    if (!skill) {
+        console.warn(`improveCharacterSkill: unknown skill ${skillData.name}`);
+        return;
+    }
+    const currentRankValue = getRankValue(skill.rank);
+    const targetRankValue = getRankValue(targetRank);
+    if (targetRankValue > currentRankValue) {
+        await setSkillRank(actor, skill.key, targetRank);
     }
 }
 

--- a/src/integrations/token-action-hud/action-handler.js
+++ b/src/integrations/token-action-hud/action-handler.js
@@ -1,5 +1,6 @@
 // Builds Token Action HUD actions from a selected The Fade actor.
 import { ACTION_TYPE, ATTRIBUTES, GROUP } from "./constants.js";
+import { getAllSkills } from "../../skills.js";
 
 export function makeActionHandler(coreApi) {
     return class TheFadeActionHandler extends coreApi.ActionHandler {
@@ -56,13 +57,13 @@ export function makeActionHandler(coreApi) {
                 "Magical":  GROUP.skillsMagic.id
             };
             const grouped = {};
-            for (const skill of actor.items.filter(i => i.type === "skill")) {
-                const bucket = buckets[skill.system?.category] || GROUP.skillsOther.id;
+            for (const skill of getAllSkills(actor)) {
+                const bucket = buckets[skill.category] || GROUP.skillsOther.id;
                 (grouped[bucket] ??= []).push({
-                    id: `skill-${skill.id}`,
+                    id: `skill-${skill.key}`,
                     name: skill.name,
-                    encodedValue: this._enc(ACTION_TYPE.skill, skill.id),
-                    info1: { text: this._rankAbbr(skill.system?.rank) }
+                    encodedValue: this._enc(ACTION_TYPE.skill, skill.key),
+                    info1: { text: this._rankAbbr(skill.rank) }
                 });
             }
             for (const [groupId, actions] of Object.entries(grouped)) {

--- a/src/integrations/token-action-hud/roll-handler.js
+++ b/src/integrations/token-action-hud/roll-handler.js
@@ -38,18 +38,19 @@ export function makeRollHandler(coreApi) {
             });
         }
 
-        async _rollSkill(actor, skillId, event) {
+        async _rollSkill(actor, skillKey, event) {
             // Defer to the character sheet's existing handler so DT prompt &
             // condition modifiers stay consistent.
             const sheet = actor.sheet;
             if (sheet?._onSkillRoll) {
-                const fakeEvent = this._fakeItemEvent(event, skillId);
+                const fakeEvent = this._fakeSkillEvent(event, skillKey);
                 return sheet._onSkillRoll(fakeEvent);
             }
-            // NPC fallback: roll skill's attribute pool directly.
-            const skill = actor.items.get(skillId);
+            // NPC fallback: roll skill's attribute pool directly via data layer.
+            const { getSkillByKey } = await import("../../skills.js");
+            const skill = getSkillByKey(actor, skillKey);
             if (!skill) return;
-            return this._rollAttribute(actor, skill.system?.attribute || "physique");
+            return this._rollAttribute(actor, skill.attribute || "physique");
         }
 
         async _rollWeapon(actor, weaponId, event) {
@@ -135,6 +136,19 @@ export function makeRollHandler(coreApi) {
                 currentTarget: {
                     dataset: {},
                     closest: (sel) => sel === ".item" ? { dataset: { itemId } } : null
+                }
+            };
+        }
+
+        _fakeSkillEvent(event, skillKey) {
+            return {
+                preventDefault: () => {},
+                stopPropagation: () => {},
+                type: event?.type ?? "click",
+                button: event?.button ?? 0,
+                currentTarget: {
+                    dataset: {},
+                    closest: (sel) => sel === "[data-skill-key]" ? { dataset: { skillKey } } : null
                 }
             };
         }

--- a/src/item-sheet.js
+++ b/src/item-sheet.js
@@ -11,7 +11,8 @@ import {
     ARMOR_MOD_SLOTS,
     DAMAGE_TYPE_LABELS
 } from './constants.js';
-import { getRankValue, openCompendiumBrowser } from './helpers.js';
+import { getRankValue, openCompendiumBrowser, applyPathSkillModifications } from './helpers.js';
+import { getSkill } from './skills.js';
 
 /**
 * Item Sheet class for The Fade system
@@ -366,8 +367,8 @@ export class TheFadeItemSheet extends ItemSheet {
             if (this.item?.type === 'weapon' && this.item.parent) {
                 const actor = this.item.parent;
                 const sys = this.item.system;
-                const skillItem = actor.items.find(i => i.type === 'skill' && i.name === sys.skill);
-                const rank = skillItem ? getRankValue(skillItem.system.rank) : 0;
+                const skill = getSkill(actor, sys.skill);
+                const rank = skill ? getRankValue(skill.rank) : 0;
                 const miscBonus = sys.miscBonus ?? 0;
                 const total = rank + miscBonus;
                 if (total > 0) data.calculatedDice = total;
@@ -745,57 +746,11 @@ export class TheFadeItemSheet extends ItemSheet {
 
                                 if (!actor) return;
 
-                                // Check if the path has associated skills
+                                // Delegate to the central path-skill application
+                                // helper so behavior matches dragging a path onto
+                                // an actor (covers SPECIFIC/CHOOSE/CUSTOM entries).
                                 if (this.item.system.pathSkills && this.item.system.pathSkills.length > 0) {
-                                    // Collect skills to add
-                                    const skillsToAdd = [];
-                                    let skillsUpgraded = 0;
-
-                                    for (const pathSkill of this.item.system.pathSkills) {
-                                        // Check if character already has this skill
-                                        const existingSkill = actor.items.find(i =>
-                                            i.type === 'skill' && i.name === pathSkill.name
-                                        );
-
-                                        if (!existingSkill) {
-                                            // Add this skill to our list
-                                            const newSkill = foundry.utils.deepClone(pathSkill);
-                                            delete newSkill._id; // Remove the path's ID to allow Foundry to generate a new one
-                                            skillsToAdd.push(newSkill);
-                                        } else {
-                                            // Character already has this skill, optionally upgrade the rank if path offers better training
-                                            const pathRankValue = getRankValue(pathSkill.system.rank);
-                                            const existingRankValue = getRankValue(existingSkill.system.rank);
-
-                                            // If path offers better training, upgrade the skill
-                                            if (pathRankValue > existingRankValue) {
-                                                await existingSkill.update({
-                                                    "system.rank": pathSkill.system.rank
-                                                });
-                                                skillsUpgraded++;
-                                            }
-                                        }
-                                    }
-
-                                    // Add all new skills to the character
-                                    if (skillsToAdd.length > 0) {
-                                        await actor.createEmbeddedDocuments("Item", skillsToAdd);
-                                    }
-
-                                    // Display results
-                                    let message = "";
-                                    if (skillsToAdd.length > 0) {
-                                        message += `${skillsToAdd.length} skills added. `;
-                                    }
-                                    if (skillsUpgraded > 0) {
-                                        message += `${skillsUpgraded} skills upgraded.`;
-                                    }
-
-                                    if (message) {
-                                        ui.notifications.info(`Skills from ${this.item.name} applied to ${actor.name}: ${message}`);
-                                    } else {
-                                        ui.notifications.info(`No new skills to add. ${actor.name} already has all skills from ${this.item.name}.`);
-                                    }
+                                    await applyPathSkillModifications(actor, this.item);
                                 } else {
                                     ui.notifications.warn(`${this.item.name} has no associated skills to add.`);
                                 }
@@ -940,8 +895,8 @@ export class TheFadeItemSheet extends ItemSheet {
                 const actor = this.item.parent;
                 if (!actor) return ui.notifications.warn("Equip this weapon to a character to roll.");
                 const sys = this.item.system;
-                const skillItem = actor.items.find(i => i.type === 'skill' && i.name === sys.skill);
-                const rank = skillItem ? getRankValue(skillItem.system.rank) : 0;
+                const skill = getSkill(actor, sys.skill);
+                const rank = skill ? getRankValue(skill.rank) : 0;
                 const miscBonus = sys.miscBonus ?? 0;
                 const dice = rank + miscBonus;
                 if (dice <= 0) return ui.notifications.warn("No dice to roll — assign a skill rank first.");

--- a/src/opposed.js
+++ b/src/opposed.js
@@ -8,23 +8,12 @@
 // Aid Another (Core Rulebook p. 60 / AUDIT P2 #26): a helper makes a
 // skill check vs DT 3 at rank Practiced or better. On success, the
 // helped ally adds +1D to their next roll with that skill.
-//
-// This module provides:
-//  - rollSkillPool(actor, {skillId, attribute, extraDice, label}) →
-//    returns { dicePool, successes, dieResultsDetails, roll, label }.
-//  - openOpposedRollDialog(actor) — attacker side, picks a target and
-//    both skills, rolls both, posts a combined chat card.
-//  - openAidAnotherDialog(actor) — helper side, picks ally and skill,
-//    rolls vs DT 3, posts an Aid Another declaration on success.
 
-const RANK_BONUS = {
-    untrained: null,       // untrained is a divisor, handled inline
-    practiced: 1,
-    adept: 2,
-    experienced: 3,
-    expert: 4,
-    mastered: 6
-};
+import {
+    getSkillByKey,
+    getAllSkills,
+    calculateSkillDice
+} from './skills.js';
 
 const TRAINED_RANKS = new Set(["practiced", "adept", "experienced", "expert", "mastered"]);
 
@@ -41,35 +30,23 @@ function getAttributeValue(actor, attribute) {
 
 /**
  * Roll a skill or attribute dice pool for the given actor.
- * Mirrors the pool math used by TheFadeCharacterSheet._onSkillRoll so
- * opposed rolls and Aid Another use the same rank/attribute formula.
+ * `skillKey` selects an entry from actor.system.skills (via getSkillByKey).
  */
-export async function rollSkillPool(actor, { skillId = null, attribute = null, extraDice = 0, label = null } = {}) {
+export async function rollSkillPool(actor, { skillKey = null, attribute = null, extraDice = 0, label = null } = {}) {
     let dicePool = 0;
     let resolvedLabel = label;
     let skill = null;
 
-    if (skillId) {
-        skill = actor.items.get(skillId);
-        if (!skill || skill.type !== "skill") skill = null;
-    }
+    if (skillKey) skill = getSkillByKey(actor, skillKey);
 
     if (skill) {
-        const attrKey = skill.system.attribute || attribute || "physique";
-        dicePool = getAttributeValue(actor, attrKey);
-        const rank = skill.system.rank || "untrained";
-        if (rank === "untrained") {
-            dicePool = Math.floor(dicePool / 2);
-        } else {
-            dicePool += RANK_BONUS[rank] || 0;
-        }
-        dicePool += (skill.system.miscBonus || 0);
-        if (!resolvedLabel) resolvedLabel = `${skill.name} (${rank})`;
+        dicePool = calculateSkillDice(actor, skill);
+        if (!resolvedLabel) resolvedLabel = `${skill.name} (${skill.rank})`;
     } else if (attribute) {
         dicePool = getAttributeValue(actor, attribute);
         if (!resolvedLabel) resolvedLabel = attribute;
     } else {
-        throw new Error("rollSkillPool requires skillId or attribute");
+        throw new Error("rollSkillPool requires skillKey or attribute");
     }
 
     dicePool += (Number(extraDice) || 0);
@@ -93,15 +70,12 @@ function renderDieStrip(details) {
     return details.map(d => `<span class="die-result ${d.class}">${d.value}</span>`).join(" ");
 }
 
-function skillOptionsHtml(actor, selectedId = "") {
-    const skills = actor.items
-        .filter(i => i.type === "skill")
-        .sort((a, b) => a.name.localeCompare(b.name));
+function skillOptionsHtml(actor, selectedKey = "") {
+    const skills = getAllSkills(actor).sort((a, b) => a.name.localeCompare(b.name));
     const options = [`<option value="">— Attribute only —</option>`];
     for (const s of skills) {
-        const sel = s.id === selectedId ? " selected" : "";
-        const rank = s.system?.rank || "untrained";
-        options.push(`<option value="${s.id}"${sel}>${s.name} (${rank})</option>`);
+        const sel = s.key === selectedKey ? " selected" : "";
+        options.push(`<option value="${s.key}"${sel}>${s.name} (${s.rank})</option>`);
     }
     return options.join("");
 }
@@ -130,7 +104,6 @@ function eligibleOpposedActors(currentActor) {
         seen.add(a.id);
         list.push(a);
     }
-    // Fall back to world actors if the scene is empty.
     if (list.length === 0) {
         for (const a of game.actors?.contents || []) {
             if (a.id === currentActor.id) continue;
@@ -209,11 +182,11 @@ export async function openOpposedRollDialog(actor) {
                 roll: {
                     icon: '<i class="fas fa-dice"></i>', label: "Roll",
                     callback: html => resolve({
-                        selfSkillId: html.find('[name="selfSkill"]').val(),
+                        selfSkillKey: html.find('[name="selfSkill"]').val(),
                         selfAttr: html.find('[name="selfAttr"]').val(),
                         selfExtra: parseInt(html.find('[name="selfExtra"]').val()) || 0,
                         targetId: html.find('[name="targetId"]').val(),
-                        targetSkillId: html.find('[name="targetSkill"]').val(),
+                        targetSkillKey: html.find('[name="targetSkill"]').val(),
                         targetAttr: html.find('[name="targetAttr"]').val(),
                         targetExtra: parseInt(html.find('[name="targetExtra"]').val()) || 0
                     })
@@ -248,17 +221,16 @@ export async function openOpposedRollDialog(actor) {
     }
 
     const attackerResult = await rollSkillPool(actor, {
-        skillId: choice.selfSkillId || null,
-        attribute: choice.selfSkillId ? null : choice.selfAttr,
+        skillKey: choice.selfSkillKey || null,
+        attribute: choice.selfSkillKey ? null : choice.selfAttr,
         extraDice: choice.selfExtra
     });
     const defenderResult = await rollSkillPool(target, {
-        skillId: choice.targetSkillId || null,
-        attribute: choice.targetSkillId ? null : choice.targetAttr,
+        skillKey: choice.targetSkillKey || null,
+        attribute: choice.targetSkillKey ? null : choice.targetAttr,
         extraDice: choice.targetExtra
     });
 
-    // Defender wins ties — standard opposed-roll convention.
     let winner = "tie-defender";
     if (attackerResult.successes > defenderResult.successes) winner = "attacker";
     else if (defenderResult.successes > attackerResult.successes) winner = "defender";
@@ -331,7 +303,7 @@ export async function openAidAnotherDialog(actor) {
                     icon: '<i class="fas fa-hands-helping"></i>', label: "Roll to Aid",
                     callback: html => resolve({
                         targetId: html.find('[name="targetId"]').val(),
-                        helperSkillId: html.find('[name="helperSkill"]').val()
+                        helperSkillKey: html.find('[name="helperSkill"]').val()
                     })
                 },
                 cancel: { icon: '<i class="fas fa-times"></i>', label: "Cancel", callback: () => resolve(null) }
@@ -346,18 +318,17 @@ export async function openAidAnotherDialog(actor) {
     const target = game.actors.get(choice.targetId);
     if (!target) { ui.notifications.warn("Aid Another: ally not found."); return; }
 
-    const helperSkill = choice.helperSkillId ? actor.items.get(choice.helperSkillId) : null;
+    const helperSkill = choice.helperSkillKey ? getSkillByKey(actor, choice.helperSkillKey) : null;
     if (!helperSkill) {
         ui.notifications.warn("Aid Another requires picking a skill.");
         return;
     }
-    const rank = helperSkill.system?.rank || "untrained";
-    if (!TRAINED_RANKS.has(rank)) {
-        ui.notifications.warn(`Aid Another requires rank Practiced or better (you have ${rank}).`);
+    if (!TRAINED_RANKS.has(helperSkill.rank)) {
+        ui.notifications.warn(`Aid Another requires rank Practiced or better (you have ${helperSkill.rank}).`);
         return;
     }
 
-    const result = await rollSkillPool(actor, { skillId: helperSkill.id });
+    const result = await rollSkillPool(actor, { skillKey: helperSkill.key });
     const DT = 3;
     const success = result.successes >= DT;
 
@@ -365,7 +336,7 @@ export async function openAidAnotherDialog(actor) {
         <div class="thefade chat-card thefade-aid-card">
             <header class="card-header"><h3>Aid Another</h3></header>
             <div class="card-content">
-                <p><strong>${actor.name}</strong> aids <strong>${target.name}</strong> with ${helperSkill.name} (${rank}).</p>
+                <p><strong>${actor.name}</strong> aids <strong>${target.name}</strong> with ${helperSkill.name} (${helperSkill.rank}).</p>
                 <p>Pool: ${result.dicePool}d12 &nbsp; Successes: <strong>${result.successes}</strong> / DT ${DT}</p>
                 <p>${renderDieStrip(result.dieResultsDetails)}</p>
                 <p class="${success ? "success" : "failure"}">

--- a/src/skills.js
+++ b/src/skills.js
@@ -1,0 +1,334 @@
+// Skill data layer for The Fade.
+//
+// Skills used to be embedded Item documents. They are now plain data on the
+// actor (`actor.system.skills`), keyed by a stable slug. Core skills are
+// defined in DEFAULT_SKILLS and read from there; the per-actor map only
+// stores ranks/bonuses for core skills, plus full data for custom skills
+// (Lore / Perform / custom Craft).
+import { DEFAULT_SKILLS } from './constants.js';
+
+const RANK_VALUES = {
+    untrained: 0,
+    learned: 1,
+    practiced: 2,
+    adept: 3,
+    experienced: 4,
+    expert: 5,
+    mastered: 6
+};
+
+const RANK_DICE = {
+    untrained: null,   // halves the attribute pool
+    learned: 0,
+    practiced: 1,
+    adept: 2,
+    experienced: 3,
+    expert: 4,
+    mastered: 6
+};
+
+/** Stable, URL-safe key for a skill name. */
+export function slugifySkill(name) {
+    if (!name) return "";
+    return String(name)
+        .toLowerCase()
+        .replace(/\(([^)]+)\)/g, "$1")
+        .replace(/[^a-z0-9]+/g, "_")
+        .replace(/^_+|_+$/g, "");
+}
+
+/** Numeric ordering for ranks (for comparison). */
+export function getRankValue(rank) {
+    return RANK_VALUES[rank] ?? 0;
+}
+
+/** Dice contribution from a rank. `null` means "halve attribute" (untrained). */
+export function getRankDice(rank) {
+    return RANK_DICE[rank] ?? null;
+}
+
+const CORE_SKILLS_BY_KEY = (() => {
+    const out = {};
+    for (const s of DEFAULT_SKILLS) {
+        out[slugifySkill(s.name)] = {
+            key: slugifySkill(s.name),
+            name: s.name,
+            category: s.category,
+            attribute: s.attribute,
+            defaultRank: s.rank || "untrained",
+            isCore: true
+        };
+    }
+    return out;
+})();
+
+export function getCoreSkillsList() {
+    return Object.values(CORE_SKILLS_BY_KEY);
+}
+
+export function getCoreSkill(key) {
+    return CORE_SKILLS_BY_KEY[key] || null;
+}
+
+function getOverride(actor, key) {
+    return actor?.system?.skills?.[key] || null;
+}
+
+/**
+ * Return a merged skill object regardless of whether the skill is core or
+ * custom. Returns null if the key is unknown and there is no custom entry.
+ */
+export function getSkillByKey(actor, key) {
+    if (!key) return null;
+    const core = CORE_SKILLS_BY_KEY[key];
+    const override = getOverride(actor, key);
+
+    if (core) {
+        return {
+            key,
+            name: core.name,
+            category: core.category,
+            attribute: core.attribute,
+            rank: override?.rank ?? core.defaultRank,
+            miscBonus: Number(override?.miscBonus) || 0,
+            isCore: true,
+            isCustom: false,
+            skillType: null,
+            subtype: null
+        };
+    }
+
+    if (override?.isCustom) {
+        return {
+            key,
+            name: override.name || key,
+            category: override.category || "Knowledge",
+            attribute: override.attribute || "mind",
+            rank: override.rank || "untrained",
+            miscBonus: Number(override.miscBonus) || 0,
+            isCore: false,
+            isCustom: true,
+            skillType: override.skillType || null,
+            subtype: override.subtype || null
+        };
+    }
+
+    return null;
+}
+
+/** Find a skill by display name (case-insensitive). */
+export function getSkill(actor, name) {
+    if (!name) return null;
+    return getSkillByKey(actor, slugifySkill(name));
+}
+
+/** Every skill the actor has: core skills + all custom entries. */
+export function getAllSkills(actor) {
+    const result = [];
+    for (const core of getCoreSkillsList()) {
+        result.push(getSkillByKey(actor, core.key));
+    }
+    const overrides = actor?.system?.skills || {};
+    for (const [key, data] of Object.entries(overrides)) {
+        if (data?.isCustom && !CORE_SKILLS_BY_KEY[key]) {
+            const merged = getSkillByKey(actor, key);
+            if (merged) result.push(merged);
+        }
+    }
+    return result;
+}
+
+/** Group skills by category, sorted by name within each category. */
+export function getSkillsByCategory(actor) {
+    const groups = {};
+    for (const skill of getAllSkills(actor)) {
+        if (!skill) continue;
+        const cat = skill.category || "Other";
+        (groups[cat] ||= []).push(skill);
+    }
+    for (const list of Object.values(groups)) {
+        list.sort((a, b) => a.name.localeCompare(b.name));
+    }
+    return groups;
+}
+
+function resolveAttributeValue(actor, attributeName) {
+    if (!attributeName || !actor?.system?.attributes) return 0;
+    const attrs = actor.system.attributes;
+    if (attributeName.includes('_')) {
+        const [a, b] = attributeName.split('_');
+        const v1 = attrs[a]?.value || 0;
+        const v2 = attrs[b]?.value || 0;
+        return Math.floor((v1 + v2) / 2);
+    }
+    return attrs[attributeName]?.value || 0;
+}
+
+/**
+ * Dice pool for a skill at this moment: attribute (halved if untrained),
+ * + rank bonus, + miscBonus, + equipped-item bonuses. Clamped to >= 1.
+ */
+export function calculateSkillDice(actor, skill) {
+    if (!skill) return 1;
+    let pool = resolveAttributeValue(actor, skill.attribute);
+    if (skill.rank === "untrained") {
+        pool = Math.floor(pool / 2);
+    } else {
+        pool += RANK_DICE[skill.rank] || 0;
+    }
+    pool += skill.miscBonus || 0;
+
+    const eb = actor?.system?.equippedBonuses;
+    if (eb) {
+        pool += (eb.skills?.[skill.name] || 0) + (eb.skills?.all || 0);
+        if (skill.category === "Magical") pool += (eb.spell || 0);
+    }
+    return Math.max(1, pool);
+}
+
+// ============================================================
+// MUTATION
+// ============================================================
+
+export async function setSkillRank(actor, key, rank) {
+    if (!actor || !key) return;
+    await actor.update({ [`system.skills.${key}.rank`]: rank });
+}
+
+export async function setSkillBonus(actor, key, bonus) {
+    if (!actor || !key) return;
+    await actor.update({ [`system.skills.${key}.miscBonus`]: Number(bonus) || 0 });
+}
+
+/**
+ * Add a custom skill (Craft/Lore/Perform). Returns the merged skill on
+ * success, or null on validation failure / duplicate.
+ */
+export async function createCustomSkill(actor, skillType, subtype, rank = "untrained") {
+    if (!subtype || !subtype.trim()) {
+        ui.notifications.error("Subtype is required for custom skills.");
+        return null;
+    }
+
+    let name, category, attribute;
+    switch ((skillType || "").toLowerCase()) {
+        case "craft":
+            name = subtype.trim();
+            category = "Craft";
+            attribute = "mind";
+            break;
+        case "lore":
+            name = `Lore (${subtype.trim()})`;
+            category = "Knowledge";
+            attribute = "mind";
+            break;
+        case "perform":
+            name = `Perform (${subtype.trim()})`;
+            category = "Physical";
+            attribute = "finesse_presence";
+            break;
+        default:
+            ui.notifications.error("Custom skill type must be Craft, Lore, or Perform.");
+            return null;
+    }
+
+    const key = slugifySkill(name);
+    const existing = getSkillByKey(actor, key);
+    if (existing) {
+        ui.notifications.warn(`${name} already exists.`);
+        return existing;
+    }
+
+    await actor.update({
+        [`system.skills.${key}`]: {
+            isCustom: true,
+            name,
+            category,
+            attribute,
+            rank,
+            miscBonus: 0,
+            skillType: skillType.toLowerCase(),
+            subtype: subtype.trim()
+        }
+    });
+
+    ui.notifications.info(`Created custom skill: ${name}`);
+    return getSkillByKey(actor, key);
+}
+
+export async function deleteCustomSkill(actor, key) {
+    if (!actor || !key) return;
+    if (CORE_SKILLS_BY_KEY[key]) {
+        ui.notifications.warn("Core skills cannot be deleted.");
+        return;
+    }
+    await actor.update({ [`system.skills.-=${key}`]: null });
+}
+
+// ============================================================
+// MIGRATION
+// ============================================================
+
+const MIGRATION_FLAG = "skillsMigratedToData";
+
+/**
+ * One-shot per-actor migration: read all skill items, write them into
+ * actor.system.skills, then delete the items. Idempotent via a flag.
+ */
+export async function migrateActorSkills(actor) {
+    if (!actor || actor.type !== "character") return false;
+    if (actor.getFlag("thefade", MIGRATION_FLAG)) return false;
+
+    const skillItems = actor.items.filter(i => i.type === "skill");
+    if (!skillItems.length) {
+        await actor.setFlag("thefade", MIGRATION_FLAG, true);
+        return false;
+    }
+
+    const updates = {};
+    for (const item of skillItems) {
+        const sys = item.system || {};
+        const key = slugifySkill(item.name);
+        if (!key) continue;
+
+        const isCustom = sys.isCore === false || CORE_SKILLS_BY_KEY[key] === undefined;
+        if (isCustom) {
+            updates[`system.skills.${key}`] = {
+                isCustom: true,
+                name: item.name,
+                category: sys.category || "Knowledge",
+                attribute: sys.attribute || "mind",
+                rank: sys.rank || "untrained",
+                miscBonus: Number(sys.miscBonus) || 0,
+                skillType: sys.skillType || null,
+                subtype: sys.subtype || null
+            };
+        } else {
+            const entry = {};
+            const defaultRank = CORE_SKILLS_BY_KEY[key].defaultRank;
+            if (sys.rank && sys.rank !== defaultRank) entry.rank = sys.rank;
+            if (Number(sys.miscBonus) > 0) entry.miscBonus = Number(sys.miscBonus);
+            if (Object.keys(entry).length) updates[`system.skills.${key}`] = entry;
+        }
+    }
+
+    if (Object.keys(updates).length) await actor.update(updates);
+    await actor.deleteEmbeddedDocuments("Item", skillItems.map(i => i.id));
+    await actor.setFlag("thefade", MIGRATION_FLAG, true);
+    return true;
+}
+
+export async function migrateAllActorSkills() {
+    if (!game?.actors) return;
+    const actors = game.actors.filter(a => a.type === "character");
+    let migrated = 0;
+    for (const actor of actors) {
+        try {
+            const did = await migrateActorSkills(actor);
+            if (did) migrated++;
+        } catch (err) {
+            console.warn(`thefade | skill migration failed for ${actor.name}:`, err);
+        }
+    }
+    if (migrated > 0) console.log(`thefade | migrated skills on ${migrated} actor(s).`);
+}

--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -10657,3 +10657,155 @@ select[name="system.aura.color"] option[value="white"] {
     font-weight: 600;
 }
 
+/* ============================================================
+   SKILLS TAB — unified inv-block cards, one row per skill
+   ============================================================ */
+.thefade .skills-section {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.thefade .skills-section .custom-skills-bar-body {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 10px 14px;
+    align-items: center;
+}
+
+.thefade .skills-section .custom-skills-bar-body button {
+    flex: 0 0 auto;
+    padding: 4px 12px;
+    background: var(--bg-surface-deep);
+    color: var(--text-primary);
+    border: 1px solid var(--border-faint);
+    border-radius: 3px;
+    font-size: 0.85em;
+    cursor: pointer;
+    transition: all var(--transition-speed) ease;
+}
+
+.thefade .skills-section .custom-skills-bar-body button:hover {
+    border-color: var(--accent-gold);
+    color: var(--accent-gold);
+}
+
+.thefade .skill-category .skills-column-header,
+.thefade .skill-category .skill-row {
+    display: grid;
+    grid-template-columns: 1fr 130px 60px 60px 70px 80px;
+    gap: 8px;
+    align-items: center;
+    padding: 5px 14px;
+}
+
+.thefade .skill-category .skills-column-header {
+    background: var(--bg-surface-deep);
+    border-bottom: 1px solid var(--border-faint);
+    color: var(--text-muted);
+    font-size: 0.72em;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    font-weight: 600;
+    padding-top: 6px;
+    padding-bottom: 6px;
+}
+
+.thefade .skill-entry {
+    border-bottom: 1px solid var(--border-faint);
+    background: var(--bg-surface);
+    transition: background var(--transition-speed) ease;
+    position: relative;
+}
+
+.thefade .skill-entry:last-child { border-bottom: none; }
+
+.thefade .skill-entry:hover {
+    background: var(--bg-surface-alt);
+}
+
+.thefade .skill-entry::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: transparent;
+    transition: background var(--transition-speed) ease;
+}
+
+.thefade .skill-entry:hover::before {
+    background: var(--accent-crimson);
+}
+
+.thefade .skill-entry .skill-name {
+    font-weight: 600;
+    color: var(--text-primary);
+    font-size: 0.95em;
+}
+
+.thefade .skill-entry .custom-badge {
+    margin-left: 6px;
+    font-size: 0.7em;
+    color: var(--accent-gold);
+    border-color: var(--accent-gold);
+    background: transparent;
+}
+
+.thefade .skill-entry .skill-attribute-cell {
+    font-size: 0.78em;
+    color: var(--text-muted);
+    text-align: center;
+    letter-spacing: 0.4px;
+}
+
+.thefade .skill-entry .skill-rank-select {
+    width: 100%;
+    height: 24px;
+    padding: 0 4px;
+    font-size: 0.85em;
+    background: var(--bg-surface-deep);
+    border: 1px solid var(--border-faint);
+    color: var(--text-primary);
+    border-radius: 2px;
+}
+
+.thefade .skill-entry .skill-bonus-cell input.small-input {
+    width: 100%;
+    height: 24px;
+    padding: 0 4px;
+    text-align: center;
+    background: var(--bg-surface-deep);
+    border: 1px solid var(--border-faint);
+    color: var(--text-primary);
+    border-radius: 2px;
+    font-size: 0.85em;
+}
+
+.thefade .skill-entry .skill-total-cell {
+    text-align: center;
+    font-weight: 600;
+    color: var(--accent-gold);
+    font-size: 0.92em;
+}
+
+.thefade .skill-entry .skill-controls {
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 10px;
+}
+
+.thefade .skill-entry .skill-controls a,
+.thefade .skill-entry .skill-controls .core-skill-indicator {
+    color: var(--text-muted);
+    transition: color var(--transition-speed) ease;
+    cursor: pointer;
+}
+
+.thefade .skill-entry .skill-controls a.skill-roll:hover { color: var(--accent-gold); }
+.thefade .skill-entry .skill-controls a.skill-delete:hover { color: var(--accent-hot); }
+.thefade .skill-entry .skill-controls .core-skill-indicator { cursor: default; opacity: 0.5; }
+

--- a/template.json
+++ b/template.json
@@ -17,6 +17,7 @@
     },
     "character": {
       "templates": [ "base" ],
+      "skills": {},
       "biography": "",
       "appearance": "",
       "sanity": {

--- a/templates/actor/parts/skill-row.html
+++ b/templates/actor/parts/skill-row.html
@@ -1,0 +1,26 @@
+<div class="skill-entry ability-entry {{#if isCustom}}custom-skill{{/if}}" data-skill-key="{{key}}">
+    <div class="skill-row">
+        <div class="skill-name-cell">
+            <span class="skill-name ability-name">{{name}}</span>
+            {{#if isCustom}}<span class="ability-meta custom-badge">Custom</span>{{/if}}
+        </div>
+        <div class="skill-rank-cell">
+            <select name="system.skills.{{key}}.rank" class="skill-rank-select">
+                {{selectOptions ../skillRankOptions selected=rank}}
+            </select>
+        </div>
+        <div class="skill-attribute-cell">{{attributeAbbr}}</div>
+        <div class="skill-bonus-cell">
+            <input type="number" name="system.skills.{{key}}.miscBonus" value="{{miscBonus}}" data-dtype="Number" class="small-input" />
+        </div>
+        <div class="skill-total-cell">{{calculatedDice}}d12</div>
+        <div class="skill-controls ability-controls">
+            <a class="skill-roll" title="Roll Skill"><i class="fas fa-dice-d12"></i></a>
+            {{#if isCustom}}
+            <a class="skill-delete" title="Delete Custom Skill"><i class="fas fa-trash"></i></a>
+            {{else}}
+            <span class="core-skill-indicator" title="Core Skill"><i class="fas fa-lock"></i></span>
+            {{/if}}
+        </div>
+    </div>
+</div>

--- a/templates/actor/parts/skills.html
+++ b/templates/actor/parts/skills.html
@@ -1,266 +1,48 @@
 <section class="skills-section">
-    <header class="skills-header flexrow">
-        <div class="skill-name">Name</div>
-        <div class="skill-rank">Rank</div>
-        <div class="skill-attribute">Attribute</div>
-        <div class="skill-bonus">Bonus</div>
-        <div class="skill-total">Total Dice</div>
-        <div class="skill-controls">
-            {{!-- Remove old buttons, add custom skill buttons --}}
-            <a class="add-custom-skill" title="Add Custom Skill"><i class="fas fa-plus"></i></a>
-            <a class="initialize-skills" title="Initialize Missing Skills"><i class="fas fa-sync"></i></a>
+    {{!-- Custom skill creation bar --}}
+    <div class="custom-skills-bar inv-block">
+        <h2 class="inv-heading">
+            <i class="fas fa-plus-circle"></i>
+            <span class="inv-title">Add Custom Skill</span>
+            <span class="inv-actions">
+                <a class="initialize-skills" title="Reset core skill ranks to defaults"><i class="fas fa-sync"></i></a>
+            </span>
+        </h2>
+        <div class="inv-block-body custom-skills-bar-body">
+            <button type="button" class="add-custom-craft" title="Add Custom Craft Skill">
+                <i class="fas fa-hammer"></i> Craft
+            </button>
+            <button type="button" class="add-custom-lore" title="Add Lore Skill">
+                <i class="fas fa-book"></i> Lore
+            </button>
+            <button type="button" class="add-custom-perform" title="Add Perform Skill">
+                <i class="fas fa-theater-masks"></i> Perform
+            </button>
         </div>
-    </header>
-
-    {{!-- Add custom skill creation buttons --}}
-    <div class="custom-skills-bar">
-        <label>Add Custom Skills:</label>
-        <button type="button" class="add-custom-craft" title="Add Custom Craft Skill">
-            <i class="fas fa-hammer"></i> Craft
-        </button>
-        <button type="button" class="add-custom-lore" title="Add Lore Skill">
-            <i class="fas fa-book"></i> Lore
-        </button>
-        <button type="button" class="add-custom-perform" title="Add Perform Skill">
-            <i class="fas fa-theater-masks"></i> Perform
-        </button>
     </div>
 
-    {{!-- Combat Skills Section --}}
-    <h2>Combat Skills</h2>
-    <ol class="items-list">
-        {{#each actor.skills as |skill id|}}
-        {{#if (eq skill.system.category "Combat")}}
-        <li class="item flexrow {{#if skill.isCustomSkill}}custom-skill{{/if}}" data-item-id="{{skill._id}}">
-            <div class="skill-name">
-                {{skill.name}}
-                {{#if skill.isCustomSkill}}<span class="custom-badge">Custom</span>{{/if}}
-            </div>
-            <div class="skill-rank">
-                <select name="system.rank" data-item-id="{{skill._id}}">
-                    {{selectOptions ../skillRankOptions selected=skill.system.rank}}
-                </select>
-            </div>
-            <div class="skill-attribute">{{skill.system.attribute}}</div>
-            <div class="skill-bonus">
-                <input type="number" name="system.miscBonus" value="{{skill.system.miscBonus}}" data-dtype="Number" data-item-id="{{skill._id}}" class="small-input" />
-            </div>
-            <div class="skill-total">{{skill.calculatedDice}}d12</div>
-            <div class="skill-controls">
-                <a class="skill-roll" title="Roll Skill"><i class="fas fa-dice-d12"></i></a>
-                <a class="item-edit" title="Edit Skill"><i class="fas fa-edit"></i></a>
-                {{#if skill.canDelete}}
-                <a class="item-delete" title="Delete Custom Skill"><i class="fas fa-trash"></i></a>
-                {{else}}
-                <span class="core-skill-indicator" title="Core Skill - Cannot Delete"><i class="fas fa-lock"></i></span>
-                {{/if}}
-            </div>
-        </li>
-        {{/if}}
-        {{/each}}
-    </ol>
+    {{#each skillCategoryGroups as |group|}}
+    <div class="skill-category inv-block">
+        <h2 class="inv-heading">
+            <i class="fas {{group.icon}}"></i>
+            <span class="inv-title">{{group.label}} Skills</span>
+            <span class="inv-count">{{group.skills.length}}</span>
+        </h2>
 
-    {{!-- Craft Skills Section --}}
-    <h2>Craft Skills</h2>
-    <ol class="items-list">
-        {{#each actor.skills as |skill id|}}
-        {{#if (eq skill.system.category "Craft")}}
-        <li class="item flexrow {{#if skill.isCustomSkill}}custom-skill{{/if}}" data-item-id="{{skill._id}}">
-            <div class="skill-name">
-                {{skill.name}}
-                {{#if skill.isCustomSkill}}<span class="custom-badge">Custom</span>{{/if}}
-            </div>
-            <div class="skill-rank">
-                <select name="system.rank" data-item-id="{{skill._id}}">
-                    {{selectOptions ../skillRankOptions selected=skill.system.rank}}
-                </select>
-            </div>
-            <div class="skill-attribute">{{skill.system.attribute}}</div>
-            <div class="skill-bonus">
-                <input type="number" name="system.miscBonus" value="{{skill.system.miscBonus}}" data-dtype="Number" data-item-id="{{skill._id}}" class="small-input" />
-            </div>
-            <div class="skill-total">{{skill.calculatedDice}}d12</div>
-            <div class="skill-controls">
-                <a class="skill-roll" title="Roll Skill"><i class="fas fa-dice-d12"></i></a>
-                <a class="item-edit" title="Edit Skill"><i class="fas fa-edit"></i></a>
-                {{#if skill.canDelete}}
-                <a class="item-delete" title="Delete Custom Skill"><i class="fas fa-trash"></i></a>
-                {{else}}
-                <span class="core-skill-indicator" title="Core Skill - Cannot Delete"><i class="fas fa-lock"></i></span>
-                {{/if}}
-            </div>
-        </li>
-        {{/if}}
-        {{/each}}
-    </ol>
+        <div class="skills-column-header">
+            <div class="skill-name-cell">Name</div>
+            <div class="skill-rank-cell">Rank</div>
+            <div class="skill-attribute-cell">Attr</div>
+            <div class="skill-bonus-cell">Bonus</div>
+            <div class="skill-total-cell">Dice</div>
+            <div class="skill-controls"></div>
+        </div>
 
-    {{!-- Knowledge Skills Section --}}
-    <h2>Knowledge Skills</h2>
-    <ol class="items-list">
-        {{#each actor.skills as |skill id|}}
-        {{#if (eq skill.system.category "Knowledge")}}
-        <li class="item flexrow {{#if skill.isCustomSkill}}custom-skill{{/if}}" data-item-id="{{skill._id}}">
-            <div class="skill-name">
-                {{skill.name}}
-                {{#if skill.isCustomSkill}}<span class="custom-badge">Custom</span>{{/if}}
-            </div>
-            <div class="skill-rank">
-                <select name="system.rank" data-item-id="{{skill._id}}">
-                    {{selectOptions ../skillRankOptions selected=skill.system.rank}}
-                </select>
-            </div>
-            <div class="skill-attribute">{{skill.system.attribute}}</div>
-            <div class="skill-bonus">
-                <input type="number" name="system.miscBonus" value="{{skill.system.miscBonus}}" data-dtype="Number" data-item-id="{{skill._id}}" class="small-input" />
-            </div>
-            <div class="skill-total">{{skill.calculatedDice}}d12</div>
-            <div class="skill-controls">
-                <a class="skill-roll" title="Roll Skill"><i class="fas fa-dice-d12"></i></a>
-                <a class="item-edit" title="Edit Skill"><i class="fas fa-edit"></i></a>
-                {{#if skill.canDelete}}
-                <a class="item-delete" title="Delete Custom Skill"><i class="fas fa-trash"></i></a>
-                {{else}}
-                <span class="core-skill-indicator" title="Core Skill - Cannot Delete"><i class="fas fa-lock"></i></span>
-                {{/if}}
-            </div>
-        </li>
-        {{/if}}
-        {{/each}}
-    </ol>
-
-    {{!-- Magical Skills Section --}}
-    <h2>Magical Skills</h2>
-    <ol class="items-list">
-        {{#each actor.skills as |skill id|}}
-        {{#if (eq skill.system.category "Magical")}}
-        <li class="item flexrow {{#if skill.isCustomSkill}}custom-skill{{/if}}" data-item-id="{{skill._id}}">
-            <div class="skill-name">
-                {{skill.name}}
-                {{#if skill.isCustomSkill}}<span class="custom-badge">Custom</span>{{/if}}
-            </div>
-            <div class="skill-rank">
-                <select name="system.rank" data-item-id="{{skill._id}}">
-                    {{selectOptions ../skillRankOptions selected=skill.system.rank}}
-                </select>
-            </div>
-            <div class="skill-attribute">{{skill.system.attribute}}</div>
-            <div class="skill-bonus">
-                <input type="number" name="system.miscBonus" value="{{skill.system.miscBonus}}" data-dtype="Number" data-item-id="{{skill._id}}" class="small-input" />
-            </div>
-            <div class="skill-total">{{skill.calculatedDice}}d12</div>
-            <div class="skill-controls">
-                <a class="skill-roll" title="Roll Skill"><i class="fas fa-dice-d12"></i></a>
-                <a class="item-edit" title="Edit Skill"><i class="fas fa-edit"></i></a>
-                {{#if skill.canDelete}}
-                <a class="item-delete" title="Delete Custom Skill"><i class="fas fa-trash"></i></a>
-                {{else}}
-                <span class="core-skill-indicator" title="Core Skill - Cannot Delete"><i class="fas fa-lock"></i></span>
-                {{/if}}
-            </div>
-        </li>
-        {{/if}}
-        {{/each}}
-    </ol>
-
-    {{!-- Physical Skills Section --}}
-    <h2>Physical Skills</h2>
-    <ol class="items-list">
-        {{#each actor.skills as |skill id|}}
-        {{#if (eq skill.system.category "Physical")}}
-        <li class="item flexrow {{#if skill.isCustomSkill}}custom-skill{{/if}}" data-item-id="{{skill._id}}">
-            <div class="skill-name">
-                {{skill.name}}
-                {{#if skill.isCustomSkill}}<span class="custom-badge">Custom</span>{{/if}}
-            </div>
-            <div class="skill-rank">
-                <select name="system.rank" data-item-id="{{skill._id}}">
-                    {{selectOptions ../skillRankOptions selected=skill.system.rank}}
-                </select>
-            </div>
-            <div class="skill-attribute">{{skill.system.attribute}}</div>
-            <div class="skill-bonus">
-                <input type="number" name="system.miscBonus" value="{{skill.system.miscBonus}}" data-dtype="Number" data-item-id="{{skill._id}}" class="small-input" />
-            </div>
-            <div class="skill-total">{{skill.calculatedDice}}d12</div>
-            <div class="skill-controls">
-                <a class="skill-roll" title="Roll Skill"><i class="fas fa-dice-d12"></i></a>
-                <a class="item-edit" title="Edit Skill"><i class="fas fa-edit"></i></a>
-                {{#if skill.canDelete}}
-                <a class="item-delete" title="Delete Custom Skill"><i class="fas fa-trash"></i></a>
-                {{else}}
-                <span class="core-skill-indicator" title="Core Skill - Cannot Delete"><i class="fas fa-lock"></i></span>
-                {{/if}}
-            </div>
-        </li>
-        {{/if}}
-        {{/each}}
-    </ol>
-
-    {{!-- Sense Skills Section --}}
-    <h2>Sense Skills</h2>
-    <ol class="items-list">
-        {{#each actor.skills as |skill id|}}
-        {{#if (eq skill.system.category "Sense")}}
-        <li class="item flexrow {{#if skill.isCustomSkill}}custom-skill{{/if}}" data-item-id="{{skill._id}}">
-            <div class="skill-name">
-                {{skill.name}}
-                {{#if skill.isCustomSkill}}<span class="custom-badge">Custom</span>{{/if}}
-            </div>
-            <div class="skill-rank">
-                <select name="system.rank" data-item-id="{{skill._id}}">
-                    {{selectOptions ../skillRankOptions selected=skill.system.rank}}
-                </select>
-            </div>
-            <div class="skill-attribute">{{skill.system.attribute}}</div>
-            <div class="skill-bonus">
-                <input type="number" name="system.miscBonus" value="{{skill.system.miscBonus}}" data-dtype="Number" data-item-id="{{skill._id}}" class="small-input" />
-            </div>
-            <div class="skill-total">{{skill.calculatedDice}}d12</div>
-            <div class="skill-controls">
-                <a class="skill-roll" title="Roll Skill"><i class="fas fa-dice-d12"></i></a>
-                <a class="item-edit" title="Edit Skill"><i class="fas fa-edit"></i></a>
-                {{#if skill.canDelete}}
-                <a class="item-delete" title="Delete Custom Skill"><i class="fas fa-trash"></i></a>
-                {{else}}
-                <span class="core-skill-indicator" title="Core Skill - Cannot Delete"><i class="fas fa-lock"></i></span>
-                {{/if}}
-            </div>
-        </li>
-        {{/if}}
-        {{/each}}
-    </ol>
-
-    {{!-- Social Skills Section --}}
-    <h2>Social Skills</h2>
-    <ol class="items-list">
-        {{#each actor.skills as |skill id|}}
-        {{#if (eq skill.system.category "Social")}}
-        <li class="item flexrow {{#if skill.isCustomSkill}}custom-skill{{/if}}" data-item-id="{{skill._id}}">
-            <div class="skill-name">
-                {{skill.name}}
-                {{#if skill.isCustomSkill}}<span class="custom-badge">Custom</span>{{/if}}
-            </div>
-            <div class="skill-rank">
-                <select name="system.rank" data-item-id="{{skill._id}}">
-                    {{selectOptions ../skillRankOptions selected=skill.system.rank}}
-                </select>
-            </div>
-            <div class="skill-attribute">{{skill.system.attribute}}</div>
-            <div class="skill-bonus">
-                <input type="number" name="system.miscBonus" value="{{skill.system.miscBonus}}" data-dtype="Number" data-item-id="{{skill._id}}" class="small-input" />
-            </div>
-            <div class="skill-total">{{skill.calculatedDice}}d12</div>
-            <div class="skill-controls">
-                <a class="skill-roll" title="Roll Skill"><i class="fas fa-dice-d12"></i></a>
-                <a class="item-edit" title="Edit Skill"><i class="fas fa-edit"></i></a>
-                {{#if skill.canDelete}}
-                <a class="item-delete" title="Delete Custom Skill"><i class="fas fa-trash"></i></a>
-                {{else}}
-                <span class="core-skill-indicator" title="Core Skill - Cannot Delete"><i class="fas fa-lock"></i></span>
-                {{/if}}
-            </div>
-        </li>
-        {{/if}}
-        {{/each}}
-    </ol>
+        <div class="skills-list abilities-list">
+            {{#each group.skills as |skill|}}
+            {{> "systems/thefade/templates/actor/parts/skill-row.html" this skillRankOptions=../../skillRankOptions}}
+            {{/each}}
+        </div>
+    </div>
+    {{/each}}
 </section>

--- a/thefade.js
+++ b/thefade.js
@@ -4,7 +4,8 @@ import { applyBonusHandlers } from './src/chat.js';
 import {
     getRankValue, initializeDefaultSkills, createCustomSkill,
     showChooseRegularSkillsDialog, showChooseLoreSkillsDialog,
-    showChoosePerformSkillsDialog, showChooseCraftSkillsDialog
+    showChoosePerformSkillsDialog, showChooseCraftSkillsDialog,
+    applyPathSkillModifications
 } from './src/helpers.js';
 import { TheFadeActor } from './src/actor.js';
 import { TheFadeItem } from './src/item.js';
@@ -408,162 +409,9 @@ Hooks.on("createItem", async (item, options, userId) => {
         if (actor.getFlag("thefade", "addingSkills")) return;
         await actor.setFlag("thefade", "addingSkills", true);
 
-        // Check if the path has associated skills
-        if (path.system.pathSkills && path.system.pathSkills.length > 0) {
-            const skillsToAdd = [];
-            let skillsUpgraded = 0;
-
-            //let skillsModified = 0;
-            //let customSkillsCreated = 0;
-            //let choicesMade = 0;
-
-            for (const pathSkill of path.system.pathSkills) {
-                const existingSkill = actor.items.find(i =>
-                    i.type === 'skill' && i.name === pathSkill.name
-                );
-
-                if (!existingSkill) {
-                    const newSkill = foundry.utils.deepClone(pathSkill);
-                    delete newSkill._id;
-                    skillsToAdd.push(newSkill);
-                } else {
-                    const pathRankValue = getRankValue(pathSkill.system.rank);
-                    const existingRankValue = getRankValue(existingSkill.system.rank);
-
-                    if (pathRankValue > existingRankValue) {
-                        await existingSkill.update({ "system.rank": pathSkill.system.rank });
-                        skillsUpgraded++;
-                    }
-                }
-            }
-
-            if (skillsToAdd.length > 0) {
-                await actor.createEmbeddedDocuments("Item", skillsToAdd);
-            }
-
-            //for (const pathSkill of path.system.pathSkills) {
-            //    const entryType = pathSkill.system.entryType;
-
-            //    switch (entryType) {
-            //        case PATH_SKILL_TYPES.SPECIFIC_SKILL:
-            //            // Handle specific core skills
-            //            const coreSkill = actor.items.find(i =>
-            //                i.type === 'skill' && i.name === pathSkill.name
-            //            );
-
-            //            if (coreSkill) {
-            //                // Upgrade existing skill if path offers better training
-            //                const pathRankValue = getRankValue(pathSkill.system.rank);
-            //                const currentRankValue = getRankValue(coreSkill.system.rank);
-
-            //                if (pathRankValue > currentRankValue) {
-            //                    await coreSkill.update({
-            //                        "system.rank": pathSkill.system.rank
-            //                    });
-            //                    skillsModified++;
-            //                }
-            //            } else {
-            //                // Create new skill
-            //                const newSkill = {
-            //                    name: pathSkill.name,
-            //                    type: "skill",
-            //                    system: {
-            //                        rank: pathSkill.system.rank,
-            //                        category: pathSkill.system.category,
-            //                        attribute: pathSkill.system.attribute
-            //                    }
-            //                };
-            //                await actor.createEmbeddedDocuments("Item", [newSkill]);
-            //                skillsModified++;
-            //            }
-            //            break;
-
-            //        case PATH_SKILL_TYPES.SPECIFIC_CUSTOM:
-            //            // Create specific custom skill
-            //            const skillType = pathSkill.system.skillType;
-            //            const subtype = pathSkill.system.subtype;
-            //            await createCustomSkill(actor, skillType, subtype, pathSkill.system.rank);
-            //            customSkillsCreated++;
-            //            break;
-
-            //        case PATH_SKILL_TYPES.CHOOSE_CATEGORY:
-            //            // Show dialog to choose from category
-            //            await showChooseRegularSkillsDialog(
-            //                actor,
-            //                pathSkill.system.chooseCount,
-            //                pathSkill.system.chooseCategory,
-            //                pathSkill.system.rank,
-            //                path
-            //            );
-            //            choicesMade++;
-            //            break;
-
-            //        case PATH_SKILL_TYPES.CHOOSE_LORE:
-            //            // Show dialog to create lore skills
-            //            await showChooseLoreSkillsDialog(
-            //                actor,
-            //                pathSkill.system.chooseCount,
-            //                pathSkill.system.rank
-            //            );
-            //            choicesMade++;
-            //            break;
-
-            //        case PATH_SKILL_TYPES.CHOOSE_PERFORM:
-            //            // Show dialog to create perform skills
-            //            await showChoosePerformSkillsDialog(
-            //                actor,
-            //                pathSkill.system.chooseCount,
-            //                pathSkill.system.rank
-            //            );
-            //            choicesMade++;
-            //            break;
-
-            //        case PATH_SKILL_TYPES.CHOOSE_CRAFT:
-            //            // Show dialog to create craft skills
-            //            await showChooseCraftSkillsDialog(
-            //                actor,
-            //                pathSkill.system.chooseCount,
-            //                pathSkill.system.rank
-            //            );
-            //            choicesMade++;
-            //            break;
-
-            //        default:
-            //            // Fallback for old-style entries without entryType
-            //            const existingSkill = actor.items.find(i =>
-            //                i.type === 'skill' && i.name === pathSkill.name
-            //            );
-
-            //            if (!existingSkill) {
-            //                const newSkill = foundry.utils.deepClone(pathSkill);
-            //                delete newSkill._id;
-            //                await actor.createEmbeddedDocuments("Item", [newSkill]);
-            //                skillsModified++;
-            //            } else {
-            //                const pathRankValue = getRankValue(pathSkill.system.rank);
-            //                const existingRankValue = getRankValue(existingSkill.system.rank);
-
-            //                if (pathRankValue > existingRankValue) {
-            //                    await existingSkill.update({
-            //                        "system.rank": pathSkill.system.rank
-            //                    });
-            //                    skillsModified++;
-            //                }
-            //            }
-            //            break;
-            //    }
-            //}
-
-
-            // Show results
-            const message = [];
-            if (skillsToAdd.length > 0) message.push(`${skillsToAdd.length} skills added`);
-            if (skillsUpgraded > 0) message.push(`${skillsUpgraded} skills upgraded`);
-
-            if (message.length > 0) {
-                ui.notifications.info(`${path.name} applied to ${actor.name}: ${message.join(', ')}`);
-            }
-
+        try {
+            await applyPathSkillModifications(actor, path);
+        } finally {
             await actor.unsetFlag("thefade", "addingSkills");
         }
     }

--- a/thefade.js
+++ b/thefade.js
@@ -16,6 +16,7 @@ import { TheFadeShopSheet } from './src/shop-sheet.js';
 import { computePerRoundDamage, CONDITION_EFFECTS } from './src/conditions.js';
 import './src/token-facing.js';
 import { registerTokenActionHud } from './src/integrations/token-action-hud/index.js';
+import { migrateAllActorSkills } from './src/skills.js';
 
 registerTokenActionHud();
 
@@ -670,15 +671,20 @@ Hooks.on("createItem", async (item, options, userId) => {
 });
 
 Hooks.on("createActor", async (actor, options, userId) => {
-    if (actor.type === 'character' && game.user.id === userId) {
-        await initializeDefaultSkills(actor);
-    }
+    // New actors no longer need skill items created up-front; core skills
+    // live in DEFAULT_SKILLS and are surfaced via getSkill helpers.
 });
 
 /**
  * System ready hook - final setup after all systems loaded
  */
 Hooks.once('ready', async function () {
+    // One-shot migration: convert legacy skill items into actor.system.skills.
+    if (game.user.isGM) {
+        try { await migrateAllActorSkills(); }
+        catch (err) { console.warn("thefade | skill migration error:", err); }
+    }
+
     if (game.user.isGM) {
         let initButton = $(`<button id="fade-init-skills">Initialize All Character Skills</button>`);
         initButton.click(async function () {


### PR DESCRIPTION
## Summary
Skills are no longer Item documents. They live on `actor.system.skills` as a keyed map (`actor.system.skills.acrobatics = { rank, miscBonus, ... }`). Core skills inherit their identity from `DEFAULT_SKILLS`; the per-actor map only stores rank/bonus overrides for core skills, plus full data for custom skills (Lore/Perform/custom Craft). Existing characters are migrated automatically on world ready.

The Skills tab is rewritten alongside the data change: the 266 lines of seven copy-pasted category blocks collapse to a single loop over `skillCategoryGroups` rendering a partial. Visual polish matches Abilities and Inventory/Magic — inv-block card headings with icon + count chip, hover crimson accent stripe on rows, gold-accent dice total.

## Why
Skills as items was costing every character ~40 Document instances just to hold `{rank, miscBonus}`. The 56 callsites across 7 files all did `actor.items.find(i => i.type === "skill" && i.name === X)` — a fragile pattern that needed an "Initialize Missing Skills" repair button. Skills are a fixed core list, not droppable/tradeable items, so the Item model was the wrong tool. Moving to embedded data simplifies every lookup, removes the repair button as a permanent fixture, and lets the template bind selects directly to `name="system.skills.acrobatics.rank"` so Foundry's form handler does the writes.

## What changed
Five phased commits:

1. **Data layer + helpers** (`src/skills.js` new, `template.json`, `src/helpers.js`) — `getSkill / getSkillByKey / getAllSkills / getSkillsByCategory / calculateSkillDice`, mutators `setSkillRank / createCustomSkill / deleteCustomSkill`, and `migrateActorSkills` for the one-shot per-actor data migration (idempotent via a `skillsMigratedToData` flag).
2. **character-sheet.js** — every `actor.items.find(i => i.type === "skill" ...)` and `skill.system.*` access routes through the data layer. `_onSkillRoll` reads `data-skill-key` instead of `data-item-id`. New `.skill-delete` handler routes custom-skill deletes through `deleteCustomSkill`.
3. **actor.js, opposed.js, TAH integration, item-sheet.js** — same treatment. `rollSkillPool` now takes a `skillKey`; the TAH skill action carries the key; weapon dice-pool calc resolves skills via `getSkill`.
4. **Migration wired** — `Hooks.once('ready')` runs `migrateAllActorSkills()` for GMs once per session. The `createActor` hook no longer creates skill items.
5. **Template + CSS** — `skills.html` rewritten, new `skill-row.html` partial, Skills tab styling that mirrors the Abilities polish.

## Migration behavior
- One-shot per actor, GM-triggered on world ready, idempotent via `flags.thefade.skillsMigratedToData`.
- Reads each existing skill item, writes its `{rank, miscBonus}` (and full custom-skill fields if applicable) into `actor.system.skills[slug(name)]`, then deletes the skill items.
- Core skills only get an override entry when rank or miscBonus differ from defaults — keeps the map sparse.
- The skill Item type stays registered (compendium content still loads, and the path sheet's "drag a compendium skill onto a path" flow still works as a template source).

## Notes for reviewer
- `src/character-sheet.js:390` keeps a no-op branch with an explanatory comment so the categorization switch reads cleanly. Not a bug.
- I deliberately kept the `initialize-skills` button on the Skills tab — it now resets core-skill overrides to defaults instead of creating items. Same UX, different mechanism.
- The path-sheet "Add Path Skills to Character" button (item-sheet.js) and the `createItem` path hook (thefade.js) both now delegate to `applyPathSkillModifications` — there were two parallel implementations of this logic before; this PR collapses them.
- Skill compendiums in `packs/skills` still exist and still work as drag sources; no compendium content was touched.

## Test plan
- [ ] Open an existing character with prior skill items. Confirm the migration runs once (console: `thefade | migrated skills on N actor(s).`), skill items are gone, and ranks/bonuses survived.
- [ ] Skills tab: every category renders with the inv-block heading + count chip + hover accent stripe. Rank dropdown + bonus input write through correctly.
- [ ] Click a skill-roll die icon — DT prompt opens, dice pool matches old behavior, chat card looks right.
- [ ] Add a custom Lore skill via the bar — appears under Knowledge, can roll, can delete (trash icon, confirm dialog). Try to delete a core skill — locked.
- [ ] Drag a path onto the actor — path skills apply (ranks improve, custom skills get created).
- [ ] Token Action HUD: skills bucket shows all skills grouped by category; click rolls.
- [ ] Opposed roll dialog and Aid Another dialog: dropdowns populate, rolls work.
- [ ] Spellcasting check on a magic actor: spell cast still works (it uses the Spellcasting skill).
- [ ] Acrobatics-based passive dodge + weapon-skill passive parry on the Stats tab match what they were pre-migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)