### PR TITLE
Add Bonuses field to Talents, Precepts, Path Abilities, Species Abilities

### DIFF
--- a/src/actor.js
+++ b/src/actor.js
@@ -481,51 +481,70 @@ export class TheFadeActor extends Actor {
         // Initialize the lookup table roll handlers read from
         data.equippedBonuses = { skills: {}, attack: 0, damage: 0, spell: 0 };
 
-        const equippedItems = actorData.items
-            ? [...actorData.items].filter(i => i.type === 'magicitem' && i.system?.equipped)
-            : [];
+        const applyBonus = (bonus) => {
+            const val = Number(bonus.value) || 0;
+            const target = (bonus.target || "").trim().toLowerCase();
 
-        for (const item of equippedItems) {
-            const bonuses = item.system?.bonuses;
-            if (!Array.isArray(bonuses)) continue;
-
-            for (const bonus of bonuses) {
-                const val = Number(bonus.value) || 0;
-                const target = (bonus.target || "").trim().toLowerCase();
-
-                switch (bonus.type) {
-                    case "avoid":
-                        data.totalAvoid = (data.totalAvoid || 0) + val;
-                        break;
-                    case "resilience":
-                        data.totalResilience = (data.totalResilience || 0) + val;
-                        break;
-                    case "grit":
-                        data.totalGrit = (data.totalGrit || 0) + val;
-                        break;
-                    case "hp":
-                        data.hpMiscBonus = (data.hpMiscBonus || 0) + val;
-                        break;
-                    case "skill": {
-                        const key = target || "all";
-                        data.equippedBonuses.skills[key] = (data.equippedBonuses.skills[key] || 0) + val;
-                        break;
+            switch (bonus.type) {
+                case "avoid":
+                    data.totalAvoid = (data.totalAvoid || 0) + val;
+                    break;
+                case "resilience":
+                    data.totalResilience = (data.totalResilience || 0) + val;
+                    break;
+                case "grit":
+                    data.totalGrit = (data.totalGrit || 0) + val;
+                    break;
+                case "hp":
+                    data.hpMiscBonus = (data.hpMiscBonus || 0) + val;
+                    break;
+                case "skill": {
+                    const key = target || "all";
+                    data.equippedBonuses.skills[key] = (data.equippedBonuses.skills[key] || 0) + val;
+                    break;
+                }
+                case "attack":
+                    if (!target || target === "all") {
+                        data.equippedBonuses.attack += val;
+                    } else {
+                        const aKey = `attack_${target}`;
+                        data.equippedBonuses[aKey] = (data.equippedBonuses[aKey] || 0) + val;
                     }
-                    case "attack":
-                        if (!target || target === "all") {
-                            data.equippedBonuses.attack += val;
-                        } else {
-                            // Store per-skill-name attack bonus
-                            const aKey = `attack_${target}`;
-                            data.equippedBonuses[aKey] = (data.equippedBonuses[aKey] || 0) + val;
-                        }
-                        break;
-                    case "damage":
-                        data.equippedBonuses.damage += val;
-                        break;
-                    case "spell":
-                        data.equippedBonuses.spell += val;
-                        break;
+                    break;
+                case "damage":
+                    data.equippedBonuses.damage += val;
+                    break;
+                case "spell":
+                    data.equippedBonuses.spell += val;
+                    break;
+            }
+        };
+
+        const items = actorData.items ? [...actorData.items] : [];
+
+        for (const item of items) {
+            const sys = item.system;
+            if (!sys) continue;
+
+            // Top-level bonuses arrays
+            // - magicitem: only when equipped
+            // - talent / precept: always active when owned
+            let topLevel = null;
+            if (item.type === 'magicitem' && sys.equipped) topLevel = sys.bonuses;
+            else if (item.type === 'talent' || item.type === 'precept') topLevel = sys.bonuses;
+
+            if (Array.isArray(topLevel)) {
+                for (const bonus of topLevel) applyBonus(bonus);
+            }
+
+            // Per-ability bonuses on paths and species
+            const abilityMap = item.type === 'path' ? sys.abilities
+                : item.type === 'species' ? sys.speciesAbilities
+                    : null;
+            if (abilityMap && typeof abilityMap === 'object') {
+                for (const ability of Object.values(abilityMap)) {
+                    if (!ability || !Array.isArray(ability.bonuses)) continue;
+                    for (const bonus of ability.bonuses) applyBonus(bonus);
                 }
             }
         }

--- a/src/item-sheet.js
+++ b/src/item-sheet.js
@@ -1201,9 +1201,14 @@ export class TheFadeItemSheet extends ItemSheet {
                     ui.notifications.info(`${this.item.name} is no longer attuned to anyone.`);
                 }
             });
+        }
 
-            // Hide target input for bonus types that don't need one
+        // Bonuses UI — supports magicitem, talent, precept (top-level)
+        // and path/species (per-ability). Each .bonus-section carries
+        // its own data-bonus-path identifying where to persist the array.
+        if (['magicitem', 'talent', 'precept', 'path', 'species'].includes(this.item.type)) {
             const NO_TARGET_TYPES = new Set(["avoid", "resilience", "grit", "hp"]);
+
             const updateTargetVisibility = (row) => {
                 const type = row.find('.bonus-type').val();
                 const targetInput = row.find('.bonus-target');
@@ -1214,13 +1219,23 @@ export class TheFadeItemSheet extends ItemSheet {
                 }
             };
 
-            // Initialize visibility for existing bonus rows
-            html.find('.bonus-row').each((i, el) => updateTargetVisibility($(el)));
+            // Read the array currently stored at a dotted path on the item.
+            const getBonusesAt = (path) => {
+                const parts = path.split('.');
+                let cur = this.item;
+                for (const p of parts) {
+                    if (cur == null) return [];
+                    cur = cur[p];
+                }
+                return Array.isArray(cur) ? cur : [];
+            };
 
-            // Collect all bonus rows from the DOM and save
-            const saveBonuses = () => {
+            // Collect bonus rows belonging to a single section and persist.
+            const saveBonusesForSection = ($section) => {
+                const path = $section.attr('data-bonus-path');
+                if (!path) return;
                 const bonuses = [];
-                html.find('.bonus-row').each((i, el) => {
+                $section.find('.bonus-row').each((i, el) => {
                     const $row = $(el);
                     const type = $row.find('.bonus-type').val();
                     bonuses.push({
@@ -1230,34 +1245,40 @@ export class TheFadeItemSheet extends ItemSheet {
                         value: parseInt($row.find('.bonus-value').val()) || 0
                     });
                 });
-                this.item.update({ "system.bonuses": bonuses });
+                this.item.update({ [path]: bonuses });
             };
 
-            // Add bonus
+            html.find('.bonus-row').each((i, el) => updateTargetVisibility($(el)));
+
             html.find('.bonus-add').click(ev => {
                 ev.preventDefault();
-                const bonuses = foundry.utils.deepClone(this.item.system.bonuses || []);
+                const $section = $(ev.currentTarget).closest('.bonus-section');
+                const path = $section.attr('data-bonus-path');
+                if (!path) return;
+                const bonuses = foundry.utils.deepClone(getBonusesAt(path));
                 bonuses.push({ id: foundry.utils.randomID(16), type: "skill", target: "", value: 1 });
-                this.item.update({ "system.bonuses": bonuses }).then(() => this.render(false));
+                this.item.update({ [path]: bonuses }).then(() => this.render(false));
             });
 
-            // Delete bonus
             html.find('.bonus-delete').click(ev => {
                 ev.preventDefault();
+                const $section = $(ev.currentTarget).closest('.bonus-section');
+                const path = $section.attr('data-bonus-path');
+                if (!path) return;
                 const id = ev.currentTarget.dataset.bonusId;
-                const bonuses = (this.item.system.bonuses || []).filter(b => b.id !== id);
-                this.item.update({ "system.bonuses": bonuses }).then(() => this.render(false));
+                const bonuses = getBonusesAt(path).filter(b => b.id !== id);
+                this.item.update({ [path]: bonuses }).then(() => this.render(false));
             });
 
-            // Type change — update target visibility then save
             html.find('.bonus-type').change(ev => {
                 const $row = $(ev.currentTarget).closest('.bonus-row');
                 updateTargetVisibility($row);
-                saveBonuses();
+                saveBonusesForSection($row.closest('.bonus-section'));
             });
 
-            // Target / value changes
-            html.find('.bonus-target, .bonus-value').change(() => saveBonuses());
+            html.find('.bonus-target, .bonus-value').change(ev => {
+                saveBonusesForSection($(ev.currentTarget).closest('.bonus-section'));
+            });
         }
 
         // Damage components (weapons only)

--- a/templates/item/parts/bonuses.html
+++ b/templates/item/parts/bonuses.html
@@ -1,0 +1,27 @@
+<div class="bonus-section" data-bonus-path="{{bonusPath}}">
+    <div class="bonus-section-header">
+        <span>Bonuses</span>
+        <button type="button" class="bonus-add"><i class="fas fa-plus"></i> Add</button>
+    </div>
+    {{#if bonuses.length}}
+        {{#each bonuses}}
+        <div class="bonus-row" data-bonus-id="{{this.id}}">
+            <select class="bonus-type" data-bonus-id="{{this.id}}">
+                <option value="skill" {{#ifEquals this.type "skill"}}selected{{/ifEquals}}>Skill</option>
+                <option value="attack" {{#ifEquals this.type "attack"}}selected{{/ifEquals}}>Attack</option>
+                <option value="damage" {{#ifEquals this.type "damage"}}selected{{/ifEquals}}>Damage</option>
+                <option value="spell" {{#ifEquals this.type "spell"}}selected{{/ifEquals}}>Spell</option>
+                <option value="avoid" {{#ifEquals this.type "avoid"}}selected{{/ifEquals}}>Avoid</option>
+                <option value="resilience" {{#ifEquals this.type "resilience"}}selected{{/ifEquals}}>Resilience</option>
+                <option value="grit" {{#ifEquals this.type "grit"}}selected{{/ifEquals}}>Grit</option>
+                <option value="hp" {{#ifEquals this.type "hp"}}selected{{/ifEquals}}>Max HP</option>
+            </select>
+            <input type="text" class="bonus-target" value="{{this.target}}" placeholder="Target (or blank = all)" data-bonus-id="{{this.id}}" />
+            <input type="number" class="bonus-value" value="{{this.value}}" data-bonus-id="{{this.id}}" />
+            <button type="button" class="bonus-delete" data-bonus-id="{{this.id}}"><i class="fas fa-times"></i></button>
+        </div>
+        {{/each}}
+    {{else}}
+        <div class="bonus-empty">No bonuses — click <strong>+ Add</strong> to create one.</div>
+    {{/if}}
+</div>

--- a/templates/item/path-sheet.html
+++ b/templates/item/path-sheet.html
@@ -78,6 +78,7 @@
           </div>
         </div>
         <textarea name="system.abilities.{{id}}.description" placeholder="Describe the ability...">{{ability.description}}</textarea>
+        {{> "systems/thefade/templates/item/parts/bonuses.html" bonuses=ability.bonuses bonusPath=(concat "system.abilities." id ".bonuses")}}
       </div>
       {{/each}}
     </div>

--- a/templates/item/precept-sheet.html
+++ b/templates/item/precept-sheet.html
@@ -29,6 +29,8 @@
                 <label>Deity</label>
                 <input type="text" name="system.deity" value="{{system.deity}}" placeholder="Associated deity or divine force" />
             </div>
+
+            {{> "systems/thefade/templates/item/parts/bonuses.html" bonuses=system.bonuses bonusPath="system.bonuses"}}
         </div>
     </section>
 </form>

--- a/templates/item/species-sheet.html
+++ b/templates/item/species-sheet.html
@@ -175,6 +175,7 @@
                     </div>
                 </div>
                 <textarea name="system.speciesAbilities.{{id}}.description">{{ability.description}}</textarea>
+                {{> "systems/thefade/templates/item/parts/bonuses.html" bonuses=ability.bonuses bonusPath=(concat "system.speciesAbilities." id ".bonuses")}}
             </div>
             {{/each}}
         </div>

--- a/templates/item/talent-sheet.html
+++ b/templates/item/talent-sheet.html
@@ -44,4 +44,6 @@
     {{/if}}
 
     <a class="item-action-btn use-talent"><i class="fas fa-star"></i> Use Talent</a>
+
+    {{> "systems/thefade/templates/item/parts/bonuses.html" bonuses=system.bonuses bonusPath="system.bonuses"}}
 </form>

--- a/thefade.js
+++ b/thefade.js
@@ -285,7 +285,8 @@ Hooks.once('init', async function () {
         "systems/thefade/templates/item/wand-sheet.html",
         "systems/thefade/templates/item/clothing-sheet.html",
         "systems/thefade/templates/item/trait-sheet.html",
-        "systems/thefade/templates/item/precept-sheet.html"
+        "systems/thefade/templates/item/precept-sheet.html",
+        "systems/thefade/templates/item/parts/bonuses.html"
 
     ]);
 


### PR DESCRIPTION
## Summary
- Extends the Bonuses UI (previously exclusive to Items of Power) to Talents and Precepts at the item level, and to individual Path Abilities and Species Abilities (per-ability).
- New reusable Handlebars partial `templates/item/parts/bonuses.html`, scoped via a `data-bonus-path` attribute so one sheet can host multiple bonus blocks writing to different sub-paths (e.g. `system.abilities.<id>.bonuses`).
- Bonus listeners in `src/item-sheet.js` refactored to be scope-aware (read `data-bonus-path` from each section instead of assuming a single top-level array). Supports magicitem, talent, precept, path, species.
- `_applyEquippedItemBonuses` in `src/actor.js` now also aggregates bonuses from:
  - `talent` / `precept` top-level `system.bonuses` (always active when owned)
  - `path` per-ability bonuses under `system.abilities.<id>.bonuses`
  - `species` per-ability bonuses under `system.speciesAbilities.<id>.bonuses`
  Magic items keep the "only when equipped" gate.

## Notes for reviewers
- Bonus row inputs have no `name` attribute, so Foundry's form serializer ignores them — persistence runs through the explicit add/delete/change listeners that call `item.update({ [path]: bonuses })`. This matches the existing magicitem implementation pattern.
- The new partial is registered in `thefade.js` `loadTemplates`; a Foundry reload is required after pulling.
- No template.json schema change — bonuses arrays are created lazily on first save, same as the existing magicitem behavior.

## Test plan
- [ ] Open a Talent item — add/remove/edit a bonus; reopen and confirm it persists.
- [ ] Same for a Precept (Details tab).
- [ ] Open a Path item — add a bonus to one ability, add another ability with its own bonus, confirm both persist independently.
- [ ] Same for a Species item (per Species Ability).
- [ ] Add a talent with `+1 skill` (target = some skill) to a character; verify the bonus shows up on rolls.
- [ ] Add a path ability with `+1 avoid` / `+5 hp`; verify defenses / max HP update on the character sheet.
- [ ] Confirm existing Items of Power bonuses still work and still only apply when equipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)