### PR TITLE
Skills: unlockable attribute override on core skills

### DIFF
--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -106,6 +106,15 @@ export class TheFadeCharacterSheet extends ActorSheet {
         // Build the Skills tab view-model: groups by category with icons.
         data.skillCategoryGroups = this._buildSkillCategoryGroups();
 
+        // Attribute options shown when a skill is unlocked for editing.
+        data.skillAttributeOptions = {
+            "physique": "Physique",
+            "finesse": "Finesse",
+            "mind": "Mind",
+            "presence": "Presence",
+            "soul": "Soul"
+        };
+
         // Additional safety checks
         if (!data.actor) {
             console.error("Actor missing from getData result");
@@ -1055,8 +1064,10 @@ export class TheFadeCharacterSheet extends ActorSheet {
             for (const skill of list) {
                 skill.calculatedDice = calculateSkillDice(this.actor, skill);
                 skill.attributeAbbr = ATTR_ABBR[skill.attribute] || (skill.attribute || "").toUpperCase();
+                skill.defaultAttributeAbbr = ATTR_ABBR[skill.defaultAttribute] || (skill.defaultAttribute || "").toUpperCase();
                 skill.isCustomSkill = !!skill.isCustom;
                 skill.canDelete = !!skill.isCustom;
+                skill.canEditAttribute = !!skill.isCustom || !!skill.attributeUnlocked;
             }
         }
 
@@ -3858,6 +3869,20 @@ export class TheFadeCharacterSheet extends ActorSheet {
                 },
                 default: "cancel"
             }).render(true);
