### PR TITLE
Weapons table: condense columns; click name to roll, right-click for actions

### DIFF
--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -3973,6 +3973,29 @@ export class TheFadeCharacterSheet extends ActorSheet {
         html.find('.skill-roll').click(this._onSkillRoll.bind(this));
         html.find('.attribute-roll').click(this._onAttributeRoll.bind(this));
         html.find('.attack-roll').click(this._onAttackRoll.bind(this));
+
+        // Right-click context menu on weapon rows: Edit / Delete
+        new ContextMenu(html, '.weapons .weapon-row', [
+            {
+                name: 'Edit',
+                icon: '<i class="fas fa-edit"></i>',
+                callback: li => {
+                    const itemId = li.data('itemId') || li.attr('data-item-id');
+                    const item = this.actor.items.get(itemId);
+                    if (item) item.sheet.render(true);
+                }
+            },
+            {
+                name: 'Delete',
+                icon: '<i class="fas fa-trash"></i>',
+                callback: li => {
+                    const itemId = li.data('itemId') || li.attr('data-item-id');
+                    if (!itemId) return;
+                    this.actor.deleteEmbeddedDocuments('Item', [itemId]);
+                    li.slideUp(200, () => this.render(false));
+                }
+            }
+        ]);
         html.find('.cast-spell').click(this._onCastSpell.bind(this));
         html.find('.initiative-roll').click(this._onInitiativeRoll.bind(this));
         html.find('.roll-dice').click(this._onRollDice.bind(this));

--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -1082,49 +1082,71 @@ input[readonly] {
 }
 
 .thefade .weapon-name {
-  flex: 2 1 120px;
-  min-width: 120px;
+  flex: 2 1 140px;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.thefade .items-list .weapon-name {
+  cursor: pointer;
+  transition: color 0.15s ease, text-shadow 0.15s ease;
+}
+
+.thefade .items-list .weapon-name:hover {
+  color: var(--accent-gold, #d4af37);
+  text-shadow: 0 0 6px rgba(212, 175, 55, 0.6);
+}
+
+.thefade .items-list .weapon-name .item-icon {
+  width: 22px;
+  height: 22px;
+  flex: 0 0 22px;
+}
+
+.thefade .items-list .weapon-name .weapon-name-text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .thefade .weapon-skill {
-  flex: 1 1 80px;
-  min-width: 80px;
+  flex: 1 1 60px;
+  min-width: 0;
   text-align: center;
 }
 
 .thefade .weapon-dice {
-  flex: 0 0 60px;
-  min-width: 60px;
-  text-align: center;
-}
-
-.thefade .weapon-dmg-attr {
-  flex: 0 0 50px;
-  min-width: 50px;
+  flex: 0 0 44px;
+  min-width: 0;
   text-align: center;
 }
 
 .thefade .weapon-damage {
-  flex: 1 1 80px;
-  min-width: 80px;
+  flex: 1 1 64px;
+  min-width: 0;
   text-align: center;
 }
 
 .thefade .weapon-crit {
-  flex: 0 0 50px;
-  min-width: 50px;
+  flex: 0 0 36px;
+  min-width: 0;
   text-align: center;
 }
 
 .thefade .weapon-range {
-  flex: 1 1 70px;
-  min-width: 70px;
+  flex: 1 1 60px;
+  min-width: 0;
   text-align: center;
 }
 
 .thefade .weapon-qualities {
-  flex: 2 1 100px;
-  min-width: 100px;
+  flex: 2 1 80px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .thefade .weapon-controls {

--- a/templates/actor/parts/inventory.html
+++ b/templates/actor/parts/inventory.html
@@ -37,37 +37,28 @@
                     </span>
                 </h2>
                 <header class="weapon-header flexrow gear-header">
-                    <div class="weapon-icon">Icon</div>
                     <div class="weapon-name">Name</div>
                     <div class="weapon-skill">Skill</div>
                     <div class="weapon-dice">Dice</div>
-                    <div class="weapon-dmg-attr">Dmg Attr</div>
                     <div class="weapon-damage">Damage</div>
                     <div class="weapon-crit">Crit</div>
                     <div class="weapon-range">Range</div>
                     <div class="weapon-qualities">Qualities</div>
-                    <div class="weapon-controls"></div>
                 </header>
 
                 <ol class="items-list">
                     {{#each actor.weapons as |weapon id|}}
-                    <li class="item flexrow" data-item-id="{{weapon._id}}">
-                        <div class="weapon-icon">
+                    <li class="item flexrow weapon-row" data-item-id="{{weapon._id}}">
+                        <div class="weapon-name attack-roll" title="Click to attack — right-click for options">
                             <img class="item-icon" src="{{weapon.img}}" alt="{{weapon.name}}" />
+                            <span class="weapon-name-text">{{weapon.name}}</span>
                         </div>
-                        <div class="weapon-name">{{weapon.name}}</div>
                         <div class="weapon-skill">{{weapon.system.skill}}</div>
                         <div class="weapon-dice">{{weapon.calculatedDice}}d12</div>
-                        <div class="weapon-dmg-attr">{{weapon.attributeAbbr}}</div>
                         <div class="weapon-damage">{{weapon.system.damage}} {{weapon.system.damageType}}</div>
                         <div class="weapon-crit">{{weapon.system.critical}}</div>
                         <div class="weapon-range">{{weapon.system.range}}</div>
                         <div class="weapon-qualities">{{weapon.system.qualities}}</div>
-                        <div class="weapon-controls">
-                            <a class="attack-roll" title="Attack with Weapon"><i class="fas fa-dice-d12"></i></a>
-                            <a class="item-edit" title="Edit Weapon"><i class="fas fa-edit"></i></a>
-                            <a class="item-delete" title="Delete Weapon"><i class="fas fa-trash"></i></a>
-                        </div>
                     </li>
                     {{/each}}
                 </ol>


### PR DESCRIPTION
## Summary
- Drop the **Icon** and **Dmg Attr** columns from the weapons table. The weapon icon now sits inline next to the name; the damage-attribute field wasn't earning its width.
- Remove the inline roll / edit / delete action icons. Clicking the weapon name now rolls the attack (the name carries `.attack-roll`, which the existing `_onAttackRoll` handler already binds). Right-clicking the row opens a Foundry `ContextMenu` with **Edit** and **Delete** entries.
- Add a hover glow on `.weapon-name` so the click affordance is visible.
- Reduce `min-width` on Skill / Dice / Damage / Crit / Range / Qualities so the row stays single-line at default sheet width; long qualities strings now ellipsize instead of wrapping.

## Why
At default sheet width the weapons row was wrapping (Qualities pushing onto a second line per weapon). The columns were too padded, and the action icons + Icon column ate horizontal space without much value.

## Files
- `templates/actor/parts/inventory.html` — header + row markup
- `styles/thefade.css` — `.weapon-name` flex layout + hover glow; tightened column widths
- `src/character-sheet.js` — `new ContextMenu(html, '.weapons .weapon-row', [...])` for Edit/Delete

## Test plan
- [ ] Open a character sheet → Inventory → Weapons; confirm one weapon renders as a single row (no wrapping) at default sheet width.
- [ ] Hover the weapon name → name glows gold; click → attack roll fires.
- [ ] Right-click the weapon row → context menu shows Edit and Delete; both work.
- [ ] Long qualities strings ellipsize instead of pushing the row to a second line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)