### PR TITLE
Add Initiative, Max Sanity, Passive Dodge/Parry, Sin Threshold, and per-attribute bonus types

### DIFF
--- a/src/actor.js
+++ b/src/actor.js
@@ -252,16 +252,19 @@ export class TheFadeActor extends Actor {
             // Ensure data integrity before calculations
             this._ensureSystemDataIntegrity(data);
 
+            // Collect bonuses from items (Items of Power, talents, precepts,
+            // path/species abilities). Must run BEFORE attribute totals and
+            // defenses so attribute, passive dodge/parry, etc. bonuses
+            // propagate through the downstream math.
+            this._applyEquippedItemBonuses(data, actorData);
+
             // Compute effective attribute totals (value + speciesBonus +
-            // flexibleBonus + manual bonus, or manual override). Must run
-            // before defenses or anything else reading attribute totals.
+            // flexibleBonus + manual bonus + item bonus, or manual override).
+            // Must run before defenses or anything else reading attribute totals.
             this._computeAttributeTotals(data);
 
             // Calculate defenses based on attributes and include bonuses
             this._calculateBaseDefenses(data, actorData);
-
-            // Apply bonuses from equipped Items of Power
-            this._applyEquippedItemBonuses(data, actorData);
 
             // Apply facing modifiers
             this._applyFacingModifiers(data);
@@ -364,12 +367,14 @@ export class TheFadeActor extends Actor {
         // Calculate max Sanity and update both properties
         const mindValue = data.attributes?.mind?.value || 1;
         const sanityMiscBonus = data.sanity?.miscBonus || 0;
-        const calculatedMaxSanity = 10 + mindValue + sanityMiscBonus;
+        const sanityItemBonus = Number(data.itemBonuses?.sanity || 0);
+        const calculatedMaxSanity = 10 + mindValue + sanityMiscBonus + sanityItemBonus;
 
         data.sanity.max = calculatedMaxSanity;
         data.maxSanity = calculatedMaxSanity; // For backward compatibility with UI
         const miscSanPart = sanityMiscBonus ? ` + ${sanityMiscBonus} misc` : "";
-        data.sanity.formula = `10 + Mind ${mindValue}${miscSanPart} = ${calculatedMaxSanity}`;
+        const itemSanPart = sanityItemBonus ? ` + ${sanityItemBonus} item` : "";
+        data.sanity.formula = `10 + Mind ${mindValue}${miscSanPart}${itemSanPart} = ${calculatedMaxSanity}`;
 
         // Ensure HP and Sanity values don't exceed max
         if (data.hp.value > data.hp.max) data.hp.value = data.hp.max;
@@ -413,7 +418,8 @@ export class TheFadeActor extends Actor {
         // Calculate sin threshold: Soul - 1 per dark magic spell + bonus
         const soulValue = data.attributes?.soul?.value || 1;
         const sinThresholdBonus = data.darkMagic.sinThresholdBonus || 0;
-        data.darkMagic.sinThreshold = soulValue - darkMagicCount + sinThresholdBonus;
+        const sinThresholdItem  = Number(data.itemBonuses?.sinThreshold || 0);
+        data.darkMagic.sinThreshold = soulValue - darkMagicCount + sinThresholdBonus + sinThresholdItem;
     }
 
     /**
@@ -464,9 +470,12 @@ export class TheFadeActor extends Actor {
 
         // Calculate the average
         const averagedFINMND = Math.floor((finesseValue + mindValue) / 2);
+        const initBonus = Number(this.system.initiativeBonus || 0)
+            + Number(this.system.itemBonuses?.initiative || 0);
+        const modifier = averagedFINMND + initBonus;
 
         // Create the roll with the proper formula
-        const formula = `1d12 + ${averagedFINMND}`;
+        const formula = `1d12 + ${modifier}`;
         const roll = new Roll(formula);
 
         return roll;
@@ -481,22 +490,60 @@ export class TheFadeActor extends Actor {
         // Initialize the lookup table roll handlers read from
         data.equippedBonuses = { skills: {}, attack: 0, damage: 0, spell: 0 };
 
+        // Structured pot consumed by attribute totals, defenses, max
+        // sanity, sin threshold, and initiative. These run AFTER this
+        // method, so they must read from this pot rather than from
+        // already-computed totals.
+        data.itemBonuses = {
+            attributes: { physique: 0, finesse: 0, mind: 0, presence: 0, soul: 0 },
+            avoid: 0,
+            resilience: 0,
+            grit: 0,
+            passiveDodge: 0,
+            passiveParry: 0,
+            initiative: 0,
+            sanity: 0,
+            sinThreshold: 0
+        };
+
         const applyBonus = (bonus) => {
             const val = Number(bonus.value) || 0;
             const target = (bonus.target || "").trim().toLowerCase();
 
             switch (bonus.type) {
                 case "avoid":
-                    data.totalAvoid = (data.totalAvoid || 0) + val;
+                    data.itemBonuses.avoid += val;
                     break;
                 case "resilience":
-                    data.totalResilience = (data.totalResilience || 0) + val;
+                    data.itemBonuses.resilience += val;
                     break;
                 case "grit":
-                    data.totalGrit = (data.totalGrit || 0) + val;
+                    data.itemBonuses.grit += val;
                     break;
                 case "hp":
                     data.hpMiscBonus = (data.hpMiscBonus || 0) + val;
+                    break;
+                case "sanity":
+                    data.itemBonuses.sanity += val;
+                    break;
+                case "initiative":
+                    data.itemBonuses.initiative += val;
+                    break;
+                case "passiveDodge":
+                    data.itemBonuses.passiveDodge += val;
+                    break;
+                case "passiveParry":
+                    data.itemBonuses.passiveParry += val;
+                    break;
+                case "sinThreshold":
+                    data.itemBonuses.sinThreshold += val;
+                    break;
+                case "physique":
+                case "finesse":
+                case "mind":
+                case "presence":
+                case "soul":
+                    data.itemBonuses.attributes[bonus.type] += val;
                     break;
                 case "skill": {
                     const key = target || "all";
@@ -600,15 +647,21 @@ export class TheFadeActor extends Actor {
         data.defenses.grit = Math.max(1, data.defenses.grit);
 
         // Calculate total defenses including bonuses but without facing penalties
-        data.totalResilience = Math.max(1, data.defenses.resilience + Number(data.defenses.resilienceBonus || 0));
-        data.totalAvoid = Math.max(1, data.defenses.avoid + Number(data.defenses.avoidBonus || 0));
-        data.totalGrit = Math.max(1, data.defenses.grit + Number(data.defenses.gritBonus || 0));
+        const itemAvoid = Number(data.itemBonuses?.avoid || 0);
+        const itemResil = Number(data.itemBonuses?.resilience || 0);
+        const itemGrit  = Number(data.itemBonuses?.grit || 0);
+        data.totalResilience = Math.max(1, data.defenses.resilience + Number(data.defenses.resilienceBonus || 0) + itemResil);
+        data.totalAvoid = Math.max(1, data.defenses.avoid + Number(data.defenses.avoidBonus || 0) + itemAvoid);
+        data.totalGrit = Math.max(1, data.defenses.grit + Number(data.defenses.gritBonus || 0) + itemGrit);
 
         // Tooltip formula strings — show the effective attribute total
         const phy = data.attributes.physique.total, fin = data.attributes.finesse.total, mnd = data.attributes.mind.total;
-        data.defenses.resilienceFormula = `Physique ${phy} ÷ 2 = ${data.defenses.resilience}` + (data.defenses.resilienceBonus ? ` + ${data.defenses.resilienceBonus} bonus` : "");
-        data.defenses.avoidFormula     = `Finesse ${fin} ÷ 2 = ${data.defenses.avoid}` + (data.defenses.avoidBonus ? ` + ${data.defenses.avoidBonus} bonus` : "");
-        data.defenses.gritFormula      = `Mind ${mnd} ÷ 2 = ${data.defenses.grit}` + (data.defenses.gritBonus ? ` + ${data.defenses.gritBonus} bonus` : "");
+        const itemResilPart = itemResil ? ` + ${itemResil} item` : "";
+        const itemAvoidPart = itemAvoid ? ` + ${itemAvoid} item` : "";
+        const itemGritPart  = itemGrit  ? ` + ${itemGrit} item`  : "";
+        data.defenses.resilienceFormula = `Physique ${phy} ÷ 2 = ${data.defenses.resilience}` + (data.defenses.resilienceBonus ? ` + ${data.defenses.resilienceBonus} bonus` : "") + itemResilPart;
+        data.defenses.avoidFormula     = `Finesse ${fin} ÷ 2 = ${data.defenses.avoid}` + (data.defenses.avoidBonus ? ` + ${data.defenses.avoidBonus} bonus` : "") + itemAvoidPart;
+        data.defenses.gritFormula      = `Mind ${mnd} ÷ 2 = ${data.defenses.grit}` + (data.defenses.gritBonus ? ` + ${data.defenses.gritBonus} bonus` : "") + itemGritPart;
 
         // Stance-level defense overrides (Tough it Out / Resolute Will replace
         // the half-attribute formula with full-attribute for Resilience/Grit).
@@ -631,8 +684,9 @@ export class TheFadeActor extends Actor {
 
         data.defenses.basePassiveDodge = Math.max(acrobonaticsDodge, finesseDodge);
         const pDodgeBonus = Number(data.defenses.passiveDodgeBonus || 0);
-        data.defenses.passiveDodge = data.defenses.basePassiveDodge + pDodgeBonus;
-        data.defenses.passiveDodgeFormula = `Base ${data.defenses.basePassiveDodge}` + (pDodgeBonus ? ` + ${pDodgeBonus} bonus` : "");
+        const pDodgeItem  = Number(data.itemBonuses?.passiveDodge || 0);
+        data.defenses.passiveDodge = data.defenses.basePassiveDodge + pDodgeBonus + pDodgeItem;
+        data.defenses.passiveDodgeFormula = `Base ${data.defenses.basePassiveDodge}` + (pDodgeBonus ? ` + ${pDodgeBonus} bonus` : "") + (pDodgeItem ? ` + ${pDodgeItem} item` : "");
         // Stash Acrobatics rank dice so stance code can add them to Avoid in Dodge Stance.
         data.defenses.acrobaticsDodgeDice = acrobonaticsDodge;
 
@@ -654,8 +708,9 @@ export class TheFadeActor extends Actor {
 
         data.defenses.basePassiveParry = highestParry;
         const pParryBonus = Number(data.defenses.passiveParryBonus || 0);
-        data.defenses.passiveParry = data.defenses.basePassiveParry + pParryBonus;
-        data.defenses.passiveParryFormula = `Base ${data.defenses.basePassiveParry}` + (pParryBonus ? ` + ${pParryBonus} bonus` : "");
+        const pParryItem  = Number(data.itemBonuses?.passiveParry || 0);
+        data.defenses.passiveParry = data.defenses.basePassiveParry + pParryBonus + pParryItem;
+        data.defenses.passiveParryFormula = `Base ${data.defenses.basePassiveParry}` + (pParryBonus ? ` + ${pParryBonus} bonus` : "") + (pParryItem ? ` + ${pParryItem} item` : "");
     }
 
     /**
@@ -757,9 +812,10 @@ export class TheFadeActor extends Actor {
             const species = Number(a.speciesBonus ?? 0);
             const flex = Number(a.flexibleBonus ?? 0);
             const bonus = Number(a.bonus ?? 0);
+            const itemBonus = Number(data.itemBonuses?.attributes?.[k] ?? 0);
             const o = a.override;
             const overridden = o !== null && o !== undefined && o !== "" && Number.isFinite(Number(o));
-            a.total = Math.max(1, overridden ? Number(o) : value + species + flex + bonus);
+            a.total = Math.max(1, overridden ? Number(o) : value + species + flex + bonus + itemBonus);
         }
     }
 

--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -2627,9 +2627,12 @@ export class TheFadeCharacterSheet extends ActorSheet {
         const mindValue = this.actor.system.attributes.mind?.value || 0;
 
         const averagedFINMND = Math.floor((finesseValue + mindValue) / 2);
+        const initBonus = Number(this.actor.system.initiativeBonus || 0)
+            + Number(this.actor.system.itemBonuses?.initiative || 0);
+        const modifier = averagedFINMND + initBonus;
 
         // Roll the dice
-        const roll = new Roll(`1d12+${averagedFINMND}`);
+        const roll = new Roll(`1d12+${modifier}`);
         await roll.evaluate();
 
         // Get the roll result
@@ -2649,7 +2652,7 @@ export class TheFadeCharacterSheet extends ActorSheet {
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
             flavor: `Initiative Roll`,
             content: `
-      <p>${this.actor.name} rolled for initiative: 1d12 (${dieResult}) + ${averagedFINMND} = ${totalResult}</p>
+      <p>${this.actor.name} rolled for initiative: 1d12 (${dieResult}) + ${modifier} = ${totalResult}</p>
     `
         });
     }

--- a/src/npc-sheet.js
+++ b/src/npc-sheet.js
@@ -45,7 +45,9 @@ export class TheFadeNPCSheet extends ActorSheet {
         html.find(".initiative-roll").click(async () => {
             const fin = this.actor.system.attributes?.finesse?.value || 0;
             const mnd = this.actor.system.attributes?.mind?.value || 0;
-            const bonus = Math.floor((fin + mnd) / 2) + (this.actor.system.initiativeBonus || 0);
+            const bonus = Math.floor((fin + mnd) / 2)
+                + (this.actor.system.initiativeBonus || 0)
+                + Number(this.actor.system.itemBonuses?.initiative || 0);
             const roll = await new Roll(`1d12 + ${bonus}`).evaluate();
             roll.toMessage({
                 speaker: ChatMessage.getSpeaker({ actor: this.actor }),

--- a/templates/item/parts/bonuses.html
+++ b/templates/item/parts/bonuses.html
@@ -15,6 +15,16 @@
                 <option value="resilience" {{#ifEquals this.type "resilience"}}selected{{/ifEquals}}>Resilience</option>
                 <option value="grit" {{#ifEquals this.type "grit"}}selected{{/ifEquals}}>Grit</option>
                 <option value="hp" {{#ifEquals this.type "hp"}}selected{{/ifEquals}}>Max HP</option>
+                <option value="sanity" {{#ifEquals this.type "sanity"}}selected{{/ifEquals}}>Max Sanity</option>
+                <option value="initiative" {{#ifEquals this.type "initiative"}}selected{{/ifEquals}}>Initiative</option>
+                <option value="passiveDodge" {{#ifEquals this.type "passiveDodge"}}selected{{/ifEquals}}>Passive Dodge</option>
+                <option value="passiveParry" {{#ifEquals this.type "passiveParry"}}selected{{/ifEquals}}>Passive Parry</option>
+                <option value="sinThreshold" {{#ifEquals this.type "sinThreshold"}}selected{{/ifEquals}}>Sin Threshold</option>
+                <option value="physique" {{#ifEquals this.type "physique"}}selected{{/ifEquals}}>Physique (PHY)</option>
+                <option value="finesse" {{#ifEquals this.type "finesse"}}selected{{/ifEquals}}>Finesse (FIN)</option>
+                <option value="mind" {{#ifEquals this.type "mind"}}selected{{/ifEquals}}>Mind (MND)</option>
+                <option value="presence" {{#ifEquals this.type "presence"}}selected{{/ifEquals}}>Presence (PRS)</option>
+                <option value="soul" {{#ifEquals this.type "soul"}}selected{{/ifEquals}}>Soul (SOL)</option>
             </select>
             <input type="text" class="bonus-target" value="{{this.target}}" placeholder="Target (or blank = all)" data-bonus-id="{{this.id}}" />
             <input type="number" class="bonus-value" value="{{this.value}}" data-bonus-id="{{this.id}}" />

--- a/thefade.js
+++ b/thefade.js
@@ -307,7 +307,8 @@ Hooks.once('init', async function () {
         if (["character", "npc"].includes(actor.type)) {
             const finesse = actor.system.attributes?.finesse?.value || 0;
             const mind = actor.system.attributes?.mind?.value || 0;
-            const bonus = (actor.system.initiativeBonus || 0);
+            const bonus = (actor.system.initiativeBonus || 0)
+                + Number(actor.system.itemBonuses?.initiative || 0);
             const modifier = Math.floor((finesse + mind) / 2) + bonus;
             return `1d12 + ${modifier}`;
         }


### PR DESCRIPTION
## Summary
Extends the Bonuses dropdown (available on Items of Power, Talents, Precepts, Path Abilities, and Species Abilities) with these new target types:

- **Initiative**
- **Max Sanity**
- **Passive Dodge** / **Passive Parry**
- **Sin Threshold**
- **Physique / Finesse / Mind / Presence / Soul** (per-attribute)

The per-attribute bonuses flow through `attribute.total`, so granting +1 Finesse also lifts Avoid (and Passive Dodge's finesse component), etc., consistent with how species/flexible bonuses already behave.

## Why
Previously only HP, Avoid, Resilience, Grit, Skill, Attack, Damage, and Spell were exposed. Several existing talents/precepts in the rulebook grant the missing categories above, and there was no in-system way to model them.

## Implementation notes for reviewers
- `_applyEquippedItemBonuses` now runs **before** `_computeAttributeTotals` and `_calculateBaseDefenses` (it used to run after). Otherwise attribute/passive-defense bonuses would be clobbered by the defense calc.
- Item-derived bonuses land in a new structured pot `system.itemBonuses` (`{ attributes, avoid, resilience, grit, passiveDodge, passiveParry, initiative, sanity, sinThreshold }`). Downstream calcs sum it on top of the existing user-input `*Bonus` fields rather than replacing them.
- Tooltip formulas for defenses and Max Sanity now show a `+ N item` segment so a player can see where a derived number came from.
- Initiative is read in **four** places — all four updated to add `system.itemBonuses.initiative`:
  - `TheFadeActor.getInitiativeRoll`
  - `Combat.getInitiativeFormula` override in `thefade.js`
  - Character sheet `_onInitiativeRoll`
  - NPC sheet `.initiative-roll` handler
- No `template.json` change — `itemBonuses` is derived data computed each `prepareData`.
- The error-fallback path (`_initializeMinimalDefenseData`) leaves `itemBonuses` undefined; every consumer uses optional chaining + `|| 0`, so a missing pot is safe.

## Note on history
The change was accidentally pushed straight to `main` first. To keep `main` reviewable I reverted that commit on `main` and re-applied the change on this branch — when this PR merges, the net effect on `main` is the same as the original commit.

## Test plan
- [ ] Add a Talent with `+2 physique`; confirm Physique total goes up and Avoid/Resilience derived from it update accordingly.
- [ ] Add a Path Ability with `+1 passiveDodge` and `+1 passiveParry`; confirm both passive defenses bump and the tooltip shows `+ 1 item`.
- [ ] Add a Species Ability with `+5 sanity`; confirm Max Sanity goes up and the formula tooltip shows the item contribution.
- [ ] Add an Item of Power with `+2 initiative`; equip it and roll Initiative from the character sheet, NPC sheet, and combat tracker — all three should include the bonus. Unequip and confirm the bonus drops.
- [ ] Add a Precept with `+1 sinThreshold`; verify the dark-magic Sin Threshold updates.
- [ ] Existing bonus types (skill/attack/damage/spell/avoid/resilience/grit/hp) still behave identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)