### PR TITLE
Damage-type bonus options: match components; armor bypass for So/Psi/Ex

### DIFF
--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -13,6 +13,7 @@ import {
 } from './skills.js';
 import { renderModifierHtml } from './conditions.js';
 import { handleDarkCast } from './dark-magic.js';
+import { damageTypeFlags } from './damage.js';
 import { openOpposedRollDialog, openAidAnotherDialog } from './opposed.js';
 import { rollHitLocation, locationLabel } from './hit-location.js';
 
@@ -2328,7 +2329,8 @@ export class TheFadeCharacterSheet extends ActorSheet {
                 hitLocationLabel: resolvedLocation ? locationLabel(resolvedLocation) : null,
                 hitLocationRollDetail: locationRollDetail,
                 calledShot: calledShot,
-                bonusDice: weaponData.miscBonus ? `Includes +${weaponData.miscBonus} bonus dice` : null
+                bonusDice: weaponData.miscBonus ? `Includes +${weaponData.miscBonus} bonus dice` : null,
+                ...damageTypeFlags(weaponData.damageType, weaponData.damageComponents)
             };
 
             const content = renderModifierHtml(condModsUntrained) +
@@ -2531,7 +2533,8 @@ export class TheFadeCharacterSheet extends ActorSheet {
                 `Includes bonus dice: ${[
                     skillData.miscBonus ? `+${skillData.miscBonus} from skill` : '',
                     weaponData.miscBonus ? `+${weaponData.miscBonus} from weapon` : ''
-                ].filter(Boolean).join(', ')}` : null
+                ].filter(Boolean).join(', ')}` : null,
+            ...damageTypeFlags(weaponData.damageType, weaponData.damageComponents)
         };
 
         const content = renderModifierHtml(condMods) +
@@ -2998,6 +3001,7 @@ export class TheFadeCharacterSheet extends ActorSheet {
             damage: spellSucceeds && spellData.damage ? spellData.damage : null,
             damageType: spellData.damageType,
             halfDamage: halfDamage,
+            ...damageTypeFlags(spellData.damageType, spellData.damageComponents),
             description: spellData.description,
             hasAttack: !!attackRollData,
             attackRoll: attackRollData,

--- a/src/damage.js
+++ b/src/damage.js
@@ -22,6 +22,37 @@ export const DAMAGE_LOCATIONS = [...BODY_PARTS];
 const BLEED_TYPES = new Set(["S", "P", "SP", "SoP", "BP", "BoP"]);
 
 /**
+ * Damage-type codes that ignore armor and Natural Deflection entirely,
+ * routing the full amount straight to HP.
+ */
+export const ARMOR_BYPASS_TYPES = new Set(["So", "Psi", "Ex"]);
+
+/**
+ * Build a presence-set + per-type booleans for a primary damage type plus
+ * any per-component types (weapons can carry multiple typed components).
+ * Used by chat templates to surface damage-type bonus options whenever a
+ * type is present, not just when it's the primary.
+ */
+export function damageTypeFlags(primary, components) {
+    const present = new Set();
+    if (Array.isArray(components)) {
+        for (const c of components) if (c?.type) present.add(c.type);
+    }
+    if (primary) present.add(primary);
+    return {
+        isFire: present.has("F"),
+        isCold: present.has("C"),
+        isAcid: present.has("A"),
+        isElectricity: present.has("E"),
+        isSonic: present.has("So"),
+        isSmiting: present.has("Sm"),
+        isExpel: present.has("Ex"),
+        isPsychokinetic: present.has("Psi"),
+        isCorruption: present.has("Co")
+    };
+}
+
+/**
  * Split armor absorption between Natural Deflection and equipped armor.
  * Mirrors the rules: ND stacks (if flagged) or takes the higher of the two;
  * the attacker reduces whichever applies first (we reduce ND first if
@@ -142,8 +173,12 @@ export async function applyDamage(actor, opts) {
     const hpMax = Number(actor.system.hp?.max ?? 1);
     const mitigation = actor.system.damageMitigation || { noExcessToHp: false, halveHp: false };
 
-    // 1) Armor/ND absorbs the front of the damage.
-    const armor = computeArmorAbsorption(actor, location, amount);
+    // 1) Armor/ND absorbs the front of the damage — unless the type bypasses
+    //    armor (Sonic, Psychokinetic, Expel route straight to HP).
+    const bypassArmor = ARMOR_BYPASS_TYPES.has(type);
+    const armor = bypassArmor
+        ? { absorbed: 0, carryToHp: amount, actorUpdates: {}, itemUpdates: [] }
+        : computeArmorAbsorption(actor, location, amount);
 
     // 2) Brace for Impact: excess past armor never reaches HP.
     let toHp = armor.carryToHp;
@@ -188,7 +223,7 @@ export async function applyDamage(actor, opts) {
     const summary = buildSummary({
         target: actor.name, sourceName, location, amount, type,
         absorbed: armor.absorbed, toHp, hpBefore, hpAfter,
-        mitigation, bleedApplied, knockedOut
+        mitigation, bleedApplied, knockedOut, bypassArmor
     });
 
     return { absorbed: armor.absorbed, hpBefore, hpAfter, hpDamage: toHp, bleedApplied, knockedOut, summary };
@@ -200,6 +235,7 @@ export async function applyDamage(actor, opts) {
 function buildSummary(o) {
     const parts = [];
     parts.push(`<strong>${o.target}</strong> takes <strong>${o.amount}</strong> ${o.type} damage to ${o.location} from ${o.sourceName}.`);
+    if (o.bypassArmor) parts.push(`<em>${o.type} damage bypasses armor.</em>`);
     if (o.absorbed > 0) parts.push(`Armor/ND absorbed ${o.absorbed}.`);
     if (o.mitigation.noExcessToHp && o.amount > o.absorbed) {
         parts.push(`<em>Brace for Impact:</em> excess blocked from HP.`);

--- a/templates/chat/attack-roll.html
+++ b/templates/chat/attack-roll.html
@@ -33,49 +33,49 @@
                 </button>
                 {{/if}}
 
-                {{#if (eq damageType "F")}}
+                {{#if isFire}}
                 <button class="bonus-option" data-option="fire" data-cost="2">
                     Fire (2 successes): Target catches fire for 1d6 rounds
                 </button>
                 {{/if}}
 
-                {{#if (eq damageType "C")}}
+                {{#if isCold}}
                 <button class="bonus-option" data-option="cold" data-cost="2">
                     Cold (2 successes): Fatigue (Low Intensity) for 1 round
                 </button>
                 {{/if}}
 
-                {{#if (eq damageType "A")}}
+                {{#if isAcid}}
                 <button class="bonus-option" data-option="acid" data-cost="2">
                     Acid (2 successes): Pain (Low Intensity) for 1 round
                 </button>
                 {{/if}}
 
-                {{#if (eq damageType "E")}}
+                {{#if isElectricity}}
                 <button class="bonus-option" data-option="electricity" data-cost="3">
                     Electricity (3 successes): Chain to adjacent target
                 </button>
                 {{/if}}
 
-                {{#if (eq damageType "So")}}
+                {{#if isSonic}}
                 <button class="bonus-option" data-option="sonic" data-cost="3" data-damage="{{halfDamage}}">
                     Sonic (3 successes): Deafness for {{halfDamage}} rounds
                 </button>
                 {{/if}}
 
-                {{#if (eq damageType "Sm")}}
+                {{#if isSmiting}}
                 <button class="bonus-option" data-option="smiting" data-cost="3">
                     Smiting (3 successes): Fear (Moderate) for 1d6 rounds
                 </button>
                 {{/if}}
 
-                {{#if (eq damageType "Ex")}}
+                {{#if isExpel}}
                 <button class="bonus-option" data-option="expel" data-cost="3">
                     Expel (3 successes): Stunned (Moderate) for 1d6 rounds
                 </button>
                 {{/if}}
 
-                {{#if (eq damageType "Psi")}}
+                {{#if isPsychokinetic}}
                 <button class="bonus-option" data-option="psychokinetic-damage" data-cost="2" data-damage="{{halfDamage}}">
                     Psychokinetic (2 successes): {{halfDamage}} to sanity
                 </button>
@@ -84,7 +84,7 @@
                 </button>
                 {{/if}}
 
-                {{#if (eq damageType "Co")}}
+                {{#if isCorruption}}
                 <button class="bonus-option" data-option="corruption" data-cost="2" data-damage="{{halfDamage}}">
                     Corruption (2 successes): {{halfDamage}} unhealable for 24h
                 </button>

--- a/templates/chat/spell-cast.html
+++ b/templates/chat/spell-cast.html
@@ -84,49 +84,49 @@
             </button>
             {{/if}}
             
-            {{#if (eq damageType "F")}}
+            {{#if isFire}}
             <button class="bonus-option attack-bonus" data-option="fire" data-cost="2">
                 Fire (2 successes): Target catches fire for 1d6 rounds
             </button>
             {{/if}}
 
-            {{#if (eq damageType "C")}}
+            {{#if isCold}}
             <button class="bonus-option attack-bonus" data-option="cold" data-cost="2">
                 Cold (2 successes): Fatigue (Low Intensity) for 1 round
             </button>
             {{/if}}
 
-            {{#if (eq damageType "A")}}
+            {{#if isAcid}}
             <button class="bonus-option attack-bonus" data-option="acid" data-cost="2">
                 Acid (2 successes): Pain (Low Intensity) for 1 round
             </button>
             {{/if}}
 
-            {{#if (eq damageType "E")}}
+            {{#if isElectricity}}
             <button class="bonus-option attack-bonus" data-option="electricity" data-cost="3">
                 Electricity (3 successes): Chain to adjacent target
             </button>
             {{/if}}
 
-            {{#if (eq damageType "So")}}
+            {{#if isSonic}}
             <button class="bonus-option attack-bonus" data-option="sonic" data-cost="3" data-damage="{{halfDamage}}">
                 Sonic (3 successes): Deafness for {{halfDamage}} rounds
             </button>
             {{/if}}
 
-            {{#if (eq damageType "Sm")}}
+            {{#if isSmiting}}
             <button class="bonus-option attack-bonus" data-option="smiting" data-cost="3">
                 Smiting (3 successes): Fear (Moderate) for 1d6 rounds
             </button>
             {{/if}}
 
-            {{#if (eq damageType "Ex")}}
+            {{#if isExpel}}
             <button class="bonus-option attack-bonus" data-option="expel" data-cost="3">
                 Expel (3 successes): Stunned (Moderate) for 1d6 rounds
             </button>
             {{/if}}
 
-            {{#if (eq damageType "Psi")}}
+            {{#if isPsychokinetic}}
             <button class="bonus-option attack-bonus" data-option="psychokinetic-damage" data-cost="2">
                 Psychokinetic (2 successes): Half damage to sanity
             </button>
@@ -135,7 +135,7 @@
             </button>
             {{/if}}
 
-            {{#if (eq damageType "Co")}}
+            {{#if isCorruption}}
             <button class="bonus-option attack-bonus" data-option="corruption" data-cost="2">
                 Corruption (2 successes): Half damage unhealable for 24h
             </button>


### PR DESCRIPTION
## Summary
- Bonus-success buttons on attack and spell-cast chat cards now fire when the damage type **is or includes** the relevant type. Weapons with multi-component damage (e.g. fire + bludgeoning) now expose the Fire bonus option, where previously only single-typed weapons did.
- Sonic, Psychokinetic, and Expel damage now bypass armor and Natural Deflection entirely in `applyDamage`, routing the full amount to HP with a note in the summary card.

## Changes
- `src/damage.js`: exports `ARMOR_BYPASS_TYPES` and `damageTypeFlags(primary, components)`. `applyDamage` skips `computeArmorAbsorption` for bypass types; summary notes the bypass.
- `src/character-sheet.js`: spreads `damageTypeFlags(...)` into the template data for both attack renders (trained + untrained) and the spell-cast render.
- `templates/chat/attack-roll.html` and `templates/chat/spell-cast.html`: replaced `{{#if (eq damageType \"F\")}}` style checks with the new `isFire` / `isCold` / etc. flags. Untyped intentionally still has no bonus option.

## Notes for reviewer
- The fixed-cost buttons (e.g. cold at 2 successes) still only spend their minimum cost — extending duration by spending additional successes per the rulebook is not in this PR.
- Bypass applies based on the primary `damageType` passed to `applyDamage` from the Apply Damage button. Splitting per-component damage on apply (when a weapon mixes Sonic with a non-bypass type) is out of scope.

## Test plan
- [ ] Roll an attack with a Fire-typed weapon → Fire bonus button appears.
- [ ] Roll an attack with a multi-component weapon (e.g. Fire + Bludgeoning) → Fire bonus button still appears.
- [ ] Cast a Sonic spell-attack → Sonic bonus button appears.
- [ ] Apply damage from a Sonic / Psychokinetic / Expel attack → armor/ND is not consumed; summary shows the bypass note; HP drops by the full amount.
- [ ] Apply damage from a Fire / Slashing / etc. attack → armor still absorbs as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)