### PR TITLE
Condense character sheet header; move HP/Sanity into Stats + Combat tabs

### DIFF
--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -4004,6 +4004,14 @@ export class TheFadeCharacterSheet extends ActorSheet {
         html.find('.roll-addiction').click(this._onDarkMagicAddictionRoll.bind(this));
         html.find('.rest-daily').click(this._onRestDaily.bind(this));
         html.find('.take-rest-btn').click(this._onTakeRest.bind(this));
+
+        // Mirror duplicated HP/Sanity inputs (rendered on Stats + Combat tabs) so
+        // form serialization stays consistent regardless of which tab is active.
+        html.find('.vitals-strip-inline input[name]').on('input', function () {
+            const name = this.getAttribute('name');
+            if (!name) return;
+            html.find(`input[name="${name}"]`).not(this).val(this.value);
+        });
         html.find('.roll-attributes').click(this._onRollAttributes.bind(this));
 
         html.find('.level-up-btn').click(this._onLevelUp.bind(this));

--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -6114,10 +6114,31 @@ select[name="system.aura.color"] option[value="white"] {
     text-align: center;
 }
 
+/* Header row containing the Roll Dice tool and Initiative pill side-by-side. */
+.thefade .redesigned-header .header-actions-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+
+.thefade .redesigned-header .header-actions-row .dice-section,
+.thefade .redesigned-header .header-actions-row .vital-pill {
+  flex: 0 0 auto;
+}
+
 /* ----- Vitals strip (HP / Sanity / Initiative) ----- */
 .thefade .vitals-strip {
   display: flex;
   align-items: stretch;
+  gap: 8px;
+}
+
+/* Inline variant rendered at the top of the Stats and Combat tabs. */
+.thefade .vitals-strip.vitals-strip-inline {
+  margin-bottom: 10px;
+  flex-wrap: wrap;
 }
 
 .thefade .vital-pill {

--- a/templates/actor/character-sheet.html
+++ b/templates/actor/character-sheet.html
@@ -12,7 +12,9 @@
                     {{#if system.species.creatureType}}<span class="sep">·</span><span>{{system.species.creatureType}}</span>{{/if}}
                     {{#if system.species.size}}<span class="sep">·</span><span>{{titleCase system.species.size}}</span>{{/if}}
                 </div>
+            </div>
 
+            <div class="header-actions-row">
                 <div class="header-tool dice-section" data-collapsed="true">
                     <div class="tool-header" data-tool="dice" title="Dice Rollerator">
                         <i class="fas fa-dice-d20"></i>
@@ -29,32 +31,6 @@
                             <button type="button" class="aid-another" title="Help an ally — DT 3, rank Practiced+ grants +1D"><i class="fas fa-hands-helping"></i> Aid</button>
                         </div>
                     </div>
-                </div>
-            </div>
-
-            <div class="vitals-strip">
-                <div class="vital-pill vital-hp hp-state-{{system.hp.state}}">
-                    <label>HP</label>
-                    <div class="vital-values">
-                        <input type="text" name="system.hp.value" value="{{system.hp.value}}" data-dtype="Number" />
-                        <span class="sep">/</span>
-                        <input type="text" name="system.hp.max" value="{{system.hp.max}}" data-dtype="Number" disabled title="{{system.hp.formula}}" />
-                    </div>
-                    <input type="text" name="system.hpMiscBonus" value="{{system.hpMiscBonus}}" data-dtype="Number" title="HP Misc Bonus" class="vital-bonus" placeholder="+0" />
-                    {{#if system.hp.stateLabel}}
-                    <span class="hp-state-badge hp-state-{{system.hp.state}}" title="HP State">{{system.hp.stateLabel}}</span>
-                    {{/if}}
-                    <button type="button" class="take-rest-btn" title="Take a rest: roll 1d12 + Physique and restore that much HP"><i class="fas fa-bed"></i></button>
-                </div>
-
-                <div class="vital-pill vital-sanity">
-                    <label>Sanity</label>
-                    <div class="vital-values">
-                        <input type="text" name="system.sanity.value" value="{{system.sanity.value}}" data-dtype="Number" />
-                        <span class="sep">/</span>
-                        <input type="text" name="system.sanity.max" value="{{system.sanity.max}}" data-dtype="Number" disabled title="{{system.sanity.formula}}" />
-                    </div>
-                    <input type="text" name="system.sanity.miscBonus" value="{{system.sanity.miscBonus}}" data-dtype="Number" title="Sanity Misc Bonus" class="vital-bonus" placeholder="+0" />
                 </div>
 
                 <div class="vital-pill vital-init">
@@ -81,6 +57,8 @@
     <section class="sheet-body">
         {{!-- Main Tab --}}
         <div class="tab" data-group="primary" data-tab="main">
+            {{> "systems/thefade/templates/actor/parts/vitals-hp-sanity.html"}}
+
             {{!-- Identity: Species + Paths summary --}}
             <div class="identity-row identity-row-top">
                 <div class="species-card{{#if system.species.manualEntry}} species-card-manual{{/if}}" data-item-id="{{actor.speciesItem._id}}">
@@ -303,6 +281,7 @@
 
         {{!-- Combat Tab --}}
         <div class="tab" data-group="primary" data-tab="combat">
+            {{> "systems/thefade/templates/actor/parts/vitals-hp-sanity.html"}}
             {{> "systems/thefade/templates/actor/parts/combat-state.html"}}
             {{> "systems/thefade/templates/actor/parts/injuries.html"}}
         </div>

--- a/templates/actor/parts/vitals-hp-sanity.html
+++ b/templates/actor/parts/vitals-hp-sanity.html
@@ -1,0 +1,25 @@
+<div class="vitals-strip vitals-strip-inline">
+    <div class="vital-pill vital-hp hp-state-{{system.hp.state}}">
+        <label>HP</label>
+        <div class="vital-values">
+            <input type="text" name="system.hp.value" value="{{system.hp.value}}" data-dtype="Number" />
+            <span class="sep">/</span>
+            <input type="text" name="system.hp.max" value="{{system.hp.max}}" data-dtype="Number" disabled title="{{system.hp.formula}}" />
+        </div>
+        <input type="text" name="system.hpMiscBonus" value="{{system.hpMiscBonus}}" data-dtype="Number" title="HP Misc Bonus" class="vital-bonus" placeholder="+0" />
+        {{#if system.hp.stateLabel}}
+        <span class="hp-state-badge hp-state-{{system.hp.state}}" title="HP State">{{system.hp.stateLabel}}</span>
+        {{/if}}
+        <button type="button" class="take-rest-btn" title="Take a rest: roll 1d12 + Physique and restore that much HP"><i class="fas fa-bed"></i></button>
+    </div>
+
+    <div class="vital-pill vital-sanity">
+        <label>Sanity</label>
+        <div class="vital-values">
+            <input type="text" name="system.sanity.value" value="{{system.sanity.value}}" data-dtype="Number" />
+            <span class="sep">/</span>
+            <input type="text" name="system.sanity.max" value="{{system.sanity.max}}" data-dtype="Number" disabled title="{{system.sanity.formula}}" />
+        </div>
+        <input type="text" name="system.sanity.miscBonus" value="{{system.sanity.miscBonus}}" data-dtype="Number" title="Sanity Misc Bonus" class="vital-bonus" placeholder="+0" />
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- Removed HP and Sanity pills from the sheet header and render them at the top of the Stats tab (above Species/Paths) and the Combat tab (above Combat State) via a new shared partial `templates/actor/parts/vitals-hp-sanity.html`.
- Header now shows only Roll Dice and the Initiative pill, sitting side-by-side in a new `.header-actions-row` for a tighter top strip.
- Added a small input-mirror handler in `character-sheet.js` so the duplicated HP/Sanity inputs (one copy per tab) stay in sync — form serialization is consistent regardless of which tab is active when the user edits a value.
- CSS additions for `.header-actions-row` and a `.vitals-strip-inline` variant for the in-tab placement.

## Test plan
- [ ] Open a character sheet — header shows name/subtitle on the left and Roll Dice + Initiative on the right (or wrapping below on narrow widths).
- [ ] Stats tab: HP and Sanity pills appear above the Species/Paths row.
- [ ] Combat tab: HP and Sanity pills appear above Combat State.
- [ ] Edit HP value on Stats tab → switch to Combat tab → value matches; do the same in reverse.
- [ ] Edit HP misc bonus and Sanity misc bonus on each tab and confirm they save correctly.
- [ ] Take Rest button still works from the in-tab HP pill.
- [ ] Initiative Roll button in the header still works.
- [ ] HP state color/badge still reflects current state on both tab copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)