### PR TITLE
Fix ability collapsibles re-collapsing after open

### DIFF
--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -3874,6 +3874,8 @@ export class TheFadeCharacterSheet extends ActorSheet {
         });
 
         html.find('.item-delete').off('click').click(ev => {
+            ev.preventDefault();
+            ev.stopPropagation();
             const li = $(ev.currentTarget).closest("[data-item-id]");
             const itemId = li.data("itemId");
 
@@ -3885,6 +3887,8 @@ export class TheFadeCharacterSheet extends ActorSheet {
             this.actor.deleteEmbeddedDocuments("Item", [itemId]);
             li.slideUp(200, () => this.render(false));
         });
+
+        html.find('.ability-controls a').on('click', ev => ev.stopPropagation());
 
         // Custom-skill deletion (skills live on system.skills, not as items)
         html.find('.skill-delete').off('click').click(ev => {

--- a/styles/thefade.css
+++ b/styles/thefade.css
@@ -2221,10 +2221,10 @@ input[readonly] {
   transition: transform 0.3s ease;
 }
 
-.path-checkbox:checked ~ .ability-header-row .path-toggle-icon,
-.talent-checkbox:checked ~ .ability-header-row .talent-toggle-icon,
-.trait-checkbox:checked ~ .ability-header-row .trait-toggle-icon,
-.precept-checkbox:checked ~ .ability-header-row .precept-toggle-icon {
+.ability-entry[open] > summary .path-toggle-icon,
+.ability-entry[open] > summary .talent-toggle-icon,
+.ability-entry[open] > summary .trait-toggle-icon,
+.ability-entry[open] > summary .precept-toggle-icon {
   transform: rotate(180deg);
 }
 
@@ -9771,6 +9771,14 @@ select[name="system.aura.color"] option[value="white"] {
 
 .thefade .ability-checkbox { display: none; }
 
+.thefade summary.ability-header {
+    list-style: none;
+}
+
+.thefade summary.ability-header::-webkit-details-marker {
+    display: none;
+}
+
 .thefade .ability-header {
     display: flex;
     align-items: center;
@@ -9837,42 +9845,16 @@ select[name="system.aura.color"] option[value="white"] {
     margin-left: 2px;
 }
 
-.thefade .ability-checkbox:checked ~ .ability-header-row .ability-toggle-icon {
+.thefade .ability-entry[open] > summary .ability-toggle-icon {
     transform: rotate(180deg);
     color: var(--accent-crimson);
 }
 
-/* Header row wraps the (label) ability-header and its sibling controls so
-   clicks on Edit/Delete never reach the label and toggle the checkbox. */
-.thefade .ability-header-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-}
-
-.thefade .ability-header-row > .ability-header {
-    flex: 1;
-    min-width: 0;
-}
-
-.thefade .ability-header-row > .ability-controls {
-    padding-right: 14px;
-}
-
 .thefade .ability-description {
-    max-height: 0;
-    overflow: hidden;
-    padding: 0 14px;
-    background: var(--bg-surface-deep);
-    border-top: 0 solid var(--border-faint);
-    color: var(--text-primary);
-    transition: max-height 0.25s ease, padding 0.25s ease, border-width 0.25s ease;
-}
-
-.thefade .ability-checkbox:checked ~ .ability-description {
-    max-height: 1000px;
     padding: 10px 14px;
-    border-top-width: 1px;
+    background: var(--bg-surface-deep);
+    border-top: 1px solid var(--border-faint);
+    color: var(--text-primary);
 }
 
 .thefade .ability-description p { margin: 0 0 6px; line-height: 1.45; }

--- a/templates/actor/parts/paths.html
+++ b/templates/actor/parts/paths.html
@@ -13,21 +13,18 @@
 
         <div class="paths-list abilities-list">
             {{#each actor.paths as |path id|}}
-            <div class="path-item ability-entry" data-item-id="{{path._id}}">
-                <input type="checkbox" id="toggle-path-{{path._id}}" class="path-checkbox ability-checkbox">
-                <div class="ability-header-row">
-                    <label for="toggle-path-{{path._id}}" class="path-header ability-header">
-                        <div class="path-name-container ability-name-container">
-                            <span class="path-name ability-name">{{path.name}}</span>
-                            <span class="path-tier ability-meta">Tier {{path.system.tier}}</span>
-                        </div>
-                        <i class="fas fa-chevron-down path-toggle-icon ability-toggle-icon"></i>
-                    </label>
+            <details class="path-item ability-entry" data-item-id="{{path._id}}">
+                <summary class="path-header ability-header">
+                    <div class="path-name-container ability-name-container">
+                        <span class="path-name ability-name">{{path.name}}</span>
+                        <span class="path-tier ability-meta">Tier {{path.system.tier}}</span>
+                    </div>
                     <div class="path-controls ability-controls">
                         <a class="item-edit" title="Edit Path"><i class="fas fa-edit"></i></a>
                         <a class="item-delete" title="Delete Path"><i class="fas fa-trash"></i></a>
                     </div>
-                </div>
+                    <i class="fas fa-chevron-down path-toggle-icon ability-toggle-icon"></i>
+                </summary>
                 <div class="path-description ability-description">
                     <p><strong>Base HP:</strong> {{path.system.baseHP}}</p>
                     {{#if path.system.description}}
@@ -44,7 +41,7 @@
                     </div>
                     {{/if}}
                 </div>
-            </div>
+            </details>
             {{/each}}
         </div>
     </div>
@@ -63,30 +60,27 @@
 
         <div class="talents-list abilities-list">
             {{#each actor.talents as |talent id|}}
-            <div class="talent-item ability-entry" data-item-id="{{talent._id}}">
-                <input type="checkbox" id="toggle-talent-{{talent._id}}" class="talent-checkbox ability-checkbox">
-                <div class="ability-header-row">
-                    <label for="toggle-talent-{{talent._id}}" class="talent-header ability-header">
-                        <div class="talent-name-container ability-name-container">
-                            <span class="talent-name ability-name">{{talent.name}}</span>
-                            {{#if talent.system.usesPerDay}}
-                            <span class="ability-meta">{{talent.system.usesPerDay}}/day</span>
-                            {{/if}}
-                        </div>
-                        <i class="fas fa-chevron-down talent-toggle-icon ability-toggle-icon"></i>
-                    </label>
+            <details class="talent-item ability-entry" data-item-id="{{talent._id}}">
+                <summary class="talent-header ability-header">
+                    <div class="talent-name-container ability-name-container">
+                        <span class="talent-name ability-name">{{talent.name}}</span>
+                        {{#if talent.system.usesPerDay}}
+                        <span class="ability-meta">{{talent.system.usesPerDay}}/day</span>
+                        {{/if}}
+                    </div>
                     <div class="talent-controls ability-controls">
                         <a class="item-edit" title="Edit Talent"><i class="fas fa-edit"></i></a>
                         <a class="item-delete" title="Delete Talent"><i class="fas fa-trash"></i></a>
                     </div>
-                </div>
+                    <i class="fas fa-chevron-down talent-toggle-icon ability-toggle-icon"></i>
+                </summary>
                 <div class="talent-description ability-description">
                     <p>{{talent.system.description}}</p>
                     {{#if talent.system.prerequisites}}
                     <p><strong>Prerequisites:</strong> {{talent.system.prerequisites}}</p>
                     {{/if}}
                 </div>
-            </div>
+            </details>
             {{/each}}
         </div>
     </div>
@@ -105,23 +99,20 @@
 
         <div class="precepts-list abilities-list">
             {{#each actor.precepts as |precept id|}}
-            <div class="precept-item ability-entry" data-item-id="{{precept._id}}">
-                <input type="checkbox" id="toggle-precept-{{precept._id}}" class="precept-checkbox ability-checkbox">
-                <div class="ability-header-row">
-                    <label for="toggle-precept-{{precept._id}}" class="precept-header ability-header">
-                        <div class="precept-name-container ability-name-container">
-                            <span class="precept-name ability-name">{{precept.name}}</span>
-                            {{#if precept.system.deity}}
-                            <span class="ability-meta">{{precept.system.deity}}</span>
-                            {{/if}}
-                        </div>
-                        <i class="fas fa-chevron-down precept-toggle-icon ability-toggle-icon"></i>
-                    </label>
+            <details class="precept-item ability-entry" data-item-id="{{precept._id}}">
+                <summary class="precept-header ability-header">
+                    <div class="precept-name-container ability-name-container">
+                        <span class="precept-name ability-name">{{precept.name}}</span>
+                        {{#if precept.system.deity}}
+                        <span class="ability-meta">{{precept.system.deity}}</span>
+                        {{/if}}
+                    </div>
                     <div class="precept-controls ability-controls">
                         <a class="item-edit" title="Edit Precept"><i class="fas fa-edit"></i></a>
                         <a class="item-delete" title="Delete Precept"><i class="fas fa-trash"></i></a>
                     </div>
-                </div>
+                    <i class="fas fa-chevron-down precept-toggle-icon ability-toggle-icon"></i>
+                </summary>
                 <div class="precept-description ability-description">
                     <p>{{precept.system.description}}</p>
                     {{#if precept.system.domain}}
@@ -131,7 +122,7 @@
                     <p><strong>Commandment:</strong> {{precept.system.commandment}}</p>
                     {{/if}}
                 </div>
-            </div>
+            </details>
             {{/each}}
         </div>
     </div>
@@ -150,30 +141,27 @@
 
         <div class="traits-list abilities-list">
             {{#each actor.traits as |trait id|}}
-            <div class="trait-item ability-entry" data-item-id="{{trait._id}}">
-                <input type="checkbox" id="toggle-trait-{{trait._id}}" class="trait-checkbox ability-checkbox">
-                <div class="ability-header-row">
-                    <label for="toggle-trait-{{trait._id}}" class="trait-header ability-header">
-                        <div class="trait-name-container ability-name-container">
-                            <span class="trait-name ability-name">{{trait.name}}</span>
-                            {{#if trait.system.source}}
-                            <span class="ability-meta">{{trait.system.source}}</span>
-                            {{/if}}
-                        </div>
-                        <i class="fas fa-chevron-down trait-toggle-icon ability-toggle-icon"></i>
-                    </label>
+            <details class="trait-item ability-entry" data-item-id="{{trait._id}}">
+                <summary class="trait-header ability-header">
+                    <div class="trait-name-container ability-name-container">
+                        <span class="trait-name ability-name">{{trait.name}}</span>
+                        {{#if trait.system.source}}
+                        <span class="ability-meta">{{trait.system.source}}</span>
+                        {{/if}}
+                    </div>
                     <div class="trait-controls ability-controls">
                         <a class="item-edit" title="Edit Trait"><i class="fas fa-edit"></i></a>
                         <a class="item-delete" title="Delete Trait"><i class="fas fa-trash"></i></a>
                     </div>
-                </div>
+                    <i class="fas fa-chevron-down trait-toggle-icon ability-toggle-icon"></i>
+                </summary>
                 <div class="trait-description ability-description">
                     <p>{{trait.system.description}}</p>
                     {{#if trait.system.prerequisites}}
                     <p><strong>Prerequisites:</strong> {{trait.system.prerequisites}}</p>
                     {{/if}}
                 </div>
-            </div>
+            </details>
             {{/each}}
         </div>
     </div>


### PR DESCRIPTION
## Summary

Paths / Talents / Precepts / Traits dropdowns opened and instantly collapsed again. The previous fix in b273ad7 targeted the wrong cause (anchors inside the `<label>`); the actual problem is that the checkbox+label pattern lives inside the `ActorSheet` `<form>`, and `ActorSheet` defaults to `submitOnChange: true` — so toggling the checkbox fires a form submit, which re-renders the sheet, which resets the (DOM-only) checkbox state back to unchecked.

Switch to the same pattern the inventory section already uses successfully: native `<details>` / `<summary>`. Details state doesn't touch the form and behaves the same way the working `inventory-category-collapsible` blocks do.

## Changes

- `templates/actor/parts/paths.html` — replace `<input type=checkbox>` + `<label>` with `<details>` + `<summary>` for all four sections.
- `styles/thefade.css` — rewrite the toggle-icon and description selectors to key off `.ability-entry[open]` instead of `.ability-checkbox:checked`; drop the unused `.ability-header-row` scaffolding; hide the default `<summary>` marker; swap the max-height animation for plain show/hide (matches inventory).
- `src/character-sheet.js` — `stopPropagation()` on `.ability-controls a` clicks and add `preventDefault()` to the item-delete handler so Edit/Delete clicks inside `<summary>` don't toggle the details element.

## Test plan

- [ ] Open a character sheet → Paths/Talents/Precepts/Traits tab.
- [ ] Click each dropdown header → expands and **stays open**.
- [ ] Click again → collapses.
- [ ] Click the Edit (pencil) icon → opens the item sheet, dropdown state unchanged.
- [ ] Click the Delete (trash) icon → deletes the item, no accidental toggle.
- [ ] Make an unrelated change elsewhere on the sheet (which triggers a re-render) → open dropdowns remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)