### PR TITLE
Clear legacy "converted from talent" trait source

### DIFF
--- a/thefade.js
+++ b/thefade.js
@@ -526,6 +526,37 @@ Hooks.on("createActor", async (actor, options, userId) => {
 });
 
 /**
+ * One-shot cleanup: clear the legacy "converted from talent" source string
+ * left on trait items by an older conversion routine.
+ */
+async function clearLegacyTraitSource() {
+    const LEGACY = "converted from talent";
+    let cleared = 0;
+
+    for (const item of game.items ?? []) {
+        if (item.type === "trait" && item.system?.source === LEGACY) {
+            await item.update({ "system.source": "" });
+            cleared++;
+        }
+    }
+
+    for (const actor of game.actors ?? []) {
+        const updates = [];
+        for (const item of actor.items) {
+            if (item.type === "trait" && item.system?.source === LEGACY) {
+                updates.push({ _id: item.id, "system.source": "" });
+            }
+        }
+        if (updates.length) {
+            await actor.updateEmbeddedDocuments("Item", updates);
+            cleared += updates.length;
+        }
+    }
+
+    if (cleared > 0) console.log(`thefade | cleared legacy trait source on ${cleared} item(s).`);
+}
+
+/**
  * System ready hook - final setup after all systems loaded
  */
 Hooks.once('ready', async function () {
@@ -533,6 +564,9 @@ Hooks.once('ready', async function () {
     if (game.user.isGM) {
         try { await migrateAllActorSkills(); }
         catch (err) { console.warn("thefade | skill migration error:", err); }
+
+        try { await clearLegacyTraitSource(); }
+        catch (err) { console.warn("thefade | trait source cleanup error:", err); }
     }
 
     if (game.user.isGM) {


### PR DESCRIPTION
## Summary
- Older code stamped `system.source = "converted from talent"` on traits generated from talents. That conversion routine is gone, but the leftover string still renders as an `ability-meta` chip next to the trait name on the actor sheet.
- Adds a one-shot GM-only cleanup in the `ready` hook (`clearLegacyTraitSource` in `thefade.js`) that walks world items and every actor's embedded items, and clears `system.source` to `""` on any trait whose source equals `"converted from talent"`.
- No template change needed — `templates/actor/parts/paths.html` already guards the chip with `{{#if trait.system.source}}`.

## Test plan
- [ ] Load a world that contains a trait item with `system.source = "converted from talent"` and confirm the chip disappears after the GM logs in.
- [ ] Verify traits with a legitimate source string (e.g. species/path name) are untouched.
- [ ] Confirm console logs `thefade | cleared legacy trait source on N item(s).` when applicable, and stays silent otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)