### PR TITLE
Fix duplicate form field corruption on armor and path sheets

### DIFF
--- a/src/item-sheet.js
+++ b/src/item-sheet.js
@@ -703,6 +703,20 @@ export class TheFadeItemSheet extends ItemSheet {
             this._showPathSkillBrowserDialog();
         });
 
+        // Path: header mirror fields (Tier + Base HP also appear in Attributes tab).
+        // Removed name= attributes on mirrors to avoid duplicate form-field collision; wire change handlers manually.
+        if (this.item.type === 'path') {
+            html.find('.path-tier-mirror').change(async ev => {
+                ev.preventDefault();
+                await this.item.update({ "system.tier": ev.currentTarget.value });
+            });
+            html.find('.path-basehp-mirror').change(async ev => {
+                ev.preventDefault();
+                const val = Number(ev.currentTarget.value);
+                if (Number.isFinite(val)) await this.item.update({ "system.baseHP": val });
+            });
+        }
+
         // Add a button to handle adding path skills to a character
         if (this.item.type === 'path') {
             // Add apply to character button if it doesn't exist
@@ -921,6 +935,11 @@ export class TheFadeItemSheet extends ItemSheet {
 
         // Armor: AP reduce/reset buttons
         if (this.item.type === 'armor') {
+            html.find('.ap-current').change(async ev => {
+                ev.preventDefault();
+                const val = Number(ev.currentTarget.value);
+                if (Number.isFinite(val)) await this.item.update({ "system.currentAP": val });
+            });
             html.find('.reduce-ap').click(async ev => {
                 ev.preventDefault();
                 const cur = this.item.system.currentAP ?? this.item.system.ap ?? 0;

--- a/templates/item/armor-sheet.html
+++ b/templates/item/armor-sheet.html
@@ -86,7 +86,7 @@
             {{/if}}
 
             <div class="item-ap-controls">
-                <span>AP: <input type="number" name="system.currentAP" value="{{system.currentAP}}" class="ap-current" data-dtype="Number" /> / {{effectiveAP}}</span>
+                <span>AP: <input type="number" value="{{system.currentAP}}" class="ap-current" data-dtype="Number" /> / {{effectiveAP}}</span>
                 <a class="item-action-btn reduce-ap"><i class="fas fa-shield-alt"></i> Take Hit (−1 AP)</a>
                 <a class="item-action-btn reset-ap"><i class="fas fa-redo"></i> Repair (Reset AP)</a>
             </div>

--- a/templates/item/path-sheet.html
+++ b/templates/item/path-sheet.html
@@ -6,13 +6,13 @@
       <div class="path-header-meta flexrow">
         <div class="form-group inline">
           <label>Tier</label>
-          <select name="system.tier">
+          <select class="path-tier-mirror">
             {{selectOptions pathTierOptions selected=system.tier}}
           </select>
         </div>
         <div class="form-group inline">
           <label>Base HP</label>
-          <input type="number" name="system.baseHP" value="{{system.baseHP}}" data-dtype="Number" />
+          <input type="number" value="{{system.baseHP}}" data-dtype="Number" class="path-basehp-mirror" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Editing **Current AP** on an armor item turned `10` into `"10,9"`. Root cause: two `<input name="system.currentAP">` fields existed in the same form (one in the main grid, one in the AP controls widget). Foundry's form serializer joined both values into a comma-separated string.
- Path item sheets had the same shape of bug: `system.tier` and `system.baseHP` each appeared twice — once in the header summary, once in the Attributes tab.
- Other sheets were audited; remaining duplicate-`name` hits are radio button groups (intentional) or a separate inventory-row issue out of scope here.

## Fix

For each duplicate, the canonical field keeps `name=`; the secondary/mirror field drops `name=` (so it no longer collides on submit) and is wired through a manual `change` handler in `src/item-sheet.js` that calls `item.update` directly. The UI is unchanged — both fields remain visible and editable.

## Files

- `templates/item/armor-sheet.html` — removed `name` from the AP-controls input
- `templates/item/path-sheet.html` — removed `name` from header Tier/Base HP mirrors
- `src/item-sheet.js` — added change handlers for `.ap-current`, `.path-tier-mirror`, `.path-basehp-mirror`

## Test plan

- [ ] Open an armor item, edit Current AP from either the main field or the bottom AP controls — value saves as a clean number, no comma.
- [ ] Take Hit / Repair buttons still adjust AP correctly.
- [ ] Open a path item, edit Tier and Base HP from both the header and the Attributes tab — both locations save cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)