### PR TITLE
Fix weapon bonus pipeline: damage bonuses, attribute override, sheet preview

### DIFF
--- a/src/actor.js
+++ b/src/actor.js
@@ -512,7 +512,12 @@ export class TheFadeActor extends Actor {
                     }
                     break;
                 case "damage":
-                    data.equippedBonuses.damage += val;
+                    if (!target || target === "all") {
+                        data.equippedBonuses.damage += val;
+                    } else {
+                        const dKey = `damage_${target}`;
+                        data.equippedBonuses[dKey] = (data.equippedBonuses[dKey] || 0) + val;
+                    }
                     break;
                 case "spell":
                     data.equippedBonuses.spell += val;

--- a/src/character-sheet.js
+++ b/src/character-sheet.js
@@ -2448,21 +2448,32 @@ export class TheFadeCharacterSheet extends ActorSheet {
         // Ensure minimum of 1 die
         dicePool = Math.max(1, dicePool);
 
-        // Add weapon specific bonuses
+        // Add weapon specific bonuses. Explicit attribute dropdown wins over
+        // Brutish/Agile defaults so the user can override.
         const attrTotal = (k) => (this.actor.system.attributes[k]?.total ?? this.actor.system.attributes[k]?.value ?? 0);
-        if (weaponData.qualities.includes("Agile")) {
+        if (weaponData.attribute && weaponData.attribute !== "none") {
+            const bonusDamage = Math.floor(attrTotal(weaponData.attribute) / 2);
+            weaponData.totalDamage = parseInt(weaponData.damage) + bonusDamage;
+        } else if (weaponData.qualities.includes("Agile")) {
             const bonusDamage = Math.floor(attrTotal("finesse") / 2);
             weaponData.totalDamage = parseInt(weaponData.damage) + bonusDamage;
         } else if (weaponData.qualities.includes("Brutish")) {
             const bonusDamage = Math.floor(attrTotal("physique") / 2);
             weaponData.totalDamage = parseInt(weaponData.damage) + bonusDamage;
-        } else if (weaponData.attribute && weaponData.attribute !== "none") {
-            // Add half of the weapon's attribute to damage if not "none"
-            const bonusDamage = Math.floor(attrTotal(weaponData.attribute) / 2);
-            weaponData.totalDamage = parseInt(weaponData.damage) + bonusDamage;
         } else {
-            // No attribute bonus
             weaponData.totalDamage = parseInt(weaponData.damage);
+        }
+
+        // Magical strengthening
+        const dmgInc = Number(weaponData.damageIncrease) || 0;
+        if (dmgInc) weaponData.totalDamage = (weaponData.totalDamage || 0) + dmgInc;
+
+        // Add equipped damage bonuses (global + per-skill from talents/paths/etc.)
+        const dmgEb = this.actor.system?.equippedBonuses;
+        if (dmgEb) {
+            const skillKey = (skill.name || "").toLowerCase();
+            const equipDmg = (dmgEb.damage || 0) + (dmgEb[`damage_${skillKey}`] || 0);
+            if (equipDmg) weaponData.totalDamage = (weaponData.totalDamage || 0) + equipDmg;
         }
 
         // Roll the dice

--- a/src/item-sheet.js
+++ b/src/item-sheet.js
@@ -12,7 +12,7 @@ import {
     DAMAGE_TYPE_LABELS
 } from './constants.js';
 import { getRankValue, openCompendiumBrowser, applyPathSkillModifications } from './helpers.js';
-import { getSkill } from './skills.js';
+import { getSkill, calculateSkillDice } from './skills.js';
 
 /**
 * Item Sheet class for The Fade system
@@ -363,14 +363,21 @@ export class TheFadeItemSheet extends ItemSheet {
                 };
             }
 
-            // Calculated dice pool for weapons owned by an actor
+            // Calculated dice pool for weapons owned by an actor. Mirrors the
+            // attack-roll math in character-sheet.js so the sheet preview matches
+            // what an actual attack roll would use.
             if (this.item?.type === 'weapon' && this.item.parent) {
                 const actor = this.item.parent;
                 const sys = this.item.system;
                 const skill = getSkill(actor, sys.skill);
-                const rank = skill ? getRankValue(skill.rank) : 0;
-                const miscBonus = sys.miscBonus ?? 0;
-                const total = rank + miscBonus;
+                const skillDice = skill ? calculateSkillDice(actor, skill) : 0;
+                const weaponMisc = Number(sys.miscBonus) || 0;
+                const eb = actor.system?.equippedBonuses;
+                const skillKey = (sys.skill || "").toLowerCase();
+                const attackBonus = eb
+                    ? (eb.attack || 0) + (eb[`attack_${skillKey}`] || 0)
+                    : 0;
+                const total = skillDice + weaponMisc + attackBonus;
                 if (total > 0) data.calculatedDice = total;
             }
 
@@ -414,19 +421,29 @@ export class TheFadeItemSheet extends ItemSheet {
                 if (this.item.parent?.system?.attributes) {
                     const attrs = this.item.parent.system.attributes;
                     const qualities = sys.qualities || "";
-                    if (qualities.includes("Agile") && attrs.finesse) {
-                        attrBonus = Math.floor((attrs.finesse.value || 0) / 2);
+                    const attrTotal = (k) => attrs[k]?.total ?? attrs[k]?.value ?? 0;
+                    // Explicit attribute dropdown wins over Brutish/Agile defaults.
+                    if (sys.attribute && sys.attribute !== "none" && attrs[sys.attribute]) {
+                        attrBonus = Math.floor(attrTotal(sys.attribute) / 2);
+                        attrLabel = sys.attribute.charAt(0).toUpperCase() + sys.attribute.slice(1);
+                    } else if (qualities.includes("Agile") && attrs.finesse) {
+                        attrBonus = Math.floor(attrTotal("finesse") / 2);
                         attrLabel = "Finesse";
                     } else if (qualities.includes("Brutish") && attrs.physique) {
-                        attrBonus = Math.floor((attrs.physique.value || 0) / 2);
+                        attrBonus = Math.floor(attrTotal("physique") / 2);
                         attrLabel = "Physique";
-                    } else if (sys.attribute && sys.attribute !== "none" && attrs[sys.attribute]) {
-                        attrBonus = Math.floor((attrs[sys.attribute].value || 0) / 2);
-                        attrLabel = sys.attribute.charAt(0).toUpperCase() + sys.attribute.slice(1);
                     }
                 }
 
-                // Build the typed breakdown: "3 Fire + 3 Bludgeoning + 2 + 4"
+                // Equipped damage bonuses (global + per-skill from talents/paths/etc.)
+                let equipDmgBonus = 0;
+                if (this.item.parent?.system?.equippedBonuses) {
+                    const eb = this.item.parent.system.equippedBonuses;
+                    const skillKey = (sys.skill || "").toLowerCase();
+                    equipDmgBonus = (eb.damage || 0) + (eb[`damage_${skillKey}`] || 0);
+                }
+
+                // Build the typed breakdown with labels for every part
                 const parts = [];
                 let typedTotal = 0;
                 for (const c of components) {
@@ -436,10 +453,11 @@ export class TheFadeItemSheet extends ItemSheet {
                     const label = DAMAGE_TYPE_LABELS[c.type] || c.type || "Untyped";
                     parts.push(`${amt} ${label}`);
                 }
-                if (dmgInc > 0) parts.push(`${dmgInc}`);
-                if (attrBonus > 0) parts.push(`${attrBonus}`);
+                if (dmgInc > 0) parts.push(`${dmgInc} Strengthening`);
+                if (attrBonus > 0) parts.push(`${attrBonus} ${attrLabel}`);
+                if (equipDmgBonus > 0) parts.push(`${equipDmgBonus} Bonus`);
 
-                data.effectiveDamage = typedTotal + dmgInc + attrBonus;
+                data.effectiveDamage = typedTotal + dmgInc + attrBonus + equipDmgBonus;
                 data.effectiveDamageBreakdown = parts.length > 1 ? parts.join(" + ") : null;
                 data.weaponAttrBonus = attrBonus;
                 data.weaponAttrLabel = attrLabel;

--- a/templates/item/weapon-sheet.html
+++ b/templates/item/weapon-sheet.html
@@ -27,8 +27,8 @@
         {{#if calculatedDice}}
         <div class="item-calc-bar">
           <span class="calc-label">Dice Pool:</span>
-          <span class="calc-value">{{calculatedDice}}d10</span>
-          <a class="item-action-btn roll-weapon-attack"><i class="fas fa-dice-d10"></i> Roll Attack</a>
+          <span class="calc-value">{{calculatedDice}}d12</span>
+          <a class="item-action-btn roll-weapon-attack"><i class="fas fa-dice-d12"></i> Roll Attack</a>
         </div>
         {{/if}}
         {{#if effectiveDamage}}


### PR DESCRIPTION
## Summary

Fixes several connected bugs in how bonuses from Talents, Path Abilities, Precepts, and equipped Magic Items flow through to weapons. Found while debugging why a Conscript path's `+2D to Axe` / `+4 Damage to Axe` wasn't applying to a Battleaxe.

## What changed

- **Damage bonuses now actually apply.** `equippedBonuses.damage` was written by `_applyEquippedItemBonuses` but never read anywhere. It now feeds both the actual attack roll's `totalDamage` and the weapon sheet's `Effective Damage` display. Also made it target-aware (`damage_axe`) so `+N Damage to <Skill>` only applies to weapons of that skill, matching how attack bonuses already worked.
- **Magical strengthening applies to attack damage.** `damageIncrease` was shown on the weapon sheet but not added into the rolled damage.
- **Weapon sheet "Dice Pool" matches the real attack roll.** Previously showed only `rankOrdinal + miscBonus` (no attribute, no equipped bonuses) and was labeled `d10`. Now uses `calculateSkillDice(actor, skill) + weapon.miscBonus + attack/attack_<skill> bonuses`, labeled `Xd12`.
- **Damage-attribute dropdown is authoritative.** Previously, `Brutish`/`Agile` qualities always won over the dropdown, so the user couldn't override. Now the explicit dropdown wins; the quality-based picks are fallbacks when the attribute is `none`. Mirrored in both the sheet preview and the attack-roll handler.
- **Attribute damage uses `.total`, not `.value`.** Species flexible bonuses and other modifiers now flow into the weapon's attribute damage.
- **Labeled breakdown.** `Effective Damage` parts used to print as bare numbers (`5 Slashing + 3 + 4`). Now every part is labeled: `5 Slashing + 3 Physique + 3 Strengthening + 4 Bonus`.

## Files

- `src/actor.js` — damage bonus now target-aware (`damage_<skill>`)
- `src/item-sheet.js` — weapon sheet Dice Pool & Effective Damage rewritten; dropdown wins over quality defaults; `.total` instead of `.value`
- `src/character-sheet.js` — attack roll adds `damageIncrease` + equipped damage bonuses to `totalDamage`; dropdown wins over Brutish/Agile
- `templates/item/weapon-sheet.html` — `d10` → `d12` on the Dice Pool readout

## Test plan

- [ ] Open a weapon owned by a character with a Path/Talent granting `+ND to <SkillName>` and confirm the Dice Pool on the weapon sheet matches the dice count rolled when you click Roll Attack.
- [ ] Same character with a Path/Talent granting `+N Damage to <SkillName>`: confirm `N Bonus` appears in the Effective Damage breakdown on a matching weapon, and does NOT appear on a weapon of a different skill.
- [ ] On a weapon with a Brutish or Agile quality, switch the Damage Attribute dropdown and confirm the breakdown updates to use the chosen attribute.
- [ ] On a character with a species flexible +1 to an attribute, confirm the weapon's attribute damage uses the bumped total, not the base value.
- [ ] Roll an attack from a weapon with `damageIncrease` > 0 and confirm the rolled damage in chat includes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)