+        });
+
+        // Toggle the attribute lock on a core skill. Locking is non-destructive:
+        // any previously-picked override attribute stays in the data and
+        // returns the next time the lock is opened.
+        html.find('.skill-attribute-lock').off('click').click(async ev => {
+            ev.preventDefault();
+            const row = ev.currentTarget.closest("[data-skill-key]");
+            const key = row?.dataset.skillKey;
+            if (!key) return;
+            const current = this.actor.system?.skills?.[key]?.attributeUnlocked ?? false;
+            await this.actor.update({
+                [`system.skills.${key}.attributeUnlocked`]: !current
+            });
         });
 
         html.find('.species-ability-add').click(async ev => {

--- a/src/skills.js
+++ b/src/skills.js
@@ -84,11 +84,17 @@ export function getSkillByKey(actor, key) {
     const override = getOverride(actor, key);
 
     if (core) {
+        const attributeUnlocked = !!override?.attributeUnlocked;
+        const attribute = attributeUnlocked && override?.attribute
+            ? override.attribute
+            : core.attribute;
         return {
             key,
             name: core.name,
             category: core.category,
-            attribute: core.attribute,
+            attribute,
+            defaultAttribute: core.attribute,
+            attributeUnlocked,
             rank: override?.rank ?? core.defaultRank,
             miscBonus: Number(override?.miscBonus) || 0,
             isCore: true,
@@ -104,6 +110,8 @@ export function getSkillByKey(actor, key) {
             name: override.name || key,
             category: override.category || "Knowledge",
             attribute: override.attribute || "mind",
+            defaultAttribute: override.attribute || "mind",
+            attributeUnlocked: true,
             rank: override.rank || "untrained",
             miscBonus: Number(override.miscBonus) || 0,
             isCore: false,

--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -10809,3 +10809,32 @@ select[name="system.aura.color"] option[value="white"] {
 .thefade .skill-entry .skill-controls a.skill-delete:hover { color: var(--accent-hot); }
 .thefade .skill-entry .skill-controls .core-skill-indicator { cursor: default; opacity: 0.5; }
 
+/* Attribute lock toggle on core skills */
+.thefade .skill-entry .skill-controls a.skill-attribute-lock {
+    color: var(--text-muted);
+    opacity: 0.55;
+    transition: color var(--transition-speed) ease, opacity var(--transition-speed) ease;
+}
+.thefade .skill-entry .skill-controls a.skill-attribute-lock:hover {
+    color: var(--accent-gold);
+    opacity: 1;
+}
+.thefade .skill-entry .skill-controls a.skill-attribute-lock.is-unlocked {
+    color: var(--accent-gold);
+    opacity: 1;
+}
+
+/* Inline attribute select shown when a skill is unlocked or custom */
+.thefade .skill-entry .skill-attribute-cell select.skill-attribute-select {
+    width: 100%;
+    height: 24px;
+    padding: 0 4px;
+    font-size: 0.8em;
+    background: var(--bg-surface-deep);
+    border: 1px solid var(--accent-gold);
+    color: var(--text-primary);
+    border-radius: 2px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+}
+

--- a/templates/actor/parts/skill-row.html
+++ b/templates/actor/parts/skill-row.html
@@ -9,7 +9,15 @@
                 {{selectOptions skillRankOptions selected=rank}}
             </select>
         </div>
-        <div class="skill-attribute-cell">{{attributeAbbr}}</div>
+        <div class="skill-attribute-cell">
+            {{#if canEditAttribute}}
+            <select name="system.skills.{{key}}.attribute" class="skill-attribute-select">
+                {{selectOptions skillAttributeOptions selected=attribute}}
+            </select>
+            {{else}}
+            <span class="skill-attribute-text" title="Default: {{defaultAttributeAbbr}}">{{attributeAbbr}}</span>
+            {{/if}}
+        </div>
         <div class="skill-bonus-cell">
             <input type="number" name="system.skills.{{key}}.miscBonus" value="{{miscBonus}}" data-dtype="Number" class="small-input" />
         </div>
@@ -19,7 +27,10 @@
             {{#if isCustom}}
             <a class="skill-delete" title="Delete Custom Skill"><i class="fas fa-trash"></i></a>
             {{else}}
-            <span class="core-skill-indicator" title="Core Skill"><i class="fas fa-lock"></i></span>
+            <a class="skill-attribute-lock {{#if attributeUnlocked}}is-unlocked{{/if}}"
+               title="{{#if attributeUnlocked}}Lock attribute back to default ({{defaultAttributeAbbr}}){{else}}Unlock to change attribute{{/if}}">
+                <i class="fas {{#if attributeUnlocked}}fa-lock-open{{else}}fa-lock{{/if}}"></i>
+            </a>
             {{/if}}
         </div>
     </div>

--- a/templates/actor/parts/skills.html
+++ b/templates/actor/parts/skills.html
@@ -40,7 +40,9 @@
 
         <div class="skills-list abilities-list">
             {{#each group.skills as |skill|}}
-            {{> "systems/thefade/templates/actor/parts/skill-row.html" this skillRankOptions=../../skillRankOptions}}
+            {{> "systems/thefade/templates/actor/parts/skill-row.html" this
+                skillRankOptions=../../skillRankOptions
+                skillAttributeOptions=../../skillAttributeOptions}}
             {{/each}}
         </div>
     </div>


### PR DESCRIPTION
## Summary
Click the lock icon next to a core skill to flip into edit mode — the attribute cell becomes a dropdown of the five attributes, and your pick is used for all dice rolls involving that skill. Click again to relock and revert to the default attribute. The override is preserved across lock/unlock, so toggling is non-destructive.

Use case: a character whose Acrobatics is Physique-based, or whose Stealth runs off Mind.

## How it works
- New per-skill flag \`actor.system.skills.{key}.attributeUnlocked\`.
- \`getSkillByKey\` returns \`override.attribute\` only when the flag is true; otherwise the core default. All downstream consumers (\`calculateSkillDice\`, \`_onSkillRoll\`, passive defenses, weapon dice pools, TAH actions) read from the merged object, so the override flows through every roll path without touching them.
- The lock icon in skill-row.html is now an \`<a class="skill-attribute-lock">\` that toggles the flag on click. The cell renders a \`<select name="system.skills.{key}.attribute">\` when unlocked, plain text when locked. Custom skills (no lock) stay always-editable.

## Test plan
- [ ] Open a character sheet's Skills tab. Click the lock on Acrobatics — it should open. Pick Physique. Roll Acrobatics — dice pool reflects PHY.
- [ ] Click the lock again — Acrobatics reverts to displaying FIN, rolls revert to FIN-based.
- [ ] Click open again — your previously-picked PHY should still be there.
- [ ] Custom skill rows (Lore, Perform, custom Craft) — no lock, attribute select visible by default, behavior unchanged.
- [ ] Refresh sheet — locked/unlocked state and chosen attribute persist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)