### PR TITLE
Add naturalDeflection defaults to Actor.character template

### DIFF
--- a/template.json
+++ b/template.json
@@ -104,6 +104,14 @@
         "leftLeg":  { "severed": false },
         "rightLeg": { "severed": false }
       },
+      "naturalDeflection": {
+        "head":     { "current": 0, "max": 0, "stacks": false },
+        "body":     { "current": 0, "max": 0, "stacks": false },
+        "leftarm":  { "current": 0, "max": 0, "stacks": false },
+        "rightarm": { "current": 0, "max": 0, "stacks": false },
+        "leftleg":  { "current": 0, "max": 0, "stacks": false },
+        "rightleg": { "current": 0, "max": 0, "stacks": false }
+      },
       "mentalDisorders": [],
       "magicItems": {
         "head": null,


### PR DESCRIPTION
### Motivation
- Ensure the actor template provides defaults for natural deflection so the UI and runtime have consistent, expected keys and casing for natural deflection values.

### Description
- Added a `naturalDeflection` object under `Actor.character` in `template.json`.
- Included keys `head`, `body`, `leftarm`, `rightarm`, `leftleg`, and `rightleg` with defaults `current: 0`, `max: 0`, and `stacks: false` for each.
- Left the existing `injuries` structure (camelCase limb keys) unchanged to preserve the distinction between injury and natural-deflection naming.

### Testing
- Ran `rg -n "naturalDeflection|leftArm|leftarm|rightarm|injury|deflection" template.json templates/actor/parts/inventory.html src/actor.js src/damage.js` to verify references and casing, and the command completed successfully.
- Inspected `template.json` with `sed -n '70,150p'` and `nl -ba template.json | sed -n '92,130p'` to confirm the inserted `naturalDeflection` block appears as expected.
- No automated unit tests were executed for this template-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a152994a318832b827ff46451a5fe78)