### PR TITLE
Inventory: keep sub-tabs horizontal, fix weapons table overflow

### DIFF
--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -1145,7 +1145,8 @@ input[readonly] {
 /* Ensure weapon table doesn't overflow container */
 .thefade .weapons {
   overflow-x: auto;
-  min-width: 800px;
+  min-width: 0;
+  max-width: 100%;
 }
 
 /* Currency */
@@ -10037,6 +10038,14 @@ select[name="system.aura.color"] option[value="white"] {
     border-bottom: none;
     border-radius: 4px 4px 0 0;
     margin-bottom: 0;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: thin;
+}
+
+.thefade .inventory-tabs .tab-button {
+    flex: 0 0 auto;
+    white-space: nowrap;
 }
 
 .thefade .inventory-tabs .tab-button {


### PR DESCRIPTION
## Summary
- Inventory sub-tab nav (Weapons / Armor / Items of Power / ...) no longer wraps to multiple rows. It now stays in a single horizontal row and scrolls horizontally when the sheet is too narrow.
- Fixed the Weapons table overflowing the inventory panel. The `.weapons` container had `min-width: 800px` which forced the panel itself wider than its parent; removing it lets the inner columns scroll within the panel instead.

## Why
At default sheet width the inventory tabs were stacking vertically (one per row), which didn't match the intended horizontal-tab layout. Separately, the weapons list bled outside the inventory panel due to the outer `min-width`.

## Changes
- `styles/thefade.css` — `.inventory-tabs .tab-nav`: `flex-wrap: nowrap` + `overflow-x: auto`; buttons get `flex: 0 0 auto; white-space: nowrap`.
- `styles/thefade.css` — `.thefade .weapons`: removed `min-width: 800px`, added `max-width: 100%`.

## Test plan
- [ ] Open a character sheet → Inventory tab; confirm Weapons/Armor/Items of Power/Consumables/Magic Gear/Mundane Gear/Companions render in a single horizontal row (scroll horizontally if narrow).
- [ ] Add a weapon; confirm the weapons table stays inside the inventory panel and scrolls internally if the columns exceed available width.
- [ ] Verify other inventory sub-tabs (armor, consumables, etc.) still render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)