### PR TITLE
Fix species ability bonuses not saving

### DIFF
--- a/src/item-sheet.js
+++ b/src/item-sheet.js
@@ -803,10 +803,15 @@ export class TheFadeItemSheet extends ItemSheet {
         // Handle input changes for species sheets
         if (this.item.type === 'species') {
             html.find('input, select, textarea').change(async (ev) => {
+                const element = ev.currentTarget;
+                // Skip bonus-row controls — they're persisted by the dedicated
+                // bonus handlers below and don't carry a `name` attribute.
+                if (element.closest('.bonus-section')) return;
+                if (!element.name) return;
+
                 ev.preventDefault();
                 ev.stopImmediatePropagation();
 
-                const element = ev.currentTarget;
                 const field = element.name;
                 let value = element.value;
 


### PR DESCRIPTION
## Summary
- The species item sheet's catch-all `change` handler intercepted bonus-row controls (`.bonus-type`, `.bonus-value`, `.bonus-target`) via `stopImmediatePropagation`, blocking the dedicated bonus save handler at [src/item-sheet.js:1291](src/item-sheet.js:1291).
- Bonus-row inputs have no `name` attribute, so the catch-all couldn't persist them either — every species-ability bonus silently stayed at its default `skill +1`, so adding Grit/Resilience/etc. bonuses under things like Human Abilities did nothing.
- Fix: skip elements inside `.bonus-section` (and any nameless element) in the species catch-all so the bonus handlers downstream can run.

## Test plan
- [ ] Open a Species item, add an ability, add a bonus row, change type to Grit and value to e.g. 2 — confirm it persists after reopening.
- [ ] Drop/attach the species to a character; confirm `totalGrit` reflects the bonus on the character sheet.
- [ ] Repeat for Resilience and a couple other bonus types.
- [ ] Verify path/talent/precept/magicitem bonus editing still works (unchanged code path).

Note: existing species-ability bonus rows already saved as `skill +1` will need to be re-set once after this fix.

Closes the report that Grit/Resilience bonuses under Human Abilities weren't applying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)