### PR TITLE
Fix HP/Sanity comma duplication when editing

### DIFF
--- a/templates/actor/character-sheet.html
+++ b/templates/actor/character-sheet.html
@@ -281,7 +281,7 @@
 
         {{!-- Combat Tab --}}
         <div class="tab" data-group="primary" data-tab="combat">
-            {{> "systems/thefade/templates/actor/parts/vitals-hp-sanity.html"}}
+            {{> "systems/thefade/templates/actor/parts/vitals-hp-sanity.html" noName=true}}
             {{> "systems/thefade/templates/actor/parts/combat-state.html"}}
             {{> "systems/thefade/templates/actor/parts/injuries.html"}}
         </div>

--- a/templates/actor/parts/vitals-hp-sanity.html
+++ b/templates/actor/parts/vitals-hp-sanity.html
@@ -2,11 +2,11 @@
     <div class="vital-pill vital-hp hp-state-{{system.hp.state}}">
         <label>HP</label>
         <div class="vital-values">
-            <input type="text" name="system.hp.value" value="{{system.hp.value}}" data-dtype="Number" />
+            <input type="text" {{#unless noName}}name="system.hp.value"{{/unless}} value="{{system.hp.value}}" data-dtype="Number" />
             <span class="sep">/</span>
-            <input type="text" name="system.hp.max" value="{{system.hp.max}}" data-dtype="Number" disabled title="{{system.hp.formula}}" />
+            <input type="text" {{#unless noName}}name="system.hp.max"{{/unless}} value="{{system.hp.max}}" data-dtype="Number" disabled title="{{system.hp.formula}}" />
         </div>
-        <input type="text" name="system.hpMiscBonus" value="{{system.hpMiscBonus}}" data-dtype="Number" title="HP Misc Bonus" class="vital-bonus" placeholder="+0" />
+        <input type="text" {{#unless noName}}name="system.hpMiscBonus"{{/unless}} value="{{system.hpMiscBonus}}" data-dtype="Number" title="HP Misc Bonus" class="vital-bonus" placeholder="+0" />
         {{#if system.hp.stateLabel}}
         <span class="hp-state-badge hp-state-{{system.hp.state}}" title="HP State">{{system.hp.stateLabel}}</span>
         {{/if}}
@@ -16,10 +16,10 @@
     <div class="vital-pill vital-sanity">
         <label>Sanity</label>
         <div class="vital-values">
-            <input type="text" name="system.sanity.value" value="{{system.sanity.value}}" data-dtype="Number" />
+            <input type="text" {{#unless noName}}name="system.sanity.value"{{/unless}} value="{{system.sanity.value}}" data-dtype="Number" />
             <span class="sep">/</span>
-            <input type="text" name="system.sanity.max" value="{{system.sanity.max}}" data-dtype="Number" disabled title="{{system.sanity.formula}}" />
+            <input type="text" {{#unless noName}}name="system.sanity.max"{{/unless}} value="{{system.sanity.max}}" data-dtype="Number" disabled title="{{system.sanity.formula}}" />
         </div>
-        <input type="text" name="system.sanity.miscBonus" value="{{system.sanity.miscBonus}}" data-dtype="Number" title="Sanity Misc Bonus" class="vital-bonus" placeholder="+0" />
+        <input type="text" {{#unless noName}}name="system.sanity.miscBonus"{{/unless}} value="{{system.sanity.miscBonus}}" data-dtype="Number" title="Sanity Misc Bonus" class="vital-bonus" placeholder="+0" />
     </div>
 </div>


### PR DESCRIPTION
## Summary
- The vitals partial was rendered in both the Stats and Combat tabs, so each form submit posted two inputs with the same `name` (e.g. `system.hp.value`). Foundry concatenated the duplicates with a comma, so `100` became `100,100` and kept growing on every save.
- The Combat tab now includes the partial with `noName=true`, which strips the `name` attributes from that copy. Only the Stats tab inputs actually submit; the Combat tab pills are display-only.

## Test plan
- [ ] Open a character sheet, edit HP and Sanity values on the Stats tab — values save cleanly with no commas.
- [ ] Switch to the Combat tab, confirm HP/Sanity display the saved values.
- [ ] Round-trip several edits to confirm values no longer grow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)