### PR TITLE
Fix d12 consistency for weapon rolls and initiative icons

### DIFF
--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -23,6 +23,14 @@ import {
 } from './ignition.js';
 
 /**
+ * Dice audit (templates/ + src/):
+ * - Check/attack contexts are d12 (weapon item-sheet roll path updated to d12; character and skill roll paths already d12-based).
+ * - Legacy d20/d10 iconography replaced in character/npc initiative and weapon attack UI with generic `fa-dice`.
+ * - `1d6x6` attribute generation is intentionally preserved by rules.
+ * - Remaining d6 references are duration/effect rolls (fire/fear/stun/confusion) and descriptive damage text, not attack/skill/check die-size mismatches.
+ */
+
+/**
 * Character Sheet class for The Fade system
 * Handles all character sheet rendering, interactions, and calculations
 */

--- a/src/item-sheet.js
+++ b/src/item-sheet.js
@@ -900,7 +900,7 @@ export class TheFadeItemSheet extends ItemSheet {
                 const miscBonus = sys.miscBonus ?? 0;
                 const dice = rank + miscBonus;
                 if (dice <= 0) return ui.notifications.warn("No dice to roll — assign a skill rank first.");
-                const roll = await new Roll(`${dice}d10`).evaluate();
+                const roll = await new Roll(`${dice}d12`).evaluate();
                 const baseDmg = Number(sys.damage) || 0;
                 const dmgInc = Number(sys.damageIncrease) || 0;
                 const effDmg = baseDmg + dmgInc;

--- a/templates/actor/character-sheet.html
+++ b/templates/actor/character-sheet.html
@@ -17,7 +17,7 @@
             <div class="header-actions-row">
                 <div class="header-tool dice-section" data-collapsed="true">
                     <div class="tool-header" data-tool="dice" title="Dice Rollerator">
-                        <i class="fas fa-dice-d20"></i>
+                        <i class="fas fa-dice"></i>
                         <span class="tool-label">Roll Dice</span>
                         <i class="fas fa-chevron-down collapse-icon"></i>
                     </div>
@@ -35,7 +35,7 @@
 
                 <div class="vital-pill vital-init">
                     <label>Initiative</label>
-                    <button type="button" class="initiative-roll"><i class="fas fa-dice-d20"></i> Roll</button>
+                    <button type="button" class="initiative-roll"><i class="fas fa-dice"></i> Roll</button>
                     <input type="text" name="system.initiativeBonus" value="{{system.initiativeBonus}}" data-dtype="Number" title="Misc Init Bonus" class="vital-bonus" placeholder="+0" />
                 </div>
             </div>

--- a/templates/actor/npc-sheet.html
+++ b/templates/actor/npc-sheet.html
@@ -36,7 +36,7 @@
 
                 <div class="vital-pill vital-init">
                     <label>Initiative</label>
-                    <button type="button" class="initiative-roll"><i class="fas fa-dice-d20"></i> Roll</button>
+                    <button type="button" class="initiative-roll"><i class="fas fa-dice"></i> Roll</button>
                     <input type="text" name="system.initiativeBonus" value="{{system.initiativeBonus}}" data-dtype="Number" title="Misc Initiative Bonus" class="vital-bonus" placeholder="+0" />
                 </div>
             </div>

--- a/templates/item/weapon-sheet.html
+++ b/templates/item/weapon-sheet.html
@@ -27,8 +27,8 @@
         {{#if calculatedDice}}
         <div class="item-calc-bar">
           <span class="calc-label">Dice Pool:</span>
-          <span class="calc-value">{{calculatedDice}}d10</span>
-          <a class="item-action-btn roll-weapon-attack"><i class="fas fa-dice-d10"></i> Roll Attack</a>
+          <span class="calc-value">{{calculatedDice}}d12</span>
+          <a class="item-action-btn roll-weapon-attack"><i class="fas fa-dice"></i> Roll Attack</a>
         </div>
         {{/if}}
         {{#if effectiveDamage}}


### PR DESCRIPTION
### Motivation
- The system uses d12 for checks and attacks but some templates and handlers still showed or rolled d10/d20, causing inconsistent UI and incorrect rolls.
- Weapon item-sheet UI and the item roll handler displayed and rolled `d10` while other roll paths used `d12`, which must be unified to system invariants.
- Initiative buttons used a `d20`-specific icon which is misleading for a d12-based system and should use a neutral dice glyph.

### Description
- Updated the weapon item-sheet display from `{{calculatedDice}}d10` to `{{calculatedDice}}d12` in `templates/item/weapon-sheet.html`.
- Replaced the weapon attack icon from `fa-dice-d10` to the generic `fa-dice` in `templates/item/weapon-sheet.html` and replaced initiative `fa-dice-d20` icons with `fa-dice` in `templates/actor/character-sheet.html` and `templates/actor/npc-sheet.html` for consistent UI.
- Changed the weapon attack roll formula in `src/item-sheet.js` from ```${dice}d10``` to ```${dice}d12```. 
- Added a concise dice-audit comment block to the top of `src/character-sheet.js` documenting remaining `dN` usages and why `d6`/`1d6x6` occurrences are intentional (attribute generation and duration/effect rolls).

### Testing
- Ran repository searches for dice/icon patterns (`rg` across `templates/` and `src/`) to locate `d10`/`d20` and confirm attack/check contexts were updated to `d12`, and these checks succeeded. 
- Verified the weapon template shows `d12` and the item-sheet handler constructs a roll string using `d12` at the handler site (`src/item-sheet.js`).
- Confirmed initiative UI in both PC and NPC sheets now uses the generic `fa-dice` icon and that no `fa-dice-d20` remains in `templates/` or `src/` for initiative buttons. 
- Noted remaining `d6` references are for valid non-attack contexts (exploding attribute rolls and effect durations) and were left documented rather than changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1531157a30832ba275d2473944e41e)