### PR TITLE
Add hex readouts to personal-detail color pickers

### DIFF
--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -2925,13 +2925,30 @@ select[name="system.aura.color"] option[value="white"] {
   font-weight: bold;
 }
 
+.color-row .color-row-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .color-row input[type="color"] {
-  width: 50px;
-  height: 30px;
+  width: 42px;
+  min-width: 42px;
+  height: 28px;
   padding: 0;
   border: 1px solid var(--border-color);
   border-radius: 3px;
   cursor: pointer;
+}
+
+.color-row .color-hex-readout {
+  flex: 1;
+  min-width: 0;
+  font-family: monospace;
+  letter-spacing: 0.2px;
+  text-transform: uppercase;
+  color: var(--text-primary);
+  background: var(--bg-surface-deep);
 }
 
 .checkbox-row label {
@@ -11029,4 +11046,3 @@ select[name="system.aura.color"] option[value="white"] {
     text-transform: uppercase;
     letter-spacing: 0.4px;
 }
-

--- a/templates/actor/character-sheet.html
+++ b/templates/actor/character-sheet.html
@@ -345,17 +345,26 @@
 
                         <div class="detail-row color-row">
                             <label>Hair Color</label>
-                            <input type="color" name="system.personalDetails.hairColor" value="{{system.personalDetails.hairColor}}" />
+                            <div class="color-row-controls">
+                                <input type="color" name="system.personalDetails.hairColor" value="{{system.personalDetails.hairColor}}" />
+                                <input type="text" class="color-hex-readout" value="{{system.personalDetails.hairColor}}" readonly />
+                            </div>
                         </div>
 
                         <div class="detail-row color-row">
                             <label>Eye Color</label>
-                            <input type="color" name="system.personalDetails.eyeColor" value="{{system.personalDetails.eyeColor}}" />
+                            <div class="color-row-controls">
+                                <input type="color" name="system.personalDetails.eyeColor" value="{{system.personalDetails.eyeColor}}" />
+                                <input type="text" class="color-hex-readout" value="{{system.personalDetails.eyeColor}}" readonly />
+                            </div>
                         </div>
 
                         <div class="detail-row color-row">
                             <label>Skin Color</label>
-                            <input type="color" name="system.personalDetails.skinColor" value="{{system.personalDetails.skinColor}}" />
+                            <div class="color-row-controls">
+                                <input type="color" name="system.personalDetails.skinColor" value="{{system.personalDetails.skinColor}}" />
+                                <input type="text" class="color-hex-readout" value="{{system.personalDetails.skinColor}}" readonly />
+                            </div>
                         </div>
 
                         <div class="detail-row checkbox-row">


### PR DESCRIPTION
### Motivation
- Improve clarity of the character appearance controls by showing the hex value next to the color picker for hair, eyes, and skin. 
- Keep existing data binding and behavior intact by preserving original input names and `type="color"` fields.

### Description
- Updated `templates/actor/character-sheet.html` to wrap each color picker for `system.personalDetails.hairColor`, `system.personalDetails.eyeColor`, and `system.personalDetails.skinColor` in a `.color-row-controls` container and added a read-only text field with class `color-hex-readout` populated from the same template value. 
- Preserved the original field names and `input type="color"` elements so existing data/behavior remain unchanged. 
- Added CSS in `styles/thefade.css` to create a horizontal control layout, enforce a fixed-size swatch, provide spacing/alignment consistent with other detail rows, and ensure the hex readout is visible on the dark theme.

### Testing
- No automated tests were executed for this change because it is an HTML/CSS template update only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a152bac85c8832b9a2b6c6c2fe8eb2e)