### PR TITLE
Fix: preload skill-row.html partial

### DIFF
--- a/thefade.js
+++ b/thefade.js
@@ -232,6 +232,7 @@ Hooks.once('init', async function () {
         "systems/thefade/templates/actor/shop-sheet.html",
         "systems/thefade/templates/actor/parts/attributes.html",
         "systems/thefade/templates/actor/parts/skills.html",
+        "systems/thefade/templates/actor/parts/skill-row.html",
         "systems/thefade/templates/actor/parts/inventory.html",
         "systems/thefade/templates/actor/parts/paths.html",
         "systems/thefade/templates/actor/parts/spells.html",


### PR DESCRIPTION
## Summary
Skills tab fails to render with \`The partial systems/thefade/templates/actor/parts/skill-row.html could not be found\`. The new partial added in [#53](https://github.com/colearkenach/thefade/pull/53) wasn't added to the \`loadTemplates()\` preload list in \`thefade.js\`, so Handlebars can't resolve \`{{> "systems/thefade/templates/actor/parts/skill-row.html" ...}}\` at render time.

One-line fix.

## Test plan
- [ ] Reload the world, open a character sheet, switch to the Skills tab — renders without console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)