### PR TITLE
Add 'More HP' alt rule as world setting toggle

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -22,6 +22,9 @@
   "THEFADE.SettingCreationModePointBuy": "Point Buy",
   "THEFADE.SettingCreationModeRandom": "Random Roll",
 
+  "THEFADE.SettingMoreHP": "More HP (Alt Rule)",
+  "THEFADE.SettingMoreHPHint": "Optional scaling HP rule. Once a Tier 2 path is taken, the character gains +1 HP per character level (starting at level 5). Once a Tier 3 path is taken, levels 10+ instead grant +2 HP per level.",
+
   "THEFADE.SetFacing": "Set Facing (to target, or click a point)",
   "THEFADE.SetFacingTargeted": "{token} now faces {target}.",
   "THEFADE.SetFacingClickPrompt": "Click a point on the canvas to set this token's facing.",

--- a/src/actor.js
+++ b/src/actor.js
@@ -310,13 +310,16 @@ export class TheFadeActor extends Actor {
         // Calculate Max HP based on Species, Path, Physique, and misc bonus
         let baseHP = (data.species?.baseHP) || 0;
         let pathHP = 0;
+        let highestPathTier = 0;
 
         // Add HP from Paths - safer item processing
         if (actorData.items && typeof actorData.items.forEach === 'function') {
             try {
                 actorData.items.forEach(item => {
-                    if (item && item.type === "path" && item.system && typeof item.system.baseHP === 'number') {
-                        pathHP += item.system.baseHP;
+                    if (item && item.type === "path" && item.system) {
+                        if (typeof item.system.baseHP === 'number') pathHP += item.system.baseHP;
+                        const t = Number(item.system.tier) || 0;
+                        if (t > highestPathTier) highestPathTier = t;
                     }
                 });
             } catch (error) {
@@ -324,16 +327,39 @@ export class TheFadeActor extends Actor {
             }
         }
 
+        // Optional "More HP" alt rule: scaling HP per level based on highest path tier.
+        // Tier 2 paths grant +1 HP per character level from L5 onward; Tier 3 paths grant
+        // +2 HP per level from L10 onward (replacing the +1 rate for those levels).
+        let levelHP = 0;
+        let levelHPNote = "";
+        try {
+            if (game?.settings?.get?.("thefade", "moreHPScaling")) {
+                const level = Math.max(1, Number(data.level) || 1);
+                if (highestPathTier >= 2) {
+                    const t2End = highestPathTier >= 3 ? Math.min(level, 9) : Math.min(level, 9999);
+                    const t2Levels = Math.max(0, t2End - 4); // levels 5..t2End
+                    levelHP += t2Levels;
+                }
+                if (highestPathTier >= 3 && level >= 10) {
+                    const t3Levels = level - 9; // levels 10..level
+                    levelHP += t3Levels * 2;
+                }
+                if (levelHP) levelHPNote = ` + ${levelHP} level`;
+            }
+        } catch (e) {
+            // settings not ready yet during early prep; ignore
+        }
+
         // Calculate max HP and update both properties
         const physiqueValue = data.attributes?.physique?.value || 1;
         const hpMiscBonus = data.hpMiscBonus || 0;
-        const calculatedMaxHP = baseHP + pathHP + physiqueValue + hpMiscBonus;
+        const calculatedMaxHP = baseHP + pathHP + physiqueValue + hpMiscBonus + levelHP;
 
         data.hp.max = calculatedMaxHP;
         data.maxHP = calculatedMaxHP; // For backward compatibility with UI
         // Tooltip formula string for the UI
         const miscHPPart = hpMiscBonus ? ` + ${hpMiscBonus} misc` : "";
-        data.hp.formula = `Species ${baseHP} + Path ${pathHP} + Physique ${physiqueValue}${miscHPPart} = ${calculatedMaxHP}`;
+        data.hp.formula = `Species ${baseHP} + Path ${pathHP} + Physique ${physiqueValue}${miscHPPart}${levelHPNote} = ${calculatedMaxHP}`;
 
         // Calculate max Sanity and update both properties
         const mindValue = data.attributes?.mind?.value || 1;

--- a/thefade.js
+++ b/thefade.js
@@ -158,6 +158,25 @@ Hooks.once('init', async function () {
     // WORLD SETTINGS
     // --------------------------------------------------------------------
 
+    game.settings.register("thefade", "moreHPScaling", {
+        name: "THEFADE.SettingMoreHP",
+        hint: "THEFADE.SettingMoreHPHint",
+        scope: "world",
+        config: true,
+        type: Boolean,
+        default: false,
+        onChange: () => {
+            for (const actor of game.actors ?? []) {
+                if (actor?.type === "character") actor.prepareData();
+            }
+            for (const app of Object.values(ui.windows)) {
+                if (app?.actor?.type === "character" && typeof app.render === "function") {
+                    app.render(false);
+                }
+            }
+        }
+    });
+
     game.settings.register("thefade", "characterCreationMode", {
         name: "THEFADE.SettingCreationMode",
         hint: "THEFADE.SettingCreationModeHint",


### PR DESCRIPTION
## Summary
- Adds the rulebook's optional **More HP** alt rule as a GM-controlled world setting (`moreHPScaling`), mirroring the existing Character Creation Mode toggle pattern.
- When enabled, HP scales with level based on the actor's highest path tier:
  - **Tier 2 path** → +1 HP per character level for L5+
  - **Tier 3 path** → +2 HP per level for L10+ (replaces the +1 rate for those levels; pre-T3 levels still contribute at +1)
- The HP tooltip formula now shows a `+ N level` term when the setting is active.

## Implementation notes
- `_calculateMaxValues` in `src/actor.js` now also tracks the highest `system.tier` across the actor's path items and adds level-scaled HP when the setting is on.
- Because there is no per-level tier-acquisition history on the actor, eras are derived from the standard tier unlock schedule (T2 at L5, T3 at L10). Removing/respeccing paths updates HP retroactively, which is appropriate for an alt-rule toggle.
- Setting `onChange` re-prepares character actors and re-renders open sheets so values update live.

## Test plan
- [ ] Toggle setting off: HP matches previous behavior (Species + Path + Physique + misc).
- [ ] Toggle on, character L4 with T1 path: no extra HP.
- [ ] Toggle on, character L5+ with T2 path: +1 HP per level from L5 to current.
- [ ] Toggle on, character L10+ with T3 path: +1 for L5-9, +2 per level for L10+.
- [ ] HP tooltip shows the `+ N level` segment when active.
- [ ] Toggling the setting at runtime updates open character sheets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)