### PR TITLE
Fix hidden weapon context menu and instantly-collapsing ability dropdowns

### DIFF
--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -533,6 +533,13 @@ input[readonly] {
   max-height: 0 !important;
 }
 
+/* <details>-based inventory collapsibles handle show/hide natively, so the
+   inner content must not clip — otherwise the weapon-row ContextMenu popup
+   is cut off and Edit/Delete become unreachable. */
+.inventory-category-collapsible > .collapsible-content {
+  overflow: visible;
+}
+
 /* Responsive adjustments */
 @media (max-width: 768px) {
   .core-stats {
@@ -2214,10 +2221,10 @@ input[readonly] {
   transition: transform 0.3s ease;
 }
 
-.path-checkbox:checked ~ .path-header .path-toggle-icon,
-.talent-checkbox:checked ~ .talent-header .talent-toggle-icon,
-.trait-checkbox:checked ~ .trait-header .trait-toggle-icon,
-.precept-checkbox:checked ~ .precept-header .precept-toggle-icon {
+.path-checkbox:checked ~ .ability-header-row .path-toggle-icon,
+.talent-checkbox:checked ~ .ability-header-row .talent-toggle-icon,
+.trait-checkbox:checked ~ .ability-header-row .trait-toggle-icon,
+.precept-checkbox:checked ~ .ability-header-row .precept-toggle-icon {
   transform: rotate(180deg);
 }
 
@@ -9830,9 +9837,26 @@ select[name="system.aura.color"] option[value="white"] {
     margin-left: 2px;
 }
 
-.thefade .ability-checkbox:checked ~ .ability-header .ability-toggle-icon {
+.thefade .ability-checkbox:checked ~ .ability-header-row .ability-toggle-icon {
     transform: rotate(180deg);
     color: var(--accent-crimson);
+}
+
+/* Header row wraps the (label) ability-header and its sibling controls so
+   clicks on Edit/Delete never reach the label and toggle the checkbox. */
+.thefade .ability-header-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.thefade .ability-header-row > .ability-header {
+    flex: 1;
+    min-width: 0;
+}
+
+.thefade .ability-header-row > .ability-controls {
+    padding-right: 14px;
 }
 
 .thefade .ability-description {

--- a/templates/actor/parts/paths.html
+++ b/templates/actor/parts/paths.html
@@ -15,17 +15,19 @@
             {{#each actor.paths as |path id|}}
             <div class="path-item ability-entry" data-item-id="{{path._id}}">
                 <input type="checkbox" id="toggle-path-{{path._id}}" class="path-checkbox ability-checkbox">
-                <label for="toggle-path-{{path._id}}" class="path-header ability-header">
-                    <div class="path-name-container ability-name-container">
-                        <span class="path-name ability-name">{{path.name}}</span>
-                        <span class="path-tier ability-meta">Tier {{path.system.tier}}</span>
-                    </div>
+                <div class="ability-header-row">
+                    <label for="toggle-path-{{path._id}}" class="path-header ability-header">
+                        <div class="path-name-container ability-name-container">
+                            <span class="path-name ability-name">{{path.name}}</span>
+                            <span class="path-tier ability-meta">Tier {{path.system.tier}}</span>
+                        </div>
+                        <i class="fas fa-chevron-down path-toggle-icon ability-toggle-icon"></i>
+                    </label>
                     <div class="path-controls ability-controls">
                         <a class="item-edit" title="Edit Path"><i class="fas fa-edit"></i></a>
                         <a class="item-delete" title="Delete Path"><i class="fas fa-trash"></i></a>
-                        <i class="fas fa-chevron-down path-toggle-icon ability-toggle-icon"></i>
                     </div>
-                </label>
+                </div>
                 <div class="path-description ability-description">
                     <p><strong>Base HP:</strong> {{path.system.baseHP}}</p>
                     {{#if path.system.description}}
@@ -63,19 +65,21 @@
             {{#each actor.talents as |talent id|}}
             <div class="talent-item ability-entry" data-item-id="{{talent._id}}">
                 <input type="checkbox" id="toggle-talent-{{talent._id}}" class="talent-checkbox ability-checkbox">
-                <label for="toggle-talent-{{talent._id}}" class="talent-header ability-header">
-                    <div class="talent-name-container ability-name-container">
-                        <span class="talent-name ability-name">{{talent.name}}</span>
-                        {{#if talent.system.usesPerDay}}
-                        <span class="ability-meta">{{talent.system.usesPerDay}}/day</span>
-                        {{/if}}
-                    </div>
+                <div class="ability-header-row">
+                    <label for="toggle-talent-{{talent._id}}" class="talent-header ability-header">
+                        <div class="talent-name-container ability-name-container">
+                            <span class="talent-name ability-name">{{talent.name}}</span>
+                            {{#if talent.system.usesPerDay}}
+                            <span class="ability-meta">{{talent.system.usesPerDay}}/day</span>
+                            {{/if}}
+                        </div>
+                        <i class="fas fa-chevron-down talent-toggle-icon ability-toggle-icon"></i>
+                    </label>
                     <div class="talent-controls ability-controls">
                         <a class="item-edit" title="Edit Talent"><i class="fas fa-edit"></i></a>
                         <a class="item-delete" title="Delete Talent"><i class="fas fa-trash"></i></a>
-                        <i class="fas fa-chevron-down talent-toggle-icon ability-toggle-icon"></i>
                     </div>
-                </label>
+                </div>
                 <div class="talent-description ability-description">
                     <p>{{talent.system.description}}</p>
                     {{#if talent.system.prerequisites}}
@@ -103,19 +107,21 @@
             {{#each actor.precepts as |precept id|}}
             <div class="precept-item ability-entry" data-item-id="{{precept._id}}">
                 <input type="checkbox" id="toggle-precept-{{precept._id}}" class="precept-checkbox ability-checkbox">
-                <label for="toggle-precept-{{precept._id}}" class="precept-header ability-header">
-                    <div class="precept-name-container ability-name-container">
-                        <span class="precept-name ability-name">{{precept.name}}</span>
-                        {{#if precept.system.deity}}
-                        <span class="ability-meta">{{precept.system.deity}}</span>
-                        {{/if}}
-                    </div>
+                <div class="ability-header-row">
+                    <label for="toggle-precept-{{precept._id}}" class="precept-header ability-header">
+                        <div class="precept-name-container ability-name-container">
+                            <span class="precept-name ability-name">{{precept.name}}</span>
+                            {{#if precept.system.deity}}
+                            <span class="ability-meta">{{precept.system.deity}}</span>
+                            {{/if}}
+                        </div>
+                        <i class="fas fa-chevron-down precept-toggle-icon ability-toggle-icon"></i>
+                    </label>
                     <div class="precept-controls ability-controls">
                         <a class="item-edit" title="Edit Precept"><i class="fas fa-edit"></i></a>
                         <a class="item-delete" title="Delete Precept"><i class="fas fa-trash"></i></a>
-                        <i class="fas fa-chevron-down precept-toggle-icon ability-toggle-icon"></i>
                     </div>
-                </label>
+                </div>
                 <div class="precept-description ability-description">
                     <p>{{precept.system.description}}</p>
                     {{#if precept.system.domain}}
@@ -146,19 +152,21 @@
             {{#each actor.traits as |trait id|}}
             <div class="trait-item ability-entry" data-item-id="{{trait._id}}">
                 <input type="checkbox" id="toggle-trait-{{trait._id}}" class="trait-checkbox ability-checkbox">
-                <label for="toggle-trait-{{trait._id}}" class="trait-header ability-header">
-                    <div class="trait-name-container ability-name-container">
-                        <span class="trait-name ability-name">{{trait.name}}</span>
-                        {{#if trait.system.source}}
-                        <span class="ability-meta">{{trait.system.source}}</span>
-                        {{/if}}
-                    </div>
+                <div class="ability-header-row">
+                    <label for="toggle-trait-{{trait._id}}" class="trait-header ability-header">
+                        <div class="trait-name-container ability-name-container">
+                            <span class="trait-name ability-name">{{trait.name}}</span>
+                            {{#if trait.system.source}}
+                            <span class="ability-meta">{{trait.system.source}}</span>
+                            {{/if}}
+                        </div>
+                        <i class="fas fa-chevron-down trait-toggle-icon ability-toggle-icon"></i>
+                    </label>
                     <div class="trait-controls ability-controls">
                         <a class="item-edit" title="Edit Trait"><i class="fas fa-edit"></i></a>
                         <a class="item-delete" title="Delete Trait"><i class="fas fa-trash"></i></a>
-                        <i class="fas fa-chevron-down trait-toggle-icon ability-toggle-icon"></i>
                     </div>
-                </label>
+                </div>
                 <div class="trait-description ability-description">
                     <p>{{trait.system.description}}</p>
                     {{#if trait.system.prerequisites}}


### PR DESCRIPTION
## Summary

Two character-sheet interaction bugs reported by the user:

- **Right-clicking a weapon row** opened Foundry's `ContextMenu`, but the popup was clipped and rendered off-screen, making Edit/Delete unreachable.
- **Clicking a Talent / Path / Precept / Trait** to expand it would instantly collapse the dropdown again.

## What changed

**Weapon context menu (`styles/thefade.css`)**
The `<details class="inventory-category-collapsible">` wrappers added in `b8a9ddc` nest each weapon row inside `.collapsible-content { overflow: hidden }`, which clipped the absolutely-positioned context menu. The `<details>` element handles show/hide natively, so its inner content doesn't need to clip. Added a scoped override that keeps overflow visible for the `<details>`-based variant only; the JS-driven `.collapsed` collapse pattern still clips as before.

**Ability dropdowns (`templates/actor/parts/paths.html` + `styles/thefade.css`)**
The `<label for=\"toggle-...\">` wrapped both the name *and* the edit/delete `<a>` controls. Because those `<a>` tags have no `href`, the browser doesn't treat them as interactive — so clicking them (or the chevron strip) still fired the label's default *toggle the associated checkbox* action, opening then immediately closing the dropdown. Moved `.item-edit` / `.item-delete` **out** of the `<label>` into a sibling `.ability-controls` div, both wrapped in a new `.ability-header-row` flex container. The chevron stays inside the label so clicking the name area still toggles. Updated the `:checked ~ … .toggle-icon` selectors to descend through the new wrapper. Applied to all four sections: Paths, Talents, Precepts, Traits.

## Test plan

- [ ] Right-click a weapon row in the Inventory tab → Edit / Delete menu is fully visible and clickable.
- [ ] Click a Talent / Path / Precept / Trait header (name area) → dropdown expands and stays open; chevron rotates.
- [ ] Click the same header again → dropdown collapses; chevron rotates back.
- [ ] Click the Edit (pencil) icon → item sheet opens, dropdown state unchanged.
- [ ] Click the Delete (trash) icon → entry deletes without toggling other entries.
- [ ] Confirm the JS-driven `.collapsible-content.collapsed` pattern used elsewhere still animates correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)