### PR TITLE
Clean up Magic tab: drop Spells Learned, auto-count Dark Magic

### DIFF
--- a/src/actor.js
+++ b/src/actor.js
@@ -398,23 +398,17 @@ export class TheFadeActor extends Actor {
         // Initialize dark magic data if needed
         if (!data.darkMagic || typeof data.darkMagic !== 'object') {
             data.darkMagic = {
-                spellsLearned: {},
                 currentSin: 0,
                 sinThresholdBonus: 0,
                 addictionLevel: "none"
             };
         }
 
-        // Count dark magic spells learned - safer processing
-        let darkMagicCount = 0;
-        if (data.darkMagic.spellsLearned && typeof data.darkMagic.spellsLearned === 'object') {
-            try {
-                darkMagicCount = Object.values(data.darkMagic.spellsLearned).filter(Boolean).length;
-            } catch (error) {
-                console.error("Error counting dark magic spells:", error);
-                darkMagicCount = 0;
-            }
-        }
+        // Count dark magic spells the actor actually owns.
+        const darkMagicCount = this.items?.filter(i =>
+            i.type === "spell" && i.system?.isDarkMagic
+        ).length ?? 0;
+        data.darkMagic.spellsLearnedCount = darkMagicCount;
 
         // Calculate sin threshold: Soul - 1 per dark magic spell + bonus
         const soulValue = data.attributes?.soul?.value || 1;

--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -605,7 +605,6 @@ export class TheFadeCharacterSheet extends ActorSheet {
         if (data.experience === undefined) data.experience = 0;
         if (data.isMonster === undefined) data.isMonster = false;
         if (data.talentsBonus === undefined) data.talentsBonus = 0;
-        if (data.spellsLearnedBase === undefined) data.spellsLearnedBase = 0;
 
         const level = data.level || 1;
 
@@ -643,10 +642,6 @@ export class TheFadeCharacterSheet extends ActorSheet {
         // Calculate current traits separately
         const currentTraits = sheetData.actor.traits ? sheetData.actor.traits.length : 0;
         data.currentTraits = currentTraits;
-
-        // Calculate spells learned from level
-        data.spellsLearnedFromLevel = this._calculateSpellsLearnedFromLevel(level);
-        data.spellsLearnedTotal = data.spellsLearnedFromLevel + data.spellsLearnedBase;
 
         // Ensure actor exists for the methods that need it
         if (!sheetData.actor) {
@@ -720,17 +715,6 @@ export class TheFadeCharacterSheet extends ActorSheet {
             }
         }
         return talents;
-    }
-
-    // Calculate spells learned from level (even levels if has spellcasting)
-    _calculateSpellsLearnedFromLevel(level) {
-        const spellcasting = getSkill(this.actor, "Spellcasting");
-        const trained = ['learned', 'practiced', 'adept', 'experienced', 'expert', 'mastered'];
-        if (!spellcasting || !trained.includes(spellcasting.rank)) return 0;
-
-        let spells = 0;
-        for (let i = 2; i <= level; i += 2) spells++;
-        return spells;
     }
 
     // Experience check - auto level up if experience >= 10

--- a/src/dark-magic.js
+++ b/src/dark-magic.js
@@ -59,7 +59,7 @@ export function applyAddictionPenalties(data) {
     // Terminal halves the Soul input to sin-threshold recomputation.
     if (effects.soulDivisor > 1) {
         const soul = data.attributes?.soul?.value || 1;
-        const spells = Object.values(data.darkMagic.spellsLearned || {}).filter(Boolean).length;
+        const spells = Number(data.darkMagic.spellsLearnedCount) || 0;
         const bonus = Number(data.darkMagic.sinThresholdBonus) || 0;
         data.darkMagic.sinThreshold = Math.max(0,
             Math.floor(soul / effects.soulDivisor) - spells + bonus);

--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -2545,8 +2545,7 @@ input[readonly] {
 }
 
 .paths-info,
-.talents-counter,
-.spells-learned-counter {
+.talents-counter {
   margin: 16px 0;
   padding: 12px;
   border: 1px solid var(--border-faint);
@@ -2555,8 +2554,7 @@ input[readonly] {
 }
 
 .paths-info h3,
-.talents-counter h3,
-.spells-learned-counter h3 {
+.talents-counter h3 {
   margin: 0 0 12px 0;
   font-size: 0.875rem;
   font-weight: bold;
@@ -2564,8 +2562,7 @@ input[readonly] {
 }
 
 .paths-progression,
-.talent-numbers,
-.spell-numbers {
+.talent-numbers {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   gap: 12px;
@@ -2766,13 +2763,6 @@ select[name="system.aura.color"] option[value="white"] {
   background: rgba(128, 0, 128, 0.05);
   border: 1px solid rgba(128, 0, 128, 0.2);
   border-radius: 5px;
-}
-
-.thefade .dark-magic-checkboxes {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-  margin-top: 5px;
 }
 
 .thefade .sin-management {
@@ -4010,8 +4000,7 @@ select[name="system.aura.color"] option[value="white"] {
   }
 
   .paths-progression,
-  .talent-numbers,
-  .spell-numbers {
+  .talent-numbers {
     grid-template-columns: 1fr;
   }
 }
@@ -7797,41 +7786,6 @@ select[name="system.aura.color"] option[value="white"] {
 }
 
 /* ----- Spells tab ----- */
-.thefade .spells-learned-counter {
-    background: var(--bg-surface);
-    border: 1px solid var(--border-faint);
-    border-left: 3px solid var(--accent-gold);
-    border-radius: 3px;
-    padding: 10px 14px;
-    margin-bottom: 14px;
-}
-
-.thefade .spells-learned-counter h3 {
-    margin: 0 0 8px !important;
-    color: var(--accent-gold) !important;
-    font-size: 0.8em !important;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-}
-
-.thefade .spells-learned-counter .spell-numbers {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 10px;
-}
-
-.thefade .spells-learned-counter .form-group {
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-}
-
-.thefade .spells-learned-counter label {
-    font-size: 0.72em;
-    color: var(--text-muted);
-    text-transform: uppercase;
-}
-
 .thefade .sin-dark-magic-section {
     background: var(--bg-surface);
     border: 1px solid var(--border-faint);
@@ -7839,41 +7793,6 @@ select[name="system.aura.color"] option[value="white"] {
     border-radius: 3px;
     padding: 12px 14px;
     margin-bottom: 14px;
-}
-
-.thefade .sin-dark-magic-section .dark-magic-spells {
-    margin-bottom: 12px;
-}
-
-.thefade .sin-dark-magic-section .dark-magic-spells > label {
-    display: block;
-    font-size: 0.78em;
-    color: var(--text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.6px;
-    margin-bottom: 6px;
-}
-
-.thefade .dark-magic-checkboxes {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px;
-}
-
-.thefade .dark-magic-checkboxes .checkbox-label {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    padding: 3px 8px;
-    background: var(--bg-surface-deep);
-    border: 1px solid var(--border-faint);
-    border-radius: 2px;
-    font-size: 0.8em;
-    cursor: pointer;
-}
-
-.thefade .dark-magic-checkboxes .checkbox-label:hover {
-    border-color: var(--accent-crimson);
 }
 
 .thefade .sin-management {
@@ -10516,9 +10435,8 @@ select[name="system.aura.color"] option[value="white"] {
     border-color: var(--accent-gold);
 }
 
-/* ----- Aura / Spells-Learned / Sin cards — drop legacy left-border, rely on inv-block ----- */
+/* ----- Aura / Sin cards — drop legacy left-border, rely on inv-block ----- */
 .thefade .aura-card.inv-block,
-.thefade .spells-learned-counter.inv-block,
 .thefade .sin-dark-magic-section.inv-block {
     border-left: 1px solid var(--border-faint);
     padding: 0;
@@ -10526,11 +10444,9 @@ select[name="system.aura.color"] option[value="white"] {
 }
 
 .thefade .aura-card.inv-block { border-left: 3px solid var(--accent-gold); }
-.thefade .spells-learned-counter.inv-block { border-left: 3px solid var(--accent-gold); }
 .thefade .sin-dark-magic-section.inv-block { border-left: 3px solid var(--accent-crimson); }
 
 .thefade .aura-card.inv-block > h2.inv-heading,
-.thefade .spells-learned-counter.inv-block > h2.inv-heading,
 .thefade .sin-dark-magic-section.inv-block > h2.inv-heading {
     margin: 0 !important;
     padding: 10px 14px !important;
@@ -10567,12 +10483,6 @@ select[name="system.aura.color"] option[value="white"] {
 
 .thefade .aura-card .aura-property strong { color: var(--accent-gold); min-width: 80px; }
 .thefade .aura-card .aura-bonus { color: var(--text-muted); margin-left: auto; }
-
-.thefade .spells-learned-counter .spell-numbers {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 12px;
-}
 
 .thefade .sin-dark-magic-section .sin-management {
     margin-top: 8px;

--- a/template.json
+++ b/template.json
@@ -25,7 +25,6 @@
         "miscBonus": 0
       },
       "darkMagic": {
-        "spellsLearned": {},
         "currentSin": 0,
         "sinThresholdBonus": 0,
         "addictionLevel": "none"

--- a/templates/actor/parts/spells.html
+++ b/templates/actor/parts/spells.html
@@ -82,52 +82,14 @@
         </div>
     </div>
 
-    <!-- Spells Learned Counter -->
-    <div class="spells-learned-counter inv-block">
-        <h2 class="inv-heading">
-            <i class="fas fa-book-sparkles"></i>
-            <span class="inv-title">Spells Learned</span>
-            <span class="inv-count">{{system.spellsLearnedTotal}}</span>
-        </h2>
-        <div class="inv-block-body">
-            <div class="spell-numbers">
-                <div class="form-group">
-                    <label>Base</label>
-                    <input type="number" name="system.spellsLearnedBase" value="{{system.spellsLearnedBase}}" data-dtype="Number" />
-                </div>
-                <div class="form-group">
-                    <label>From Level</label>
-                    <input type="number" name="system.spellsLearnedFromLevel" value="{{system.spellsLearnedFromLevel}}" data-dtype="Number" readonly />
-                </div>
-                <div class="form-group">
-                    <label>Total</label>
-                    <input type="number" name="system.spellsLearnedTotal" value="{{system.spellsLearnedTotal}}" data-dtype="Number" readonly />
-                </div>
-            </div>
-        </div>
-    </div>
-
     <!-- Sin and Dark Magic -->
     <div class="sin-dark-magic-section inv-block inv-block--crimson">
         <h2 class="inv-heading">
             <i class="fas fa-skull"></i>
             <span class="inv-title">Sin and Dark Magic</span>
+            <span class="inv-count" title="Dark Magic spells known">{{system.darkMagic.spellsLearnedCount}}</span>
         </h2>
         <div class="inv-block-body">
-            <!-- Dark Magic Spells Learned -->
-            <div class="dark-magic-spells">
-                <label>Dark Magic Spells Learned:</label>
-                <div class="dark-magic-checkboxes">
-                    {{#times 10}}
-                    <label class="checkbox-label">
-                        <input type="checkbox" name="system.darkMagic.spellsLearned.spell{{this}}"
-                               {{#if (lookup ../system.darkMagic.spellsLearned (concat "spell" this))}} checked{{/if}} />
-                        <span>{{this}}</span>
-                    </label>
-                    {{/times}}
-                </div>
-            </div>
-
             <!-- Sin Management -->
             <div class="sin-management grid grid-4col">
                 <div class="form-group">


### PR DESCRIPTION
## Summary
- Removed the **Spells Learned** counter on the Magic tab (base / from-level / total) — it was unused bookkeeping that didn't gate anything.
- Replaced the **1–10 Dark Magic Spells Learned** checkbox grid with a live count of owned spell items flagged `system.isDarkMagic`. The skull-icon block heading shows the count.
- Sin threshold math is unchanged (`Soul − darkMagicCount + bonus`), but it now reads from the derived count instead of the manual checkboxes — so adding/removing a Dark Magic spell automatically updates the threshold. The terminal-stage `Soul/2` recompute in `dark-magic.js` was updated the same way.
- Dropped the obsolete `darkMagic.spellsLearned` bag from `template.json` and removed the dead CSS / `_calculateSpellsLearnedFromLevel` helper.

## Why
The checkbox grid duplicated the per-spell `isDarkMagic` flag, so the two could drift out of sync (and players had to remember to tick a box every time they learned a new Dark Magic spell). Spells Learned was a relic with no downstream effect.

## Migration note
Existing actors will still have a `system.darkMagic.spellsLearned` object sitting in their data. It's ignored — no behavior impact — but happy to add a one-time strip if desired.

## Test plan
- [ ] Open a character sheet → Magic tab: Spells Learned section is gone; Sin & Dark Magic block shows a count next to the skull icon.
- [ ] Add a spell item with Dark Magic checked → count increments, Sin Threshold drops by 1.
- [ ] Delete that spell → count decrements, threshold restores.
- [ ] Confirm terminal-stage addiction still halves Soul correctly when recomputing the threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)