### PR TITLE
Add Aura Ignition: ignite from sheet, draw lines, chat card with actions

### DIFF
--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -16,6 +16,10 @@ import { handleDarkCast } from './dark-magic.js';
 import { damageTypeFlags } from './damage.js';
 import { openOpposedRollDialog, openAidAnotherDialog } from './opposed.js';
 import { rollHitLocation, locationLabel } from './hit-location.js';
+import {
+    startIgnition, endIgnition, getIgnitionState,
+    IGNITION_INTENSITY_LABEL
+} from './ignition.js';
 
 /**
 * Character Sheet class for The Fade system
@@ -85,6 +89,23 @@ export class TheFadeCharacterSheet extends ActorSheet {
             "moderate": "Moderate",
             "intense": "Intense"
         };
+
+        // Ignition status view-model for the aura card UI
+        try {
+            const ig = getIgnitionState(this.actor);
+            const now = game?.time?.worldTime ?? 0;
+            const recoveryRemaining = Math.max(0, (ig?.recoveryUntil || 0) - now);
+            data.ignition = {
+                active: !!ig?.active,
+                intensityLabel: ig?.intensity ? (IGNITION_INTENSITY_LABEL[ig.intensity] || ig.intensity) : "",
+                radius: ig?.radius || 0,
+                participantCount: ig?.participants?.length || 0,
+                recovering: !ig?.active && recoveryRemaining > 0,
+                recoveryRemainingMin: Math.ceil(recoveryRemaining / 60)
+            };
+        } catch (_) {
+            data.ignition = { active: false, recovering: false };
+        }
 
         data.addictionLevelOptions = {
             "none": "None",
@@ -3509,6 +3530,16 @@ export class TheFadeCharacterSheet extends ActorSheet {
 
         // Pencil-icon edit dialog for adjustable computed values.
         html.find('.tf-edit-adjustable').on('click', this._onEditAdjustable.bind(this));
+
+        // Aura: Ignite / End Ignition
+        html.find('.aura-ignite-btn').on('click', async (ev) => {
+            ev.preventDefault();
+            await startIgnition(this.actor);
+        });
+        html.find('.aura-end-ignition-btn').on('click', async (ev) => {
+            ev.preventDefault();
+            await endIgnition(this.actor);
+        });
 
         // Combat-state: clear all conditions + stance
         html.find('.combat-state-clear').on('click', async (ev) => {

--- a/src/ignition.js
+++ b/src/ignition.js
@@ -127,24 +127,17 @@ export async function startIgnition(initiatorActor) {
     const radius = IGNITION_INTENSITY_RADIUS[intensity];
     const candidates = findAlliesInRadius(token, radius);
 
+    // Initiator only — allies opt in via whispered invites (or the Join button
+    // on the public card). Matches the rules: joining is a free action on the
+    // ally's turn or a Reaction outside of it.
     const participants = [{
         actorUuid: initiatorActor.uuid,
         tokenUuid: token.document.uuid,
         name: initiatorActor.name,
         role: "initiator"
     }];
-    for (const t of candidates) {
-        participants.push({
-            actorUuid: t.actor.uuid,
-            tokenUuid: t.document.uuid,
-            name: t.actor.name,
-            role: "ally"
-        });
-    }
 
     const totalLevel = Number(initiatorActor.system?.level) || 1;
-    const durationMin = Math.min(participants.length, totalLevel);
-
     const flag = {
         active: true,
         role: "initiator",
@@ -154,28 +147,109 @@ export async function startIgnition(initiatorActor) {
         participants,
         spentActions: [],
         startedAt: now,
-        durationSec: durationMin * 60,
+        durationSec: _durationSecFor(participants.length, totalLevel),
+        maxParticipants: totalLevel,
         recoveryUntil: 0
     };
     await initiatorActor.setFlag(FLAG_SCOPE, FLAG_KEY, flag);
 
-    for (const p of participants.slice(1)) {
-        const ally = await fromUuid(p.actorUuid);
-        if (ally) {
-            await ally.setFlag(FLAG_SCOPE, FLAG_KEY, {
-                active: true,
-                role: "participant",
-                initiatorUuid: initiatorActor.uuid,
-                intensity, radius,
-                startedAt: now,
-                durationSec: flag.durationSec,
-                recoveryUntil: 0
-            });
-        }
+    await _postIgnitionCard(initiatorActor, flag);
+
+    // Whisper each candidate ally an Accept/Decline invite
+    for (const t of candidates) {
+        await _postIgnitionInvite(initiatorActor, t.actor, t.document);
+    }
+    if (candidates.length) {
+        ui.notifications.info(`Sent ${candidates.length} Ignition invite(s).`);
     }
 
-    await _postIgnitionCard(initiatorActor, flag);
     drawIgnitionOverlay();
+}
+
+function _durationSecFor(participantCount, totalLevel) {
+    return Math.min(participantCount, Math.max(1, totalLevel)) * 60;
+}
+
+/**
+ * Add an ally to an active Ignition. Validates the ally's token is currently
+ * within radius of the initiator's token and that the ignition is live and
+ * not full. Joining is the rules' "free action on your turn / Reaction
+ * outside your turn" — the system enforces eligibility, the table decides
+ * whether the action economy fits.
+ */
+export async function joinIgnition(initiatorUuid, allyActorUuid) {
+    const initiator = await fromUuid(initiatorUuid);
+    if (!initiator) {
+        ui.notifications.warn("Initiator not found.");
+        return false;
+    }
+    const flag = getIgnitionState(initiator);
+    if (!flag?.active || flag.role !== "initiator") {
+        ui.notifications.warn("That Ignition is no longer active.");
+        return false;
+    }
+
+    const ally = await fromUuid(allyActorUuid);
+    if (!ally) return false;
+    if (!ally.isOwner && !game.user.isGM) {
+        ui.notifications.warn("You don't own that actor.");
+        return false;
+    }
+    if ((flag.participants || []).some(p => p.actorUuid === ally.uuid)) {
+        ui.notifications.info(`${ally.name} is already in the Ignition.`);
+        return false;
+    }
+
+    const initToken = canvas?.tokens?.placeables.find(t => t.document.uuid === flag.participants?.[0]?.tokenUuid);
+    if (!initToken) {
+        ui.notifications.warn("Initiator's token isn't on the active scene.");
+        return false;
+    }
+    const allyToken = canvas?.tokens?.placeables.find(t => t.actor?.id === ally.id);
+    if (!allyToken) {
+        ui.notifications.warn(`${ally.name} has no token on this scene.`);
+        return false;
+    }
+    const d = hexDistance(initToken.center, allyToken.center);
+    if (d > flag.radius + 0.001) {
+        ui.notifications.warn(`${ally.name} is outside the aura's radius.`);
+        return false;
+    }
+
+    const newParticipant = {
+        actorUuid: ally.uuid,
+        tokenUuid: allyToken.document.uuid,
+        name: ally.name,
+        role: "ally"
+    };
+    const participants = [...flag.participants, newParticipant];
+    const totalLevel = Number(initiator.system?.level) || 1;
+    const durationSec = _durationSecFor(participants.length, totalLevel);
+
+    await initiator.setFlag(FLAG_SCOPE, FLAG_KEY, {
+        ...flag,
+        participants,
+        durationSec
+    });
+
+    await ally.setFlag(FLAG_SCOPE, FLAG_KEY, {
+        active: true,
+        role: "participant",
+        initiatorUuid: initiator.uuid,
+        intensity: flag.intensity,
+        radius: flag.radius,
+        startedAt: flag.startedAt,
+        durationSec,
+        recoveryUntil: 0
+    });
+
+    await ChatMessage.create({
+        speaker: ChatMessage.getSpeaker({ actor: ally }),
+        content: `<div class="thefade-ignition-action"><strong>${ally.name}</strong> joins <strong>${initiator.name}</strong>'s Ignition.</div>`
+    });
+
+    drawIgnitionOverlay();
+    return true;
 }
 
 /**
@@ -209,6 +283,51 @@ export async function endIgnition(initiatorActor, { reason = "ended" } = {}) {
     });
 
     drawIgnitionOverlay();
+}
+
+/**
+ * Whisper an Ignition invitation to the owners of an ally token. Includes
+ * Accept / Decline buttons that the ally's owner can click.
+ */
+async function _postIgnitionInvite(initiator, allyActor, allyTokenDoc) {
+    const owners = _ownerUserIds(allyActor);
+    const whisper = owners.length ? owners : [game.user.id];
+    const content = `
+        <div class="thefade-ignition-invite" data-initiator-uuid="${initiator.uuid}" data-ally-uuid="${allyActor.uuid}">
+            <header class="ignition-header">
+                <i class="fas fa-fire"></i>
+                <strong>${initiator.name}</strong> invites <strong>${allyActor.name}</strong> to an Ignition
+                <span class="ignition-meta">${IGNITION_INTENSITY_LABEL[initiator.system?.aura?.intensity] || ""}</span>
+            </header>
+            <p class="ignition-section-label">Joining is a free action on your turn, or a Reaction outside it.</p>
+            <div class="ignition-invite-controls">
+                <button type="button" class="ignition-accept-btn"
+                        data-initiator-uuid="${initiator.uuid}"
+                        data-ally-uuid="${allyActor.uuid}">
+                    <i class="fas fa-fire"></i> Accept
+                </button>
+                <button type="button" class="ignition-decline-btn"
+                        data-ally-uuid="${allyActor.uuid}">
+                    Decline
+                </button>
+            </div>
+        </div>`;
+    await ChatMessage.create({
+        speaker: ChatMessage.getSpeaker({ actor: allyActor }),
+        whisper,
+        content
+    });
+}
+
+function _ownerUserIds(actor) {
+    const ids = [];
+    for (const user of game.users) {
+        if (user.isGM) continue;
+        if (actor.testUserPermission?.(user, "OWNER")) ids.push(user.id);
+    }
+    // Always include GMs so they see invites too
+    for (const user of game.users) if (user.isGM) ids.push(user.id);
+    return Array.from(new Set(ids));
 }
 
 async function _postIgnitionCard(actor, flag) {
@@ -291,10 +410,74 @@ export function drawIgnitionOverlay() {
 
 // ---------------- Chat card handlers ----------------
 
+function _bindIgnitionInvite(html) {
+    const $html = html instanceof jQuery ? html : $(html);
+    const invite = $html.find(".thefade-ignition-invite");
+    if (!invite.length) return;
+
+    invite.find(".ignition-accept-btn").on("click", async (ev) => {
+        ev.preventDefault();
+        const btn = ev.currentTarget;
+        const ok = await joinIgnition(btn.dataset.initiatorUuid, btn.dataset.allyUuid);
+        if (ok) {
+            invite.find(".ignition-accept-btn, .ignition-decline-btn")
+                .prop("disabled", true).addClass("spent");
+            invite.append('<p class="ignition-invite-resolved"><em>Accepted.</em></p>');
+        }
+    });
+
+    invite.find(".ignition-decline-btn").on("click", async (ev) => {
+        ev.preventDefault();
+        const btn = ev.currentTarget;
+        const ally = await fromUuid(btn.dataset.allyUuid);
+        if (ally && !ally.isOwner && !game.user.isGM) {
+            ui.notifications.warn("You don't own that actor.");
+            return;
+        }
+        invite.find(".ignition-accept-btn, .ignition-decline-btn")
+            .prop("disabled", true).addClass("spent");
+        invite.append('<p class="ignition-invite-resolved"><em>Declined.</em></p>');
+    });
+}
+
 function _bindIgnitionCard(html) {
     const $html = html instanceof jQuery ? html : $(html);
     const card = $html.find(".thefade-ignition-card");
     if (!card.length) return;
+
+    card.find(".ignition-join-btn").on("click", async (ev) => {
+        ev.preventDefault();
+        const initiatorUuid = ev.currentTarget.dataset.actorUuid;
+        // Use the user's first owned character on this scene as the joiner
+        const candidates = (canvas?.tokens?.placeables || []).filter(t => t.actor?.isOwner && ["character","npc"].includes(t.actor?.type));
+        if (!candidates.length) {
+            ui.notifications.warn("You don't own a token on this scene to join with.");
+            return;
+        }
+        let allyActor = candidates[0].actor;
+        if (candidates.length > 1) {
+            const opts = candidates.map((t, i) =>
+                `<label style="display:block;margin:2px 0"><input type="radio" name="join" value="${i}" ${i===0?"checked":""}/> ${t.actor.name}</label>`
+            ).join("");
+            allyActor = await new Promise(resolve => {
+                new Dialog({
+                    title: "Join Ignition",
+                    content: `<form><p>Join with which token?</p>${opts}</form>`,
+                    buttons: {
+                        ok: { label: "Join", callback: h => {
+                            const v = Number(h[0].querySelector("input[name='join']:checked")?.value ?? 0);
+                            resolve(candidates[v].actor);
+                        } },
+                        cancel: { label: "Cancel", callback: () => resolve(null) }
+                    },
+                    default: "ok",
+                    close: () => resolve(null)
+                }).render(true);
+            });
+            if (!allyActor) return;
+        }
+        await joinIgnition(initiatorUuid, allyActor.uuid);
+    });
 
     card.find(".ignition-action-btn").on("click", async (ev) => {
         ev.preventDefault();
@@ -452,5 +635,8 @@ export function registerIgnitionHooks() {
             drawIgnitionOverlay();
         }
     });
-    Hooks.on("renderChatMessage", (msg, html) => _bindIgnitionCard(html));
+    Hooks.on("renderChatMessage", (msg, html) => {
+        _bindIgnitionCard(html);
+        _bindIgnitionInvite(html);
+    });
 }

--- a/src/ignition.js
+++ b/src/ignition.js
@@ -1,0 +1,456 @@
+// Aura Ignition: lets a character ignite their aura and link allies within
+// its radius. Renders connecting lines on the canvas, posts a chat card with
+// the Ignition Actions, and tracks duration/recovery on actor flags.
+
+const FLAG_SCOPE = "thefade";
+const FLAG_KEY = "ignition";
+
+export const IGNITION_INTENSITY_RADIUS = { faint: 3, moderate: 2, intense: 1 };
+export const IGNITION_INTENSITY_LABEL = {
+    faint: "Faint",
+    moderate: "Moderate",
+    intense: "Intense"
+};
+
+export const IGNITION_ACTIONS = {
+    "shared-surge": {
+        label: "Shared Surge",
+        description: "As a Minor Action, you and an ally within Ignition you designate receive +2D to the next roll you or they make within the duration of the Ignition.",
+        needsAlly: 1
+    },
+    "interlinked-defense": {
+        label: "Interlinked Defense",
+        description: "You can designate two other allies; you and your allies designated share their Defense stats (effectively using the highest among them) against the next attack roll they each individually would suffer. This benefit disappears if not triggered within 4 rounds.",
+        needsAlly: 2
+    },
+    "echoed-strikes": {
+        label: "Echoed Strikes",
+        description: "When making an attack roll if you successfully hit and deal damage, an ally within the aura's radius can expend their Reaction to make a free attack roll—even if they'd normally be out of range as their spectral energy from their spirit charges your own attack for a follow-up."
+    },
+    "harmonic-flow": {
+        label: "Harmonic Flow",
+        description: "You can cast a spell you don't know but an ally within the Ignition knows."
+    },
+    "resonant-healing": {
+        label: "Resonant Healing",
+        description: "As a Minor Action you can activate a burst of healing energy—all allies within the Ignition heal 2D immediately.",
+        heal: true
+    },
+    "combat-unity": {
+        label: "Combat Unity",
+        description: "As a Minor Action, you can treat yourself as possessing the Talent of an ally within the Ignition, even if you don't meet the prerequisites."
+    },
+    "flare-of-purpose": {
+        label: "Flare of Purpose",
+        description: "You can activate this after making a successful attack, however doing so will end the Ignition for everyone. You increase the damage of your attack by 15 per ally within the Ignition (including yourself).",
+        endsIgnition: true
+    }
+};
+
+const AURA_COLOR_HEX = {
+    red: 0xff4040, blue: 0x4080ff, green: 0x40c060, yellow: 0xffe040,
+    purple: 0x9040ff, orange: 0xff8040, pink: 0xff80c0, gold: 0xffd040,
+    silver: 0xc0c0d0, turquoise: 0x40e0d0, indigo: 0x4040ff, brown: 0x8b5a2b,
+    violet: 0x8a2be2, gray: 0x808080, black: 0x303030, white: 0xf0f0f0
+};
+
+function auraColorHex(c) { return AURA_COLOR_HEX[c] ?? 0xff8040; }
+
+export function getIgnitionState(actor) {
+    return actor?.getFlag(FLAG_SCOPE, FLAG_KEY) || null;
+}
+
+function getInitiatorToken(actor) {
+    if (!canvas?.ready) return null;
+    const controlled = canvas.tokens.controlled.find(t => t.actor?.id === actor.id);
+    if (controlled) return controlled;
+    return canvas.tokens.placeables.find(t => t.actor?.id === actor.id) || null;
+}
+
+function hexDistance(p1, p2) {
+    try {
+        if (canvas?.grid?.measurePath) {
+            return canvas.grid.measurePath([p1, p2]).distance;
+        }
+        if (canvas?.grid?.measureDistance) {
+            return canvas.grid.measureDistance(p1, p2);
+        }
+    } catch (_) { /* fall through */ }
+    const dx = p1.x - p2.x, dy = p1.y - p2.y;
+    return Math.hypot(dx, dy) / (canvas?.grid?.size || 100);
+}
+
+function findAlliesInRadius(initiatorToken, radius) {
+    const center = initiatorToken.center;
+    const result = [];
+    for (const t of canvas.tokens.placeables) {
+        if (t.id === initiatorToken.id) continue;
+        if (!t.actor || !["character", "npc"].includes(t.actor.type)) continue;
+        if (t.document.disposition !== initiatorToken.document.disposition) continue;
+        const d = hexDistance(center, t.center);
+        if (d <= radius + 0.001) result.push(t);
+    }
+    return result;
+}
+
+/**
+ * Begin Ignition: derives radius from the actor's aura intensity, gathers
+ * same-disposition tokens within radius, stamps flags on each, and posts the
+ * chat card. Honors a recovery cooldown if the previous ignition just ended.
+ */
+export async function startIgnition(initiatorActor) {
+    if (!initiatorActor) return;
+    const intensity = initiatorActor.system?.aura?.intensity;
+    if (!intensity || !IGNITION_INTENSITY_RADIUS[intensity]) {
+        ui.notifications.warn("Set an Aura Intensity (Faint, Moderate, or Intense) before igniting.");
+        return;
+    }
+
+    const existing = getIgnitionState(initiatorActor);
+    const now = game.time.worldTime;
+    if (existing?.active) {
+        ui.notifications.warn(`${initiatorActor.name} is already in an Ignition.`);
+        return;
+    }
+    if (existing?.recoveryUntil && existing.recoveryUntil > now) {
+        const remainingMin = Math.ceil((existing.recoveryUntil - now) / 60);
+        ui.notifications.warn(`${initiatorActor.name} is still recovering (${remainingMin} min remaining).`);
+        return;
+    }
+
+    const token = getInitiatorToken(initiatorActor);
+    if (!token) {
+        ui.notifications.error("No token for this actor found on the active scene. Place a token first.");
+        return;
+    }
+
+    const radius = IGNITION_INTENSITY_RADIUS[intensity];
+    const candidates = findAlliesInRadius(token, radius);
+
+    const participants = [{
+        actorUuid: initiatorActor.uuid,
+        tokenUuid: token.document.uuid,
+        name: initiatorActor.name,
+        role: "initiator"
+    }];
+    for (const t of candidates) {
+        participants.push({
+            actorUuid: t.actor.uuid,
+            tokenUuid: t.document.uuid,
+            name: t.actor.name,
+            role: "ally"
+        });
+    }
+
+    const totalLevel = Number(initiatorActor.system?.level) || 1;
+    const durationMin = Math.min(participants.length, totalLevel);
+
+    const flag = {
+        active: true,
+        role: "initiator",
+        initiatorUuid: initiatorActor.uuid,
+        intensity,
+        radius,
+        participants,
+        spentActions: [],
+        startedAt: now,
+        durationSec: durationMin * 60,
+        recoveryUntil: 0
+    };
+    await initiatorActor.setFlag(FLAG_SCOPE, FLAG_KEY, flag);
+
+    for (const p of participants.slice(1)) {
+        const ally = await fromUuid(p.actorUuid);
+        if (ally) {
+            await ally.setFlag(FLAG_SCOPE, FLAG_KEY, {
+                active: true,
+                role: "participant",
+                initiatorUuid: initiatorActor.uuid,
+                intensity, radius,
+                startedAt: now,
+                durationSec: flag.durationSec,
+                recoveryUntil: 0
+            });
+        }
+    }
+
+    await _postIgnitionCard(initiatorActor, flag);
+    drawIgnitionOverlay();
+}
+
+/**
+ * End Ignition for the initiator and all participants. Sets a recovery
+ * cooldown of 1 hour per ally who participated.
+ */
+export async function endIgnition(initiatorActor, { reason = "ended" } = {}) {
+    const flag = getIgnitionState(initiatorActor);
+    if (!flag?.active) return;
+    const now = game.time.worldTime;
+    const allyCount = Math.max(0, (flag.participants?.length || 1) - 1);
+    const recoveryUntil = now + allyCount * 3600;
+
+    await initiatorActor.setFlag(FLAG_SCOPE, FLAG_KEY, {
+        active: false,
+        recoveryUntil
+    });
+    for (const p of (flag.participants || []).slice(1)) {
+        const ally = await fromUuid(p.actorUuid);
+        if (ally) {
+            await ally.setFlag(FLAG_SCOPE, FLAG_KEY, {
+                active: false,
+                recoveryUntil
+            });
+        }
+    }
+
+    await ChatMessage.create({
+        speaker: ChatMessage.getSpeaker({ actor: initiatorActor }),
+        content: `<div class="thefade-ignition-end"><i class="fas fa-fire-flame-curved"></i> <strong>${initiatorActor.name}</strong>'s Ignition has ${reason}. Participants must wait <strong>${allyCount} hour(s)</strong> before joining a new Ignition.</div>`
+    });
+
+    drawIgnitionOverlay();
+}
+
+async function _postIgnitionCard(actor, flag) {
+    const actions = Object.entries(IGNITION_ACTIONS).map(([key, v]) => ({
+        key,
+        label: v.label,
+        description: v.description
+    }));
+    const html = await renderTemplate("systems/thefade/templates/chat/ignition.html", {
+        actorName: actor.name,
+        actorUuid: actor.uuid,
+        intensity: IGNITION_INTENSITY_LABEL[flag.intensity],
+        radius: flag.radius,
+        participants: flag.participants,
+        durationMin: Math.round(flag.durationSec / 60),
+        actions
+    });
+    await ChatMessage.create({
+        speaker: ChatMessage.getSpeaker({ actor }),
+        content: html
+    });
+}
+
+// ---------------- Canvas overlay ----------------
+
+let _overlay = null;
+
+function _ensureOverlay() {
+    if (!canvas?.ready) return null;
+    if (_overlay && !_overlay.destroyed && _overlay.parent) return _overlay;
+    _overlay = new PIXI.Graphics();
+    _overlay.eventMode = "none";
+    _overlay.interactiveChildren = false;
+    _overlay.zIndex = 100;
+    canvas.tokens.addChild(_overlay);
+    return _overlay;
+}
+
+/**
+ * Redraw all active Ignition lines on the current scene. Called from token
+ * and actor update hooks so the lines follow tokens around.
+ */
+export function drawIgnitionOverlay() {
+    if (!canvas?.ready) return;
+    const g = _ensureOverlay();
+    if (!g) return;
+    g.clear();
+
+    const initiators = canvas.tokens.placeables.filter(t => {
+        const f = t.actor?.getFlag(FLAG_SCOPE, FLAG_KEY);
+        return f?.active && f?.role === "initiator";
+    });
+
+    for (const init of initiators) {
+        const flag = init.actor.getFlag(FLAG_SCOPE, FLAG_KEY);
+        const color = auraColorHex(init.actor.system?.aura?.color);
+        const start = init.center;
+
+        g.lineStyle({ width: 4, color, alpha: 0.65, cap: PIXI.LINE_CAP?.ROUND ?? 1 });
+        for (const p of (flag.participants || []).slice(1)) {
+            const tok = canvas.tokens.placeables.find(t => t.document.uuid === p.tokenUuid);
+            if (!tok) continue;
+            const end = tok.center;
+            g.moveTo(start.x, start.y);
+            g.lineTo(end.x, end.y);
+
+            g.beginFill(color, 0.85);
+            g.drawCircle(end.x, end.y, 6);
+            g.endFill();
+        }
+
+        g.lineStyle(0);
+        g.beginFill(color, 0.95);
+        g.drawCircle(start.x, start.y, 9);
+        g.endFill();
+        g.lineStyle({ width: 2, color: 0xffffff, alpha: 0.85 });
+        g.drawCircle(start.x, start.y, 9);
+    }
+}
+
+// ---------------- Chat card handlers ----------------
+
+function _bindIgnitionCard(html) {
+    const $html = html instanceof jQuery ? html : $(html);
+    const card = $html.find(".thefade-ignition-card");
+    if (!card.length) return;
+
+    card.find(".ignition-action-btn").on("click", async (ev) => {
+        ev.preventDefault();
+        const btn = ev.currentTarget;
+        const key = btn.dataset.action;
+        const actorUuid = btn.dataset.actorUuid;
+        await _onIgnitionAction(actorUuid, key, card);
+    });
+
+    card.find(".ignition-end-btn").on("click", async (ev) => {
+        ev.preventDefault();
+        const actorUuid = ev.currentTarget.dataset.actorUuid;
+        const actor = await fromUuid(actorUuid);
+        if (!actor) return;
+        if (!actor.isOwner && !game.user.isGM) {
+            ui.notifications.warn("You don't own this actor.");
+            return;
+        }
+        await endIgnition(actor);
+    });
+
+    // Reflect already-spent actions and grey them out
+    const cardActor = card.data("actorUuid") || card.attr("data-actor-uuid");
+    if (cardActor) {
+        fromUuid(cardActor).then(actor => {
+            const f = getIgnitionState(actor);
+            if (!f) return;
+            for (const key of (f.spentActions || [])) {
+                card.find(`.ignition-action-btn[data-action="${key}"]`)
+                    .prop("disabled", true).addClass("spent");
+            }
+            if (!f.active) {
+                card.find(".ignition-action-btn, .ignition-end-btn")
+                    .prop("disabled", true).addClass("spent");
+            }
+        });
+    }
+}
+
+async function _onIgnitionAction(actorUuid, key, card) {
+    const actor = await fromUuid(actorUuid);
+    if (!actor) return;
+    if (!actor.isOwner && !game.user.isGM) {
+        ui.notifications.warn("You don't own this Ignition.");
+        return;
+    }
+    const flag = getIgnitionState(actor);
+    if (!flag?.active || flag.role !== "initiator") {
+        ui.notifications.warn("No active Ignition for this actor.");
+        return;
+    }
+    if ((flag.spentActions || []).includes(key)) {
+        ui.notifications.warn("That Ignition Action has already been used.");
+        return;
+    }
+    const action = IGNITION_ACTIONS[key];
+    if (!action) return;
+
+    let summary = `<p><strong>${action.label}:</strong> ${action.description}</p>`;
+    let targets = [];
+
+    if (action.needsAlly) {
+        targets = await _promptAllyTargets(flag, action.needsAlly, action.label);
+        if (targets === null) return; // cancelled
+        if (targets.length) {
+            summary += `<p><em>Targets:</em> ${targets.map(t => t.name).join(", ")}</p>`;
+        }
+    }
+
+    if (key === "resonant-healing") {
+        const roll = await new Roll("2d12").evaluate();
+        const heal = roll.total;
+        summary += `<p><strong>Healing roll:</strong> ${heal} HP applied to each participant.</p>`;
+        if (game.user.isGM) {
+            for (const p of (flag.participants || [])) {
+                const a = await fromUuid(p.actorUuid);
+                if (!a) continue;
+                const cur = Number(a.system?.hp?.value ?? 0);
+                const max = Number(a.system?.hp?.max ?? cur + heal);
+                const next = Math.min(max, cur + heal);
+                await a.update({ "system.hp.value": next });
+            }
+        } else {
+            summary += `<p><em>(GM must confirm to apply HP.)</em></p>`;
+        }
+    }
+
+    if (key === "flare-of-purpose") {
+        const bonusDmg = 15 * (flag.participants?.length || 1);
+        summary += `<p><strong>Damage bonus:</strong> +${bonusDmg} to the triggering attack. <strong>Ignition ends.</strong></p>`;
+    }
+
+    const spent = [...(flag.spentActions || []), key];
+    await actor.setFlag(FLAG_SCOPE, FLAG_KEY, { ...flag, spentActions: spent });
+
+    card.find(`.ignition-action-btn[data-action="${key}"]`).prop("disabled", true).addClass("spent");
+
+    await ChatMessage.create({
+        speaker: ChatMessage.getSpeaker({ actor }),
+        content: `<div class="thefade-ignition-action">${summary}</div>`
+    });
+
+    if (action.endsIgnition) {
+        await endIgnition(actor, { reason: "ended via Flare of Purpose" });
+    }
+}
+
+async function _promptAllyTargets(flag, count, label) {
+    const allies = (flag.participants || []).filter(p => p.role !== "initiator");
+    if (!allies.length) {
+        ui.notifications.warn("No allies in the Ignition to target.");
+        return [];
+    }
+    const inputType = count === 1 ? "radio" : "checkbox";
+    const options = allies.map((a, i) =>
+        `<label style="display:block;margin:2px 0">
+            <input type="${inputType}" name="ally" value="${i}" />
+            ${a.name}
+        </label>`
+    ).join("");
+    const content = `<form><p>Select ${count === 1 ? "an ally" : `up to ${count} allies`}:</p>${options}</form>`;
+
+    return new Promise(resolve => {
+        new Dialog({
+            title: label,
+            content,
+            buttons: {
+                ok: {
+                    label: "Confirm",
+                    callback: html => {
+                        const selected = Array.from(html[0].querySelectorAll("input[name='ally']:checked"))
+                            .map(el => allies[Number(el.value)]).slice(0, count);
+                        resolve(selected);
+                    }
+                },
+                cancel: { label: "Cancel", callback: () => resolve(null) }
+            },
+            default: "ok",
+            close: () => resolve(null)
+        }).render(true);
+    });
+}
+
+// ---------------- Hook registration ----------------
+
+export function registerIgnitionHooks() {
+    Hooks.on("canvasReady", () => drawIgnitionOverlay());
+    Hooks.on("updateToken", () => drawIgnitionOverlay());
+    Hooks.on("createToken", () => drawIgnitionOverlay());
+    Hooks.on("deleteToken", () => drawIgnitionOverlay());
+    Hooks.on("refreshToken", () => drawIgnitionOverlay());
+    Hooks.on("updateActor", (actor, changes) => {
+        if (foundry.utils.hasProperty(changes, "flags.thefade.ignition")
+            || foundry.utils.hasProperty(changes, "system.aura")) {
+            drawIgnitionOverlay();
+        }
+    });
+    Hooks.on("renderChatMessage", (msg, html) => _bindIgnitionCard(html));
+}

--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -10484,6 +10484,166 @@ select[name="system.aura.color"] option[value="white"] {
 .thefade .aura-card .aura-property strong { color: var(--accent-gold); min-width: 80px; }
 .thefade .aura-card .aura-bonus { color: var(--text-muted); margin-left: auto; }
 
+/* ----- Aura Ignition controls ----- */
+.thefade .aura-card .aura-ignition {
+    margin-top: 10px;
+    padding-top: 8px;
+    border-top: 1px dashed var(--border-faint);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.thefade .aura-card .aura-ignition .ignition-status {
+    font-size: 0.85em;
+    color: var(--accent-gold);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.thefade .aura-card .aura-ignition .ignition-status.recovering {
+    color: var(--text-muted);
+}
+
+.thefade .aura-card .aura-ignite-btn,
+.thefade .aura-card .aura-end-ignition-btn {
+    align-self: flex-start;
+    padding: 4px 12px;
+    font-size: 0.85em;
+    background: linear-gradient(180deg, #5a1d0a, #3a1004);
+    color: #ffd9b8;
+    border: 1px solid var(--accent-gold);
+    border-radius: 3px;
+    cursor: pointer;
+}
+
+.thefade .aura-card .aura-ignite-btn:hover:not(:disabled),
+.thefade .aura-card .aura-end-ignition-btn:hover:not(:disabled) {
+    background: linear-gradient(180deg, #7a2e15, #5a1d0a);
+}
+
+.thefade .aura-card .aura-ignite-btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+/* ----- Ignition chat card ----- */
+.thefade-ignition-card {
+    border: 1px solid #8a3a16;
+    border-left: 3px solid #c66b2c;
+    background: rgba(40, 16, 8, 0.18);
+    border-radius: 4px;
+    padding: 8px 10px;
+    font-size: 0.9em;
+}
+
+.thefade-ignition-card .ignition-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+    padding-bottom: 6px;
+    border-bottom: 1px dashed rgba(198, 107, 44, 0.4);
+    margin-bottom: 6px;
+}
+
+.thefade-ignition-card .ignition-header i { color: #c66b2c; }
+
+.thefade-ignition-card .ignition-meta {
+    margin-left: auto;
+    font-size: 0.85em;
+    color: #8a8074;
+}
+
+.thefade-ignition-card .ignition-section-label {
+    margin: 6px 0 2px;
+    font-size: 0.88em;
+}
+
+.thefade-ignition-card ul.ignition-participants,
+.thefade-ignition-card ul.ignition-effects-list {
+    list-style: none;
+    margin: 0;
+    padding-left: 4px;
+}
+
+.thefade-ignition-card ul.ignition-participants li,
+.thefade-ignition-card ul.ignition-effects-list li {
+    padding: 1px 0;
+    font-size: 0.85em;
+}
+
+.thefade-ignition-card ul.ignition-participants i {
+    color: #c66b2c;
+    margin-right: 4px;
+    width: 12px;
+}
+
+.thefade-ignition-card .ignition-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-top: 4px;
+}
+
+.thefade-ignition-card .ignition-action-btn {
+    flex: 0 0 auto;
+    padding: 3px 8px;
+    font-size: 0.8em;
+    background: rgba(198, 107, 44, 0.15);
+    border: 1px solid #8a3a16;
+    color: #e8c79a;
+    border-radius: 3px;
+    cursor: pointer;
+}
+
+.thefade-ignition-card .ignition-action-btn:hover:not(:disabled) {
+    background: rgba(198, 107, 44, 0.3);
+}
+
+.thefade-ignition-card .ignition-action-btn.spent,
+.thefade-ignition-card .ignition-action-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    text-decoration: line-through;
+}
+
+.thefade-ignition-card .ignition-controls {
+    margin-top: 8px;
+    text-align: right;
+}
+
+.thefade-ignition-card .ignition-end-btn {
+    padding: 3px 10px;
+    font-size: 0.82em;
+    background: rgba(40, 8, 4, 0.6);
+    border: 1px solid #8a3a16;
+    color: #e8c79a;
+    border-radius: 3px;
+    cursor: pointer;
+}
+
+.thefade-ignition-card .ignition-end-btn:hover:not(:disabled) {
+    background: rgba(60, 16, 8, 0.8);
+}
+
+.thefade-ignition-end {
+    padding: 6px 10px;
+    border-left: 3px solid #c66b2c;
+    background: rgba(40, 16, 8, 0.15);
+    font-size: 0.9em;
+}
+
+.thefade-ignition-end i { color: #c66b2c; margin-right: 4px; }
+
+.thefade-ignition-action {
+    padding: 6px 10px;
+    border-left: 3px solid #c66b2c;
+    background: rgba(40, 16, 8, 0.1);
+    font-size: 0.9em;
+}
+
 .thefade .sin-dark-magic-section .sin-management {
     margin-top: 8px;
 }

--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -10611,9 +10611,12 @@ select[name="system.aura.color"] option[value="white"] {
 
 .thefade-ignition-card .ignition-controls {
     margin-top: 8px;
-    text-align: right;
+    display: flex;
+    justify-content: flex-end;
+    gap: 6px;
 }
 
+.thefade-ignition-card .ignition-join-btn,
 .thefade-ignition-card .ignition-end-btn {
     padding: 3px 10px;
     font-size: 0.82em;
@@ -10624,8 +10627,76 @@ select[name="system.aura.color"] option[value="white"] {
     cursor: pointer;
 }
 
-.thefade-ignition-card .ignition-end-btn:hover:not(:disabled) {
+.thefade-ignition-card .ignition-end-btn:hover:not(:disabled),
+.thefade-ignition-card .ignition-join-btn:hover:not(:disabled) {
     background: rgba(60, 16, 8, 0.8);
+}
+
+/* ----- Ignition invitation (whispered) ----- */
+.thefade-ignition-invite {
+    border: 1px solid #8a3a16;
+    border-left: 3px solid #c66b2c;
+    background: rgba(40, 16, 8, 0.18);
+    border-radius: 4px;
+    padding: 8px 10px;
+    font-size: 0.9em;
+}
+
+.thefade-ignition-invite .ignition-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+    padding-bottom: 6px;
+    border-bottom: 1px dashed rgba(198, 107, 44, 0.4);
+    margin-bottom: 6px;
+}
+
+.thefade-ignition-invite .ignition-header i { color: #c66b2c; }
+
+.thefade-ignition-invite .ignition-meta {
+    margin-left: auto;
+    font-size: 0.85em;
+    color: #8a8074;
+}
+
+.thefade-ignition-invite .ignition-invite-controls {
+    display: flex;
+    gap: 6px;
+    margin-top: 6px;
+}
+
+.thefade-ignition-invite .ignition-accept-btn,
+.thefade-ignition-invite .ignition-decline-btn {
+    padding: 3px 10px;
+    font-size: 0.82em;
+    background: rgba(198, 107, 44, 0.15);
+    border: 1px solid #8a3a16;
+    color: #e8c79a;
+    border-radius: 3px;
+    cursor: pointer;
+}
+
+.thefade-ignition-invite .ignition-accept-btn:hover:not(:disabled) {
+    background: rgba(198, 107, 44, 0.35);
+}
+
+.thefade-ignition-invite .ignition-decline-btn:hover:not(:disabled) {
+    background: rgba(40, 8, 4, 0.6);
+}
+
+.thefade-ignition-invite .ignition-accept-btn.spent,
+.thefade-ignition-invite .ignition-decline-btn.spent,
+.thefade-ignition-invite .ignition-accept-btn:disabled,
+.thefade-ignition-invite .ignition-decline-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.thefade-ignition-invite .ignition-invite-resolved {
+    margin: 6px 0 0;
+    font-size: 0.85em;
+    color: #8a8074;
 }
 
 .thefade-ignition-end {

--- a/templates/actor/parts/spells.html
+++ b/templates/actor/parts/spells.html
@@ -79,6 +79,32 @@
                 </div>
                 {{/if}}
             </div>
+
+            <div class="aura-ignition">
+                {{#if ignition.active}}
+                    <div class="ignition-status">
+                        <i class="fas fa-fire"></i>
+                        <strong>Ignition active</strong>
+                        <span>({{ignition.intensityLabel}}, {{ignition.radius}} hex, {{ignition.participantCount}} participant(s))</span>
+                    </div>
+                    <button type="button" class="aura-end-ignition-btn">
+                        <i class="fas fa-fire-flame-curved"></i> End Ignition
+                    </button>
+                {{else}}
+                    {{#if ignition.recovering}}
+                        <div class="ignition-status recovering">
+                            <i class="fas fa-hourglass-half"></i>
+                            <em>Recovering from Ignition — {{ignition.recoveryRemainingMin}} min remaining.</em>
+                        </div>
+                    {{/if}}
+                    <button type="button" class="aura-ignite-btn"
+                            title="Begin an Ignition with allies in your aura's radius"
+                            {{#unless system.aura.intensity}}disabled{{/unless}}
+                            {{#if ignition.recovering}}disabled{{/if}}>
+                        <i class="fas fa-fire"></i> Ignite
+                    </button>
+                {{/if}}
+            </div>
         </div>
     </div>
 

--- a/templates/chat/ignition.html
+++ b/templates/chat/ignition.html
@@ -1,0 +1,51 @@
+<div class="thefade-ignition-card" data-actor-uuid="{{actorUuid}}">
+    <header class="ignition-header">
+        <i class="fas fa-fire"></i>
+        <strong>{{actorName}}</strong> initiates an <strong>Ignition</strong>
+        <span class="ignition-meta">{{intensity}} &middot; {{radius}} hex &middot; up to {{durationMin}} min</span>
+    </header>
+
+    <div class="ignition-body">
+        <div class="ignition-participants-block">
+            <p class="ignition-section-label"><strong>Participants ({{participants.length}}):</strong></p>
+            <ul class="ignition-participants">
+                {{#each participants}}
+                <li>
+                    <i class="fas fa-{{#if (eq role "initiator")}}fire{{else}}user{{/if}}"></i>
+                    {{name}}{{#if (eq role "initiator")}} <em>(initiator)</em>{{/if}}
+                </li>
+                {{/each}}
+            </ul>
+        </div>
+
+        <div class="ignition-effects-block">
+            <p class="ignition-section-label"><strong>While active:</strong></p>
+            <ul class="ignition-effects-list">
+                <li>+1D to attack rolls (allies in radius)</li>
+                <li>Bonus to skills associated with Aura Color and Shape</li>
+                <li>Sense the life force of allies in the Ignition</li>
+            </ul>
+        </div>
+
+        <div class="ignition-actions-block">
+            <p class="ignition-section-label"><strong>Ignition Actions</strong> <em>(one-time, shared)</em>:</p>
+            <div class="ignition-actions">
+                {{#each actions}}
+                <button type="button"
+                        class="ignition-action-btn"
+                        data-action="{{key}}"
+                        data-actor-uuid="{{../actorUuid}}"
+                        title="{{description}}">
+                    {{label}}
+                </button>
+                {{/each}}
+            </div>
+        </div>
+
+        <div class="ignition-controls">
+            <button type="button" class="ignition-end-btn" data-actor-uuid="{{actorUuid}}">
+                <i class="fas fa-fire-flame-curved"></i> End Ignition
+            </button>
+        </div>
+    </div>
+</div>

--- a/templates/chat/ignition.html
+++ b/templates/chat/ignition.html
@@ -43,6 +43,10 @@
         </div>
 
         <div class="ignition-controls">
+            <button type="button" class="ignition-join-btn" data-actor-uuid="{{actorUuid}}"
+                    title="Join this Ignition with a token you own that is within the aura's radius">
+                <i class="fas fa-user-plus"></i> Join Ignition
+            </button>
             <button type="button" class="ignition-end-btn" data-actor-uuid="{{actorUuid}}">
                 <i class="fas fa-fire-flame-curved"></i> End Ignition
             </button>

--- a/thefade.js
+++ b/thefade.js
@@ -18,8 +18,10 @@ import { computePerRoundDamage, CONDITION_EFFECTS } from './src/conditions.js';
 import './src/token-facing.js';
 import { registerTokenActionHud } from './src/integrations/token-action-hud/index.js';
 import { migrateAllActorSkills } from './src/skills.js';
+import { registerIgnitionHooks } from './src/ignition.js';
 
 registerTokenActionHud();
+registerIgnitionHooks();
 
 
 /**
@@ -261,6 +263,7 @@ Hooks.once('init', async function () {
         "systems/thefade/templates/chat/attack-roll.html",
         "systems/thefade/templates/chat/skill-roll.html",
         "systems/thefade/templates/chat/spell-cast.html",
+        "systems/thefade/templates/chat/ignition.html",
         "systems/thefade/templates/dialogs/ability-edit.html",
         "systems/thefade/templates/dialogs/character-select.html",
 


### PR DESCRIPTION
## Summary
- Adds an **Ignite** button to the Aura card on the character sheet. Uses the configured Aura Intensity to derive radius (Faint 3 / Moderate 2 / Intense 1 hex), gathers same-disposition `character`/`npc` tokens within that radius, and stamps ignition flags on every participant.
- Renders connecting lines on the canvas from the initiator to each ally via a PIXI overlay tinted to the aura's color. Lines redraw on `updateToken`, `updateActor`, and `canvasReady`, so they follow tokens around.
- Posts a chat card listing participants, passive effects, and the seven Ignition Actions as one-time buttons (shared across the ignition). Includes an **End Ignition** control on both the sheet and the chat card.
- Ending an Ignition applies a 1-hour-per-ally recovery cooldown to every participant; the sheet button stays disabled with remaining time shown until clear.

## Ignition Action behavior
- **Shared Surge** / **Interlinked Defense** prompt for ally targets (1 / up to 2) from the participant list.
- **Resonant Healing** rolls `2d12` and applies HP to each participant (GM only — players see a reminder).
- **Flare of Purpose** adds +15 damage per participant and ends the Ignition for everyone.
- Echoed Strikes / Harmonic Flow / Combat Unity post their rule text as reminders.

## Files
- `src/ignition.js` (new) — module: start/end, overlay, chat handlers, hook registration.
- `templates/chat/ignition.html` (new) — chat card layout.
- `templates/actor/parts/spells.html` — Ignite / End controls + status under aura info.
- `src/character-sheet.js` — imports ignition module, view-model in `getData`, listeners.
- `thefade.js` — `registerIgnitionHooks()` + preload chat template.
- `styles/thefade.css` — aura-card button styling and chat-card theme.

## Caveats reviewers should sanity-check
- Healing assumes `"2D"` means `2d12` summed against `system.hp.value`/`max`. Adjust if the system convention differs.
- Duration text is informational (no auto-expiry tick on combat rounds yet).
- Allies are auto-joined when in radius at ignite time; the rules describe per-ally opt-in, which can be a follow-up.

## Test plan
- [ ] Set Aura color/shape/intensity on a character; confirm Ignite is enabled only when intensity is set.
- [ ] Place tokens of the same disposition within the intensity radius and click Ignite; verify lines render in the aura's color and that participants in the chat card match.
- [ ] Move tokens around — lines should follow.
- [ ] Use each Ignition Action button; confirm one-time behavior, ally-target dialogs, healing application, and that Flare of Purpose ends the Ignition.
- [ ] End the Ignition manually; verify the recovery cooldown shows on each participant's sheet and prevents a second Ignite until elapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)