### PR TITLE
Preload vitals-hp-sanity partial

### DIFF
--- a/thefade.js
+++ b/thefade.js
@@ -238,6 +238,7 @@ Hooks.once('init', async function () {
         "systems/thefade/templates/actor/parts/spells.html",
         "systems/thefade/templates/actor/parts/combat-state.html",
         "systems/thefade/templates/actor/parts/injuries.html",
+        "systems/thefade/templates/actor/parts/vitals-hp-sanity.html",
         "systems/thefade/templates/chat/attack-roll.html",
         "systems/thefade/templates/chat/skill-roll.html",
         "systems/thefade/templates/chat/spell-cast.html",


### PR DESCRIPTION
## Summary
- Register `templates/actor/parts/vitals-hp-sanity.html` in the `loadTemplates()` preload list in `thefade.js`.
- Fixes the render error introduced in #58: `The partial systems/thefade/templates/actor/parts/vitals-hp-sanity.html could not be found`. Foundry requires Handlebars partials to be preloaded before `{{> ...}}` references can resolve them.

## Test plan
- [ ] Reload Foundry; open a character sheet — no render error in console.
- [ ] Stats tab shows HP/Sanity at the top.
- [ ] Combat tab shows HP/Sanity at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)